### PR TITLE
[DM-24685] Improve and document logging

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,18 @@
 Change log
 ##########
 
+1.1.2 (2020-05-07)
+==================
+
+This release changes Gafaelfawr's logging format and standardizes the contents of the logs.
+All logs are now in JSON.
+See `the new logging documentation <https://gafaelfawr.lsst.io/logging.html>`__ for more information.
+
+- Default to JSON logging (controlled via ``SAFIR_PROFILE``)
+- Add remote IP and ``User-Agent`` header field values to all logs.
+- Add more structured information to authentication logging.
+- Ensure each route logs at least one event.
+
 1.1.1 (2020-04-29)
 ==================
 

--- a/README.rst
+++ b/README.rst
@@ -17,10 +17,10 @@ Gafaelfawr is named for Glewlwyd Gafaelfawr, the knight who challenges King Arth
 Gafaelfawr is pronounced (very roughly) gah-VILE-fahwr.
 (If you speak Welsh and can provide a better pronunciation guide, please open an issue!)
 
-.. |Build| image:: https://github.com/lsst/gafaelfawr/workflows/CI/badge.svg
+.. |Build| image:: https://github.com/lsst-sqre/gafaelfawr/workflows/CI/badge.svg
    :alt: GitHub Actions
    :scale: 100%
-   :target: https://github.com/lsst/gafaelfawr/actions
+   :target: https://github.com/lsst-sqre/gafaelfawr/actions
 
 .. |Docker| image:: https://img.shields.io/docker/v/lsstsqre/gafaelfawr?sort=semver
    :alt: Docker Hub repository

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -70,6 +70,7 @@ intersphinx_mapping = {
     "dynaconf": ("https://dynaconf.readthedocs.io/en/latest/", None),
     "jwt": ("https://pyjwt.readthedocs.io/en/latest/", None),
     "python": ("https://docs.python.org/3/", None),
+    "structlog": ("http://www.structlog.org/en/stable/", None),
     "wtforms": ("https://wtforms.readthedocs.io/en/stable/", None),
 }
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -160,8 +160,8 @@ Secrets beginning or ending in whitespace are not supported.
 Examples
 ========
 
-See `gafaelfawr.yaml <https://github.com/lsst/gafaelfawr/blob/master/examples/gafaelfawr.yaml>`__ for an example configuration file.
+See `gafaelfawr.yaml <https://github.com/lsst-sqre/gafaelfawr/blob/master/examples/gafaelfawr.yaml>`__ for an example configuration file.
 
-See `gafaelfawr-dev.yaml <https://github.com/lsst/gafaelfawr/blob/master/examples/gafaelfawr-dev.yaml>`__ for a configuration file designed for a development server running on localhost.
+See `gafaelfawr-dev.yaml <https://github.com/lsst-sqre/gafaelfawr/blob/master/examples/gafaelfawr-dev.yaml>`__ for a configuration file designed for a development server running on localhost.
 **WARNING**: Do not use this configuration for anything other than a local development server.
 It contains published secrets available to anyone on the Internet.

--- a/docs/dev/development.rst
+++ b/docs/dev/development.rst
@@ -14,7 +14,7 @@ For that reason, it's a good idea to propose changes with a new `GitHub issue`_ 
 
 Gafaelfawr is developed by the LSST SQuaRE team.
 
-.. _GitHub issue: https://github.com/lsst/gafaelfawr/issues/new
+.. _GitHub issue: https://github.com/lsst-sqre/gafaelfawr/issues/new
 
 .. _dev-environment:
 
