### PR TITLE
[DM-24753] Add support for suppressing caching of errors

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,8 +2,11 @@
 Change log
 ##########
 
-1.1.2 (2020-05-07)
+1.2.0 (2020-05-07)
 ==================
+
+New in this release is an ``/auth/forbidden`` route that can be used to provide a non-cached 403 error page.
+See `the documentation <https://gafaelfawr.lsst.io/install.html#disabling-error-caching>`__ for more information.
 
 This release changes Gafaelfawr's logging format and standardizes the contents of the logs.
 All logs are now in JSON.

--- a/docs/arch/routes.rst
+++ b/docs/arch/routes.rst
@@ -17,6 +17,12 @@ Gafaelfawr supports the following routes:
     The response from this route includes various headers that provide information about the JWT claims.
     For a complete list, see :ref:`auth-headers`.
 
+``/auth/forbidden``
+    Helper error page route for ``/auth``.
+    Serves a 403 (HTTP Forbidden) error with an appropriate challenge given the same request parameters as an ``/auth`` request.
+    For more information on how this route is used, see :ref:`error-caching`.
+    For documentation on the parameters accepted by this route, see :ref:`auth-config`.
+
 ``/auth/analyze``
     Analyze a token or session handle and return information about it as JSON.
     If the request method is GET, uses the session handle from the user's session cookie or from an ``Authentication`` header.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -59,7 +59,7 @@ default_role = "py:obj"
 # Intersphinx ================================================================
 
 intersphinx_mapping = {
-    "aiohttp": ("https://aiohttp.readthedocs.io/en/stable/", None),
+    "aiohttp": ("https://docs.aiohttp.org/en/stable/", None),
     "aiohttp_session": (
         "https://aiohttp-session.readthedocs.io/en/stable/",
         None,


### PR DESCRIPTION
- Add a route that can be used as a custom error handler for 403 errors
- Add Cache-Control headers to all errors returned by /auth
- Refactor the parsing of /auth route parameters