@@ -25,7 +25,7 @@ To develop Gafaelfawr, create a virtual environment with your method of choice (
 
 .. code-block:: sh
 
-   git clone https://github.com/lsst/gafaelfawr.git
+   git clone https://github.com/lsst-sqre/gafaelfawr.git
    cd gafaelfawr
    make init
 

--- a/docs/dev/release.rst
+++ b/docs/dev/release.rst
@@ -9,7 +9,7 @@ Gafaelfawr's releases are largely automated through GitHub Actions (see the `ci.
 When a semantic version tag is pushed to GitHub, `Gafaelfawr is pushed to Docker Hub`_ with that version.
 
 .. _`Gafaelfawr is pushed to Docker Hub`: https://hub.docker.com/repository/docker/lsstdm/gafaelfawr
-.. _`ci.yaml`: https://github.com/lsst/gafaelfawr/blob/master/.github/workflows/ci.yaml
+.. _`ci.yaml`: https://github.com/lsst-sqre/gafaelfawr/blob/master/.github/workflows/ci.yaml
 
 .. _regular-release:
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -22,6 +22,7 @@ Installation
 
    install
    configuration
+   logging
    glossary
    changelog
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -8,7 +8,7 @@ It also provides a web page where people can create and manage long-lived tokens
 As a component of the Science Platform, it is designed for deployment with Kubernetes.
 Gafaelfawr requires the Kubernetes `NGINX ingress controller <https://github.com/kubernetes/ingress-nginx>`__.
 
-Gafaelfawr is developed on `GitHub <https://github.com/lsst/gafaelfawr>`__.
+Gafaelfawr is developed on `GitHub <https://github.com/lsst-sqre/gafaelfawr>`__.
 
 Gafaelfawr is named for Glewlwyd Gafaelfawr, the knight who challenges King Arthur in *Pa gur yv y porthaur?* and, in later stories, is a member of his court and acts as gatekeeper.
 Gafaelfawr is pronounced (very roughly) gah-VILE-fahwr.

--- a/docs/logging.rst
+++ b/docs/logging.rst
@@ -1,0 +1,67 @@
+#######
+Logging
+#######
+
+Gafaelfawr uses structlog to log all messages in JSON.
+Most routes will log a single message at the ``INFO`` log level (the default) on success.
+The ``/login`` route does a bit more work and will log more messages.
+More detailed logging is available at the ``DEBUG`` level, including a snapshot of Gafaelfawr's configuration on initial startup.
+User errors are logged at the ``WARNING`` level.
+
+Log attributes
+==============
+
+The main log message will be in the ``event`` attribute of each log message.
+If this message indicates an error with supplemental information, the additional details of the error will be in the ``error`` attribute.
+
+The following attributes will be added to each log message, in addition to the default attributes added by :py:mod:`structlog`:
+
+``logger``
+    Always set to ``gafaelfawr``.
+
+``method``
+    The HTTP method of the request.
+
+``path``
+    The path portion of the HTTP request.
+
+``remote``
+    The remote IP address making the request.
+    This will be taken from ``X-Forwarded-For`` if available, since Gafaelfawr is designed to be run behind a Kubernetes NGINX ingress.
+
+``request_id``
+    A unique UUID for each request.
+    This can be used to correlate multiple messages logged from a single request.
+
+``user_agent``
+    The ``User-Agent`` header of the incoming request.
+    This can be helpful in finding requests from a particular user or investigating problems with specific web browsers.
+
+All authenticated routes add the following attributes once the user's token has been located and verified:
+
+``scope``
+    The ``scope`` claim of the user's token.
+
+``token``
+    The ``jti`` claim of the token.
+
+``user``
+    The username claim of the token (configured via the ``username_claim`` configuration parameter).
+
+The ``/auth`` route adds the following attributes:
+
+``auth_uri``
+    The URL being authenticated.
+    This is the URL (withough the scheme and host) of the original request that Gafaelfawr is being asked to authenticate via a subrequest.
+    This will be ``NONE`` if the request was made directly to the ``/auth`` endpoint (which should not happen in normal usage, but may happen during testing).
+
+``required_scope``
+    The list of scopes required, taken from the ``scope`` query parameter
+
+``satisfy``
+    The authorization strategy, taken from the ``satisfy`` query parameter.
+
+The ``/login`` route adds the following attributes:
+
+``return_url``
+    The URL to which the user will be sent after successful authentication.

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,11 +5,11 @@ author = Association of Universities for Research in Astronomy, Inc. (AURA)
 author_email = sqre-admin@lists.lsst.org
 long_description = file: README.rst, CHANGELOG.rst, LICENSE
 long_description_content_type = text/x-rst
-url = https://github.com/lsst/gafaelfawr
+url = https://github.com/lsst-sqre/gafaelfawr
 project_urls =
     Change log = https://github.com/sqre/gafaelfawr/master/blob/CHANGELOG.rst
-    Source code = https://github.com/lsst/gafaelfawr
-    Issue tracker = https://github.com/lsst/gafaelfawr/issues
+    Source code = https://github.com/lsst-sqre/gafaelfawr
+    Issue tracker = https://github.com/lsst-sqre/gafaelfawr/issues
 classifiers =
     Development Status :: 4 - Beta
     License :: OSI Approved :: MIT License

--- a/src/gafaelfawr/app.py
+++ b/src/gafaelfawr/app.py
@@ -92,11 +92,12 @@ async def create_app(
 
 async def setup_middleware(app: Application, config: Config) -> None:
     """Add middleware to the application."""
-    app.middlewares.append(bind_logger)
-
     # Unconditionally trust X-Forwarded-For, since this application is desiged
     # to run behind an NGINX ingress.
     await aiohttp_remotes.setup(app, aiohttp_remotes.XForwardedRelaxed())
+
+    # Create a custom logger for each request with request information bound.
+    app.middlewares.append(bind_logger)
 
     # Set up encrypted session storage via a cookie.
     session_storage = EncryptedCookieStorage(
@@ -109,6 +110,7 @@ async def setup_middleware(app: Application, config: Config) -> None:
     csrf_storage = aiohttp_csrf.storage.SessionStorage("csrf")
     aiohttp_csrf.setup(app, policy=csrf_policy, storage=csrf_storage)
 
+    # Configure Jinja2 templating of responses.
     templates_path = os.path.join(os.path.dirname(__file__), "templates")
     aiohttp_jinja2.setup(
         app, loader=jinja2.FileSystemLoader(templates_path),

--- a/src/gafaelfawr/config.py
+++ b/src/gafaelfawr/config.py
@@ -49,7 +49,7 @@ class SafirConfig:
     Set with the ``SAFIR_NAME`` environment variable.
     """
 
-    profile: str = os.getenv("SAFIR_PROFILE", "development")
+    profile: str = os.getenv("SAFIR_PROFILE", "production")
     """Application run profile: "development" or "production".
 
     Set with the ``SAFIR_PROFILE`` environment variable.

--- a/src/gafaelfawr/handlers/analyze.py
+++ b/src/gafaelfawr/handlers/analyze.py
@@ -31,14 +31,24 @@ async def get_analyze(request: web.Request) -> web.Response:
     -------
     response : `aiohttp.web.Response`
         The response.
+
+    Raises
+    ------
+    aiohttp.web.HTTPException
+        If the user is not logged in.
     """
     factory: ComponentFactory = request.config_dict["gafaelfawr/factory"]
     logger: BoundLogger = request["safir/logger"]
 
     session = await get_session(request)
+    if "handle" not in session:
+        msg = "Not logged in"
+        logger.warning(msg)
+        raise web.HTTPBadRequest(reason=msg, text=msg)
     handle = SessionHandle.from_str(session["handle"])
     session_store = factory.create_session_store(request, logger)
     result = await session_store.analyze_handle(handle)
+    logger.info("Analyzed user session")
     return web.json_response(result)
 
 
@@ -69,11 +79,13 @@ async def post_analyze(request: web.Request) -> web.Response:
     try:
         handle = SessionHandle.from_str(handle_or_token)
         session_store = factory.create_session_store(request, logger)
+        logger.info("Analyzed user-provided session handle")
         result = await session_store.analyze_handle(handle)
     except InvalidSessionHandleException:
         token = Token(encoded=handle_or_token)
         verifier = factory.create_token_verifier(request, logger)
         analysis = verifier.analyze_token(token)
+        logger.info("Analyzed user-provided token")
         result = {"token": analysis}
 
     return web.json_response(result)

--- a/src/gafaelfawr/handlers/auth.py
+++ b/src/gafaelfawr/handlers/auth.py
@@ -127,17 +127,22 @@ async def get_auth(request: web.Request) -> web.Response:
         msg = "auth_type parameter must be basic or bearer"
         raise web.HTTPBadRequest(reason=msg, text=msg)
     auth_type = AuthType[auth_type_name.capitalize()]
+    logger = logger.bind(
+        auth_uri=request.headers.get("X-Original-Uri", "NONE"),
+        required_scope=" ".join(sorted(required_scopes)),
+        satisfy=satisfy,
+    )
 
     # Check authentication and return an appropriate challenge and error
     # status if authentication failed.
     try:
-        token = await get_token_from_request(request)
+        token = await get_token_from_request(request, logger)
         if not token:
             logger.info("No token found, returning unauthorized")
             challenge = AuthChallenge(auth_type=auth_type, realm=config.realm)
             raise unauthorized(request, challenge, "Authentication required")
     except InvalidRequestException as e:
-        logger.warning("Invalid Authorization header: %s", str(e))
+        logger.warning("Invalid Authorization header", error=str(e))
         challenge = AuthChallenge(
             auth_type=auth_type,
             realm=config.realm,
@@ -147,7 +152,7 @@ async def get_auth(request: web.Request) -> web.Response:
         headers = {"WWW-Authenticate": challenge.as_header()}
         raise web.HTTPBadRequest(headers=headers, reason=str(e), text=str(e))
     except InvalidTokenException as e:
-        logger.warning("Invalid token: %s", str(e))
+        logger.warning("Invalid token", error=str(e))
         challenge = AuthChallenge(
             auth_type=auth_type,
             realm=config.realm,
@@ -155,6 +160,13 @@ async def get_auth(request: web.Request) -> web.Response:
             error_description=str(e),
         )
         raise unauthorized(request, challenge, str(e))
+
+    # Add user information to the logger.
+    logger = logger.bind(
+        token=token.jti,
+        user=token.username,
+        scope=" ".join(sorted(token.scope)),
+    )
 
     # Determine whether the request is authorized.
     if satisfy == "any":
@@ -166,15 +178,8 @@ async def get_auth(request: web.Request) -> web.Response:
     # return a 403 and include the desired scope in the resulting challenge,
     # since that may be useful for debugging issues.
     if not authorized:
-        logger.error(
-            "Token %s (user: %s, scope: %s) not authorized (needed %s of %s)",
-            token.jti,
-            token.username,
-            ", ".join(sorted(token.scope)) if token.scope else "--none--",
-            satisfy,
-            ", ".join(sorted(required_scopes)),
-        )
-        error = "Missing required scope"
+        error = "Token missing required scope"
+        logger.warning(error)
         challenge = AuthChallenge(
             auth_type=auth_type,
             realm=config.realm,
@@ -186,21 +191,14 @@ async def get_auth(request: web.Request) -> web.Response:
         raise web.HTTPForbidden(headers=headers, reason=error, text=error)
 
     # Log and return the results.
-    logger.info(
-        "Token %s (user: %s, scope: %s) authorized (needed %s of %s)",
-        token.jti,
-        token.username,
-        ", ".join(sorted(token.scope)),
-        satisfy,
-        ", ".join(sorted(required_scopes)),
-    )
-    token = maybe_reissue_token(request, token)
+    logger.info("Token authorized")
+    token = maybe_reissue_token(request, token, logger)
     headers = build_success_headers(request, token)
     return web.Response(headers=headers, text="ok")
 
 
 async def get_token_from_request(
-    request: web.Request,
+    request: web.Request, logger: BoundLogger,
 ) -> Optional[VerifiedToken]:
     """From the request, find the token we need.
 
@@ -212,6 +210,8 @@ async def get_token_from_request(
     ----------
     request : `aiohttp.web.Request`
         The incoming request.
+    logger : `structlog.BoundLogger`
+        Logger to use.
 
     Returns
     -------
@@ -226,7 +226,6 @@ async def get_token_from_request(
         A token was provided but it could not be verified.
     """
     factory: ComponentFactory = request.config_dict["gafaelfawr/factory"]
-    logger: BoundLogger = request["safir/logger"]
 
     # Use the session cookie if it is available.  This check has to be before
     # checking the Authorization header, since JupyterHub will set its own
@@ -246,7 +245,7 @@ async def get_token_from_request(
     # header.  This case is used by API calls from clients.  If we got a
     # session handle, convert it to a token.  Otherwise, if we got a token,
     # verify it.
-    handle_or_token = parse_authorization(request)
+    handle_or_token = parse_authorization(request, logger)
     if not handle_or_token:
         return None
     elif handle_or_token.startswith("gsh-"):
@@ -258,7 +257,9 @@ async def get_token_from_request(
         return verify_token(request, handle_or_token)
 
 
-def parse_authorization(request: web.Request) -> Optional[str]:
+def parse_authorization(
+    request: web.Request, logger: BoundLogger
+) -> Optional[str]:
     """Find a handle or token in the Authorization header.
 
     Supports either ``Bearer`` or ``Basic`` authorization types.
@@ -267,6 +268,8 @@ def parse_authorization(request: web.Request) -> Optional[str]:
     ----------
     request : `aiohttp.web.Request`
         The incoming request.
+    logger : `structlog.BoundLogger`
+        Logger to use.
 
     Returns
     -------
@@ -287,8 +290,6 @@ def parse_authorization(request: web.Request) -> Optional[str]:
     handle).  If neither is the case, assume the token or session handle is
     the username.
     """
-    logger: BoundLogger = request["safir/logger"]
-
     # Parse the header and handle Bearer.
     header = request.headers.get("Authorization")
     if not header:
@@ -297,13 +298,13 @@ def parse_authorization(request: web.Request) -> Optional[str]:
         raise InvalidRequestException("malformed Authorization header")
     auth_type, auth_blob = header.split(" ")
     if auth_type.lower() == "bearer":
+        logger.debug("Found token via Bearer auth")
         return auth_blob
     elif auth_type.lower() != "basic":
         msg = f"unkonwn Authorization type {auth_type}"
         raise InvalidRequestException(msg)
 
     # Basic, the complicated part.
-    logger.debug("Using OAuth with Basic")
     try:
         basic_auth = base64.b64decode(auth_blob).decode()
         user, password = basic_auth.strip().split(":")
@@ -311,8 +312,10 @@ def parse_authorization(request: web.Request) -> Optional[str]:
         msg = f"invalid Basic auth string: {str(e)}"
         raise InvalidRequestException(msg)
     if password == "x-oauth-basic":
+        logger.debug("Found token via Basic auth username")
         return user
     elif user == "x-oauth-basic":
+        logger.debug("Found token via Basic auth password")
         return password
     else:
         logger.info(
@@ -372,7 +375,7 @@ def unauthorized(
 
 
 def maybe_reissue_token(
-    request: web.Request, token: VerifiedToken
+    request: web.Request, token: VerifiedToken, logger: BoundLogger
 ) -> VerifiedToken:
     """Possibly reissue the token.
 
@@ -382,6 +385,8 @@ def maybe_reissue_token(
         The incoming request.
     token : `gafaelfawr.tokens.VerifiedToken`
         The current token.
+    logger : `structlog.BoundLogger`
+        Logger to use.
 
     Returns
     -------
@@ -410,6 +415,7 @@ def maybe_reissue_token(
     # session handle, so we don't use the handle to store it.
     issuer = factory.create_token_issuer()
     handle = SessionHandle()
+    logger.info("Reissuing token to audience %s", config.issuer.aud_internal)
     return issuer.reissue_token(token, jti=handle.key, internal=True)
 
 

--- a/src/gafaelfawr/handlers/login.py
+++ b/src/gafaelfawr/handlers/login.py
@@ -94,6 +94,7 @@ async def redirect_to_provider(request: web.Request) -> web.Response:
         msg = "No destination URL specified"
         logger.warning(msg)
         raise web.HTTPBadRequest(reason=msg, text=msg)
+    logger = logger.bind(return_url=return_url)
     if urlparse(return_url).hostname != request.url.raw_host:
         msg = f"Redirect URL not at {request.host}"
         logger.warning(msg)
@@ -170,22 +171,28 @@ async def handle_provider_return(request: web.Request) -> web.Response:
         msg = "Authentication state mismatch"
         raise web.HTTPForbidden(reason=msg, text=msg)
     return_url = session.pop("rd")
+    logger = logger.bind(return_url=return_url)
 
     # Build a session based on the reply from the authentication provider.
     auth_provider = factory.create_provider(request, logger)
     try:
         auth_session = await auth_provider.create_session(code, state)
     except ProviderException as e:
-        logger.warning("Provider authentication failed: %s", str(e))
+        logger.warning("Provider authentication failed", error=str(e))
         raise web.HTTPInternalServerError(reason=str(e), text=str(e))
-    except ClientResponseError:
+    except ClientResponseError as e:
         msg = "Cannot contact authentication provider"
-        logger.exception(msg)
+        logger.exception(msg, error=str(e))
         raise web.HTTPInternalServerError(reason=msg, text=msg)
 
     # Store the session and send the user back to what they were doing.
     session = await new_session(request)
     session["handle"] = auth_session.handle.encode()
+    logger = logger.bind(
+        user=auth_session.token.username,
+        token=auth_session.token.jti,
+        scope=" ".join(sorted(auth_session.token.scope)),
+    )
     logger.info(
         "Successfully authenticated user %s (%s)",
         auth_session.token.username,

--- a/src/gafaelfawr/handlers/logout.py
+++ b/src/gafaelfawr/handlers/logout.py
@@ -44,6 +44,10 @@ async def get_logout(request: web.Request) -> web.Response:
     logger: BoundLogger = request["safir/logger"]
 
     session = await get_session(request)
+    if session.get("handle"):
+        logger.info("Successful logout")
+    else:
+        logger.info("Logout of already-logged-out session")
     session.invalidate()
 
     redirect_url = request.query.get("rd")

--- a/src/gafaelfawr/handlers/logout.py
+++ b/src/gafaelfawr/handlers/logout.py
@@ -12,7 +12,7 @@ from gafaelfawr.handlers import routes
 
 if TYPE_CHECKING:
     from gafaelfawr.config import Config
-    from logging import Logger
+    from structlog import BoundLogger
 
 __all__ = ["get_logout"]
 
@@ -41,7 +41,7 @@ async def get_logout(request: web.Request) -> web.Response:
         the requested redirect URL is not valid.
     """
     config: Config = request.config_dict["gafaelfawr/config"]
-    logger: Logger = request["safir/logger"]
+    logger: BoundLogger = request["safir/logger"]
 
     session = await get_session(request)
     session.invalidate()

--- a/src/gafaelfawr/handlers/tokens.py
+++ b/src/gafaelfawr/handlers/tokens.py
@@ -210,6 +210,7 @@ async def get_tokens_new(
         The response.
     """
     config: Config = request.config_dict["gafaelfawr/config"]
+    logger: BoundLogger = request["safir/logger"]
 
     scopes = {s: d for s, d in config.known_scopes.items() if s in token.scope}
     form = build_new_token_form(scopes)
@@ -217,6 +218,7 @@ async def get_tokens_new(
     session = await get_session(request)
     session["csrf"] = await generate_token(request)
 
+    logger.info("Returned token creation form")
     return {
         "form": form,
         "scopes": scopes,
@@ -310,8 +312,10 @@ async def get_token_by_handle(
 
     if not user_token:
         msg = f"No token with handle {handle} found"
+        logger.warning(msg)
         raise web.HTTPNotFound(reason=msg, text=msg)
 
+    logger.info("Viewed token %s", handle)
     return {"token": user_token}
 
 

--- a/src/gafaelfawr/handlers/util.py
+++ b/src/gafaelfawr/handlers/util.py
@@ -15,6 +15,7 @@ from gafaelfawr.tokens import Token
 if TYPE_CHECKING:
     from gafaelfawr.factory import ComponentFactory
     from gafaelfawr.tokens import VerifiedToken
+    from structlog import BoundLogger
     from typing import Optional
 
 __all__ = [
@@ -119,9 +120,10 @@ def verify_token(request: web.Request, encoded_token: str) -> VerifiedToken:
         If the token is missing required claims.
     """
     factory: ComponentFactory = request.config_dict["gafaelfawr/factory"]
+    logger: BoundLogger = request["safir/logger"]
 
     token = Token(encoded=encoded_token)
-    token_verifier = factory.create_token_verifier(request)
+    token_verifier = factory.create_token_verifier(request, logger)
     try:
         return token_verifier.verify_internal_token(token)
     except jwt.InvalidTokenError as e:

--- a/src/gafaelfawr/handlers/well_known.py
+++ b/src/gafaelfawr/handlers/well_known.py
@@ -10,6 +10,7 @@ from gafaelfawr.handlers import routes
 
 if TYPE_CHECKING:
     from gafaelfawr.config import Config
+    from structlog import BoundLogger
 
 __all__ = ["get_well_known_jwks"]
 
@@ -31,6 +32,8 @@ async def get_well_known_jwks(request: web.Request) -> web.Response:
         The outgoing response.
     """
     config: Config = request.config_dict["gafaelfawr/config"]
+    logger: BoundLogger = request["safir/logger"]
 
     jwks = config.issuer.keypair.public_key_as_jwks(kid=config.issuer.kid)
+    logger.info("Returned JWKS")
     return web.json_response({"keys": [jwks]})

--- a/src/gafaelfawr/providers/github.py
+++ b/src/gafaelfawr/providers/github.py
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
     from gafaelfawr.config import GitHubConfig
     from gafaelfawr.issuer import TokenIssuer
     from gafaelfawr.session import SessionStore
-    from logging import Logger
+    from structlog import BoundLogger
     from typing import List
 
 __all__ = ["GitHubException", "GitHubProvider"]
@@ -82,7 +82,7 @@ class GitHubProvider(Provider):
         Issuer to use to generate new tokens.
     session_store : `gafaelfawr.session.SessionStore`
         Store for authentication sessions.
-    logger : `logging.Logger`
+    logger : `structlog.BoundLogger`
         Logger for any log messages.
     """
 
@@ -111,7 +111,7 @@ class GitHubProvider(Provider):
         http_session: ClientSession,
         issuer: TokenIssuer,
         session_store: SessionStore,
-        logger: Logger,
+        logger: BoundLogger,
     ) -> None:
         self._config = config
         self._http_session = http_session

--- a/src/gafaelfawr/providers/oidc.py
+++ b/src/gafaelfawr/providers/oidc.py
@@ -11,11 +11,11 @@ from gafaelfawr.tokens import Token
 
 if TYPE_CHECKING:
     from aiohttp import ClientSession
-    from logging import Logger
     from gafaelfawr.config import OIDCConfig
     from gafaelfawr.issuer import TokenIssuer
     from gafaelfawr.session import SessionStore
     from gafaelfawr.verify import TokenVerifier
+    from structlog import BoundLogger
 
 __all__ = ["OIDCException", "OIDCProvider"]
 
@@ -39,7 +39,7 @@ class OIDCProvider(Provider):
         Store for authentication sessions.
     http_session : `aiohttp.ClientSession`
         Session to use to make HTTP requests.
-    logger : `logging.Logger`
+    logger : `structlog.BoundLogger`
         Logger for any log messages.
     """
 
@@ -51,7 +51,7 @@ class OIDCProvider(Provider):
         issuer: TokenIssuer,
         session_store: SessionStore,
         http_session: ClientSession,
-        logger: Logger,
+        logger: BoundLogger,
     ) -> None:
         self._config = config
         self._verifier = verifier

--- a/src/gafaelfawr/session.py
+++ b/src/gafaelfawr/session.py
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
     from aioredis.commands import Pipeline
     from gafaelfawr.tokens import VerifiedToken
     from gafaelfawr.verify import TokenVerifier
-    from logging import Logger
+    from structlog import BoundLogger
     from typing import Any, Dict, Optional
 
 __all__ = [
@@ -174,12 +174,16 @@ class SessionStore:
     redis : `aioredis.Redis`
         A Redis client configured to talk to the backend store that holds the
         (encrypted) tokens.
-    logger : `logging.Logger`
+    logger : `structlog.BoundLogger`
         Logger for diagnostics.
     """
 
     def __init__(
-        self, key: str, verifier: TokenVerifier, redis: Redis, logger: Logger
+        self,
+        key: str,
+        verifier: TokenVerifier,
+        redis: Redis,
+        logger: BoundLogger,
     ) -> None:
         self._fernet = Fernet(key.encode())
         self._verifier = verifier

--- a/src/gafaelfawr/token_store.py
+++ b/src/gafaelfawr/token_store.py
@@ -10,8 +10,8 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from aioredis import Redis
     from aioredis.commands import Pipeline
-    from logging import Logger
     from gafaelfawr.session import Session
+    from structlog import BoundLogger
     from typing import List, Optional
 
 __all__ = ["TokenEntry", "TokenStore"]
@@ -96,11 +96,11 @@ class TokenStore:
     ----------
     redis : `aioredis.Redis`
         Redis client used to store and retrieve tokens.
-    logger : `logging.Logger`
+    logger : `structlog.BoundLogger`
         Logger to report any errors.
     """
 
-    def __init__(self, redis: Redis, logger: Logger) -> None:
+    def __init__(self, redis: Redis, logger: BoundLogger) -> None:
         self._redis = redis
         self._logger = logger
 

--- a/src/gafaelfawr/verify.py
+++ b/src/gafaelfawr/verify.py
@@ -19,9 +19,9 @@ from gafaelfawr.util import base64_to_number
 if TYPE_CHECKING:
     from aiohttp import ClientSession
     from cachetools import TTLCache
-    from logging import Logger
     from gafaelfawr.config import VerifierConfig
     from gafaelfawr.tokens import Token
+    from structlog import BoundLogger
     from typing import Any, Dict, List, Mapping, Optional
 
 __all__ = [
@@ -63,7 +63,7 @@ class TokenVerifier:
         The session to use for making requests.
     cache : `cachetools.TTLCache`
         Cache in which to store issuer keys.
-    logger : `logging.Logger`
+    logger : `structlog.BoundLogger`
         Logger to use to report status information.
     """
 
@@ -72,12 +72,12 @@ class TokenVerifier:
         config: VerifierConfig,
         session: ClientSession,
         cache: TTLCache,
-        logger: Logger,
+        logger: BoundLogger,
     ) -> None:
         self._config = config
         self._session = session
-        self._logger = logger
         self._cache = cache
+        self._logger = logger
 
     def analyze_token(self, token: Token) -> Dict[str, Any]:
         """Analyze a token and return its expanded information.

--- a/tests/handlers/analyze_test.py
+++ b/tests/handlers/analyze_test.py
@@ -16,6 +16,14 @@ if TYPE_CHECKING:
     from tests.setup import SetupTestCallable
 
 
+async def test_analyze_no_auth(create_test_setup: SetupTestCallable) -> None:
+    setup = await create_test_setup()
+
+    r = await setup.client.get("/auth/analyze")
+    assert r.status == 400
+    assert "Not logged in" in await r.text()
+
+
 async def test_analyze_handle(create_test_setup: SetupTestCallable) -> None:
     setup = await create_test_setup()
 

--- a/tests/handlers/auth_test.py
+++ b/tests/handlers/auth_test.py
@@ -161,7 +161,7 @@ async def test_access_denied(create_test_setup: SetupTestCallable) -> None:
     assert authenticate.error == AuthError.insufficient_scope
     assert authenticate.scope == "exec:admin"
     body = await r.text()
-    assert "Missing required scope" in body
+    assert "Token missing required scope" in body
 
 
 async def test_satisfy_all(create_test_setup: SetupTestCallable) -> None:
@@ -180,7 +180,7 @@ async def test_satisfy_all(create_test_setup: SetupTestCallable) -> None:
     assert authenticate.error == AuthError.insufficient_scope
     assert authenticate.scope == "exec:admin exec:test"
     body = await r.text()
-    assert "Missing required scope" in body
+    assert "Token missing required scope" in body
 
 
 async def test_success(create_test_setup: SetupTestCallable) -> None:
@@ -408,15 +408,104 @@ async def test_logging(
     setup = await create_test_setup()
     token = setup.create_token(scope="exec:admin")
 
+    # Successful request.
     r = await setup.client.get(
         "/auth",
         params={"scope": "exec:admin"},
-        headers={"Authorization": f"Bearer {token.encoded}"},
+        headers={
+            "Authorization": f"Bearer {token.encoded}",
+            "X-Original-Uri": "/foo",
+            "X-Forwarded-For": "192.0.2.1",
+        },
     )
     assert r.status == 200
     data = json.loads(caplog.record_tuples[0][2])
-    assert data["path"] == "/auth"
-    assert data["method"] == "GET"
-    assert data["request_id"]
-    assert data["remote"] == "127.0.0.1"
-    assert data["user_agent"]
+    assert data == {
+        "auth_uri": "/foo",
+        "event": "Token authorized",
+        "level": "info",
+        "logger": "gafaelfawr",
+        "method": "GET",
+        "path": "/auth",
+        "remote": "192.0.2.1",
+        "request_id": ANY,
+        "required_scope": "exec:admin",
+        "satisfy": "all",
+        "scope": "exec:admin",
+        "token": token.jti,
+        "user": token.username,
+        "user_agent": ANY,
+    }
+    caplog.clear()
+
+    # Authorization failed.
+    r = await setup.client.get(
+        "/auth",
+        params={"scope": "exec:test", "satisfy": "any"},
+        headers={
+            "Authorization": f"Bearer {token.encoded}",
+            "X-Original-Uri": "/foo",
+        },
+    )
+    assert r.status == 403
+    data = json.loads(caplog.record_tuples[0][2])
+    assert data == {
+        "auth_uri": "/foo",
+        "event": "Token missing required scope",
+        "level": "warning",
+        "logger": "gafaelfawr",
+        "method": "GET",
+        "path": "/auth",
+        "remote": "127.0.0.1",
+        "request_id": ANY,
+        "required_scope": "exec:test",
+        "satisfy": "any",
+        "scope": "exec:admin",
+        "token": token.jti,
+        "user": token.username,
+        "user_agent": ANY,
+    }
+    caplog.clear()
+
+    # No token found.
+    r = await setup.client.get("/auth", params={"scope": "exec:admin"})
+    assert r.status == 401
+    data = json.loads(caplog.record_tuples[0][2])
+    assert data == {
+        "auth_uri": "NONE",
+        "event": "No token found, returning unauthorized",
+        "level": "info",
+        "logger": "gafaelfawr",
+        "method": "GET",
+        "path": "/auth",
+        "remote": "127.0.0.1",
+        "request_id": ANY,
+        "required_scope": "exec:admin",
+        "satisfy": "all",
+        "user_agent": ANY,
+    }
+    caplog.clear()
+
+    # Invalid token.
+    r = await setup.client.get(
+        "/auth",
+        params={"scope": "exec:admin"},
+        headers={"Authorization": f"Bearer blah"},
+    )
+    assert r.status == 401
+    data = json.loads(caplog.record_tuples[0][2])
+    assert data == {
+        "auth_uri": "NONE",
+        "error": "Not enough segments",
+        "event": "Invalid token",
+        "level": "warning",
+        "logger": "gafaelfawr",
+        "method": "GET",
+        "path": "/auth",
+        "remote": "127.0.0.1",
+        "request_id": ANY,
+        "required_scope": "exec:admin",
+        "satisfy": "all",
+        "user_agent": ANY,
+    }
+    caplog.clear()

--- a/tests/handlers/logout_test.py
+++ b/tests/handlers/logout_test.py
@@ -2,14 +2,19 @@
 
 from __future__ import annotations
 
+import json
 from typing import TYPE_CHECKING
+from unittest.mock import ANY
 from urllib.parse import parse_qs, urlparse
 
 if TYPE_CHECKING:
+    from _pytest.logging import LogCaptureFixture
     from tests.setup import SetupTestCallable
 
 
-async def test_logout(create_test_setup: SetupTestCallable) -> None:
+async def test_logout(
+    create_test_setup: SetupTestCallable, caplog: LogCaptureFixture
+) -> None:
     setup = await create_test_setup("github")
 
     # Simulate the initial authentication request.
@@ -36,9 +41,21 @@ async def test_logout(create_test_setup: SetupTestCallable) -> None:
     assert r.status == 200
 
     # Go to /logout without specifying a redirect URL and check the redirect.
+    caplog.clear()
     r = await setup.client.get("/logout", allow_redirects=False)
     assert r.status == 303
     assert r.headers["Location"] == setup.config.after_logout_url
+    data = json.loads(caplog.record_tuples[0][2])
+    assert data == {
+        "event": "Successful logout",
+        "level": "info",
+        "logger": "gafaelfawr",
+        "method": "GET",
+        "path": "/logout",
+        "remote": "127.0.0.1",
+        "request_id": ANY,
+        "user_agent": ANY,
+    }
 
     # Confirm that we're no longer logged in.
     r = await setup.client.get("/auth", params={"scope": "read:all"})
@@ -85,13 +102,25 @@ async def test_logout_with_url(create_test_setup: SetupTestCallable) -> None:
 
 
 async def test_logout_not_logged_in(
-    create_test_setup: SetupTestCallable,
+    create_test_setup: SetupTestCallable, caplog: LogCaptureFixture
 ) -> None:
     setup = await create_test_setup()
 
     r = await setup.client.get("/logout", allow_redirects=False)
     assert r.status == 303
     assert r.headers["Location"] == setup.config.after_logout_url
+    data = json.loads(caplog.record_tuples[0][2])
+    assert data == {
+        "event": "Logout of already-logged-out session",
+        "level": "info",
+        "logger": "gafaelfawr",
+        "method": "GET",
+        "path": "/logout",
+        "remote": "127.0.0.1",
+        "request_id": ANY,
+        "user_agent": ANY,
+    }
+
     r = await setup.client.get("/auth", params={"scope": "read:all"})
     assert r.status == 401
 


### PR DESCRIPTION
- Switch to the JSON log output format by default
- Add custom `remote` and `user_agent` attributes to every request
- Add additional custom attributes appropriate to various routes
- Ensure that all the routes log at least one message
- Standardize on separating the log message from the exception message
- Add tests for the logging
- Provide a nicer error message if someone goes to `/auth/analyze` without authentication