### PR TITLE
[DM-24964] Lowercase GitHub usernames and organizations

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,8 +2,12 @@
 Change log
 ##########
 
-1.3.0 (unreleased)
+1.3.0 (2020-05-19)
 ==================
+
+This release changes the construction of identity and groups from GitHub authentication by coercing identifiers to lowercase.
+GitHub is case-preserving but case-insensitive, which is complex for protected applications to deal with.
+This change ensures Gafaelfawr exposes a consistent canonical identity to downstream applications that is also compatible with other systems that expect lowercase identifiers, such as Kubernetes namespaces.
 
 - Lowercase GitHub usernames when constructing identity tokens.
 - Lowercase GitHub organization names when constructing group membership.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,12 @@
 Change log
 ##########
 
+1.3.0 (unreleased)
+==================
+
+- Lowercase GitHub usernames when constructing identity tokens.
+- Lowercase GitHub organization names when constructing group membership.
+
 1.2.1 (2020-05-14)
 ==================
 

--- a/docs/arch/providers.rst
+++ b/docs/arch/providers.rst
@@ -36,9 +36,9 @@ In addition to the standard JWT claims, the following information is included:
     ``name`` is a string and ``id`` is a number.
     See :ref:`github-groups` for more details.
 ``sub``
-    The ``login`` attribute returned by the ``/user`` API route.
+    The ``login`` attribute returned by the ``/user`` API route, forced to lowercase.
 ``uid``
-    The ``login`` attribute returned by the ``/user`` API route.
+    The ``login`` attribute returned by the ``/user`` API route, forced to lowercase.
 ``uidNumber``
     The ``id`` attribute returned by the ``/user`` API route, converted to a string.
     The hope is that this is suitable for a unique UID.
@@ -50,7 +50,7 @@ Groups from GitHub
 
 Gafaelfawr synthesizes groups from GitHub teams.
 Each team membership that an authenticated user has on GitHub (and releases through the GitHub OAuth authentication) will be mapped to a group in the ``isMemberOf`` claim.
-The default group name is ``<organization>-<team-slug>`` where ``<organization>`` is the ``login`` attribute of the organization containing the team and ``<team-slug>`` is the ``slug`` attribute of the team.
+The default group name is ``<organization>-<team-slug>`` where ``<organization>`` is the ``login`` attribute (forced to lowercase) of the organization containing the team and ``<team-slug>`` is the ``slug`` attribute of the team.
 These values are retrieved through the ``/user/teams`` API route.
 The ``slug`` attribute is constructed by GitHub based on the name.
 It's a canonicalization of the name that removes case differences and replaces special characters like space with a dash.

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -153,7 +153,9 @@ To use that chart, you will need to provide a ``values.yaml`` file with the foll
 
 ``group_mapping``
     Mapping of scope names to lists of groups that provide that scope.
-    Tokens from an OpenID Connect provider such as CILogon that include groups in an ``isMemberOf`` claim will be granted scopes based on this mapping.
+    When GitHub is used as the provider, group membership will be synthesized from GitHub team membership.
+    See :ref:`github-groups` for more information.
+    When an OpenID Connect provider such as CILogon is used as the provider, group membership will be taken from the ``isMemberOf`` claim of the token returned by the provider.
 
 For an example, see `the configuration for the LSST Science Platform deployments <https://github.com/lsst-sqre/lsp-deploy/blob/master/services/gafaelfawr>`__.
 

--- a/src/gafaelfawr/providers/github.py
+++ b/src/gafaelfawr/providers/github.py
@@ -175,8 +175,8 @@ class GitHubProvider(Provider):
             "isMemberOf": groups,
             "jti": handle.key,
             "name": user_info.name,
-            "sub": user_info.username,
-            self._config.username_claim: user_info.username,
+            "sub": user_info.username.lower(),
+            self._config.username_claim: user_info.username.lower(),
             self._config.uid_claim: str(user_info.uid),
         }
 
@@ -208,7 +208,7 @@ class GitHubProvider(Provider):
         will be truncated to 25 characters and the first six characters of a
         hash of the full name will be appended for uniqueness.
         """
-        group_name = f"{organization}-{team_slug}"
+        group_name = f"{organization.lower()}-{team_slug}"
         if len(group_name) > 32:
             name_hash = hashlib.sha256(group_name.encode()).digest()
             suffix = base64.urlsafe_b64encode(name_hash).decode()[:6]

--- a/src/gafaelfawr/providers/github.py
+++ b/src/gafaelfawr/providers/github.py
@@ -36,17 +36,31 @@ class GitHubTeam:
     organization: str
     """The organization (its login attribute) of which the team is a part."""
 
-    group_name: str
-    """A group name constructed from the slug and organization.
-
-    The default construction is the organization name (from the login field),
-    a dash, and the team slug.  If this is over 32 characters, it will be
-    truncated to 25 characters and the first six characters of a hash of the
-    full name will be appended for uniqueness.
-    """
-
     gid: int
     """The GitHub ID of the team, hopefully usable as a GID."""
+
+    @property
+    def group_name(self) -> str:
+        """The group name corresponding to this GitHub team.
+
+        Returns
+        -------
+        group_name : `str`
+            The name of the group.
+
+        Notes
+        -----
+        The default construction is the organization name (from the login
+        field), a dash, and the team slug.  If this is over 32 characters, it
+        will be truncated to 25 characters and the first six characters of a
+        hash of the full name will be appended for uniqueness.
+        """
+        group_name = f"{self.organization.lower()}-{self.slug}"
+        if len(group_name) > 32:
+            name_hash = hashlib.sha256(group_name.encode()).digest()
+            suffix = base64.urlsafe_b64encode(name_hash).decode()[:6]
+            group_name = group_name[:25] + "-" + suffix
+        return group_name
 
 
 @dataclass(frozen=True)
@@ -185,36 +199,6 @@ class GitHubProvider(Provider):
         await self._session_store.store_session(session)
         return session
 
-    @staticmethod
-    def _build_group_name(team_slug: str, organization: str) -> str:
-        """Construct a group name from the team slug and organization name.
-
-        Parameters
-        ----------
-        team_slug : `str`
-            The slug attribute of the GitHub team.
-        organization : `str`
-            The name of the organization that owns the team.
-
-        Returns
-        -------
-        group_name : `str`
-            The name of the group.
-
-        Notes
-        -----
-        The default construction is the organization name (from the login
-        field), a dash, and the team slug.  If this is over 32 characters, it
-        will be truncated to 25 characters and the first six characters of a
-        hash of the full name will be appended for uniqueness.
-        """
-        group_name = f"{organization.lower()}-{team_slug}"
-        if len(group_name) > 32:
-            name_hash = hashlib.sha256(group_name.encode()).digest()
-            suffix = base64.urlsafe_b64encode(name_hash).decode()[:6]
-            group_name = group_name[:25] + "-" + suffix
-        return group_name
-
     async def _get_access_token(self, code: str, state: str) -> str:
         """Given the code from a successful authentication, get a token.
 
@@ -303,13 +287,9 @@ class GitHubProvider(Provider):
         for team in teams_data:
             slug = team["slug"]
             organization = team["organization"]["login"]
-            group_name = self._build_group_name(slug, organization)
             teams.append(
                 GitHubTeam(
-                    slug=slug,
-                    organization=organization,
-                    group_name=group_name,
-                    gid=team["id"],
+                    slug=slug, organization=organization, gid=team["id"],
                 )
             )
 

--- a/tests/handlers/login_github_test.py
+++ b/tests/handlers/login_github_test.py
@@ -30,17 +30,12 @@ async def test_login(
         uid=123456,
         email="githubuser@example.com",
         teams=[
-            GitHubTeam(
-                slug="a-team", gid=1000, organization="org", group_name=""
-            ),
-            GitHubTeam(
-                slug="other-team", gid=1001, organization="org", group_name=""
-            ),
+            GitHubTeam(slug="a-team", gid=1000, organization="org"),
+            GitHubTeam(slug="other-team", gid=1001, organization="org"),
             GitHubTeam(
                 slug="team-with-very-long-name",
                 gid=1002,
                 organization="other-org",
-                group_name="",
             ),
         ],
     )
@@ -212,11 +207,7 @@ async def test_cookie_auth_with_token(
         username="githubuser",
         uid=123456,
         email="githubuser@example.com",
-        teams=[
-            GitHubTeam(
-                slug="a-team", gid=1000, organization="org", group_name=""
-            ),
-        ],
+        teams=[GitHubTeam(slug="a-team", gid=1000, organization="org")],
     )
     setup.set_github_userinfo(userinfo)
 
@@ -254,11 +245,7 @@ async def test_claim_names(create_test_setup: SetupTestCallable) -> None:
         username="githubuser",
         uid=123456,
         email="githubuser@example.com",
-        teams=[
-            GitHubTeam(
-                slug="a-team", gid=1000, organization="org", group_name=""
-            ),
-        ],
+        teams=[GitHubTeam(slug="a-team", gid=1000, organization="org")],
     )
     setup.set_github_userinfo(userinfo)
 
@@ -357,11 +344,7 @@ async def test_github_uppercase(create_test_setup: SetupTestCallable,) -> None:
         username="SomeUser",
         uid=1000,
         email="user@example.com",
-        teams=[
-            GitHubTeam(
-                slug="a-team", gid=1000, organization="ORG", group_name=""
-            ),
-        ],
+        teams=[GitHubTeam(slug="a-team", gid=1000, organization="ORG")],
     )
     setup.set_github_userinfo(userinfo)
 

--- a/tests/handlers/login_github_test.py
+++ b/tests/handlers/login_github_test.py
@@ -8,7 +8,11 @@ from unittest.mock import ANY
 from urllib.parse import parse_qs, urlparse
 
 from gafaelfawr.constants import ALGORITHM
-from gafaelfawr.providers.github import GitHubProvider
+from gafaelfawr.providers.github import (
+    GitHubProvider,
+    GitHubTeam,
+    GitHubUserInfo,
+)
 
 if TYPE_CHECKING:
     from _pytest.logging import LogCaptureFixture
@@ -20,6 +24,27 @@ async def test_login(
 ) -> None:
     setup = await create_test_setup()
     assert setup.config.github
+    userinfo = GitHubUserInfo(
+        name="GitHub User",
+        username="githubuser",
+        uid=123456,
+        email="githubuser@example.com",
+        teams=[
+            GitHubTeam(
+                slug="a-team", gid=1000, organization="org", group_name=""
+            ),
+            GitHubTeam(
+                slug="other-team", gid=1001, organization="org", group_name=""
+            ),
+            GitHubTeam(
+                slug="team-with-very-long-name",
+                gid=1002,
+                organization="other-org",
+                group_name="",
+            ),
+        ],
+    )
+    setup.set_github_userinfo(userinfo)
 
     # Simulate the initial authentication request.
     return_url = f"https://{setup.client.host}:4444/foo?a=bar&b=baz"
@@ -131,6 +156,14 @@ async def test_login_redirect_header(
 ) -> None:
     """Test receiving the redirect header via X-Auth-Request-Redirect."""
     setup = await create_test_setup()
+    userinfo = GitHubUserInfo(
+        name="GitHub User",
+        username="githubuser",
+        uid=123456,
+        email="githubuser@example.com",
+        teams=[],
+    )
+    setup.set_github_userinfo(userinfo)
 
     # Simulate the initial authentication request.
     return_url = f"https://{setup.client.host}/foo?a=bar&b=baz"
@@ -174,6 +207,18 @@ async def test_cookie_auth_with_token(
     Authorization header.
     """
     setup = await create_test_setup()
+    userinfo = GitHubUserInfo(
+        name="GitHub User",
+        username="githubuser",
+        uid=123456,
+        email="githubuser@example.com",
+        teams=[
+            GitHubTeam(
+                slug="a-team", gid=1000, organization="org", group_name=""
+            ),
+        ],
+    )
+    setup.set_github_userinfo(userinfo)
 
     # Simulate the initial authentication request.
     r = await setup.client.get(
@@ -204,6 +249,18 @@ async def test_claim_names(create_test_setup: SetupTestCallable) -> None:
     """Uses an alternate settings environment with non-default claims."""
     setup = await create_test_setup("github-claims")
     assert setup.config.github
+    userinfo = GitHubUserInfo(
+        name="GitHub User",
+        username="githubuser",
+        uid=123456,
+        email="githubuser@example.com",
+        teams=[
+            GitHubTeam(
+                slug="a-team", gid=1000, organization="org", group_name=""
+            ),
+        ],
+    )
+    setup.set_github_userinfo(userinfo)
 
     # Simulate the initial authentication request.
     r = await setup.client.get(
@@ -243,6 +300,14 @@ async def test_claim_names(create_test_setup: SetupTestCallable) -> None:
 
 async def test_bad_redirect(create_test_setup: SetupTestCallable) -> None:
     setup = await create_test_setup()
+    userinfo = GitHubUserInfo(
+        name="GitHub User",
+        username="githubuser",
+        uid=123456,
+        email="githubuser@example.com",
+        teams=[],
+    )
+    setup.set_github_userinfo(userinfo)
 
     r = await setup.client.get(
         "/login", params={"rd": "https://example.com/"}, allow_redirects=False,

--- a/tests/handlers/logout_test.py
+++ b/tests/handlers/logout_test.py
@@ -7,6 +7,8 @@ from typing import TYPE_CHECKING
 from unittest.mock import ANY
 from urllib.parse import parse_qs, urlparse
 
+from gafaelfawr.providers.github import GitHubTeam, GitHubUserInfo
+
 if TYPE_CHECKING:
     from _pytest.logging import LogCaptureFixture
     from tests.setup import SetupTestCallable
@@ -16,6 +18,18 @@ async def test_logout(
     create_test_setup: SetupTestCallable, caplog: LogCaptureFixture
 ) -> None:
     setup = await create_test_setup("github")
+    userinfo = GitHubUserInfo(
+        name="GitHub User",
+        username="githubuser",
+        uid=123456,
+        email="githubuser@example.com",
+        teams=[
+            GitHubTeam(
+                slug="a-team", gid=1000, organization="org", group_name=""
+            ),
+        ],
+    )
+    setup.set_github_userinfo(userinfo)
 
     # Simulate the initial authentication request.
     r = await setup.client.get(
@@ -64,6 +78,18 @@ async def test_logout(
 
 async def test_logout_with_url(create_test_setup: SetupTestCallable) -> None:
     setup = await create_test_setup("github")
+    userinfo = GitHubUserInfo(
+        name="GitHub User",
+        username="githubuser",
+        uid=123456,
+        email="githubuser@example.com",
+        teams=[
+            GitHubTeam(
+                slug="a-team", gid=1000, organization="org", group_name=""
+            ),
+        ],
+    )
+    setup.set_github_userinfo(userinfo)
 
     # Simulate the initial authentication request.
     r = await setup.client.get(

--- a/tests/handlers/logout_test.py
+++ b/tests/handlers/logout_test.py
@@ -23,11 +23,7 @@ async def test_logout(
         username="githubuser",
         uid=123456,
         email="githubuser@example.com",
-        teams=[
-            GitHubTeam(
-                slug="a-team", gid=1000, organization="org", group_name=""
-            ),
-        ],
+        teams=[GitHubTeam(slug="a-team", gid=1000, organization="org")],
     )
     setup.set_github_userinfo(userinfo)
 
@@ -83,11 +79,7 @@ async def test_logout_with_url(create_test_setup: SetupTestCallable) -> None:
         username="githubuser",
         uid=123456,
         email="githubuser@example.com",
-        teams=[
-            GitHubTeam(
-                slug="a-team", gid=1000, organization="org", group_name=""
-            ),
-        ],
+        teams=[GitHubTeam(slug="a-team", gid=1000, organization="org")],
     )
     setup.set_github_userinfo(userinfo)
 

--- a/tests/setup.py
+++ b/tests/setup.py
@@ -13,6 +13,7 @@ if TYPE_CHECKING:
     from aioredis import Redis
     from gafaelfawr.config import Config
     from gafaelfawr.factory import ComponentFactory
+    from gafaelfawr.providers.github import GitHubUserInfo
     from gafaelfawr.tokens import Token, VerifiedToken
     from tests.support.http_session import MockClientSession
     from typing import Awaitable, Callable, List, Optional, Union
@@ -113,6 +114,17 @@ class SetupTest:
             The generated token.
         """
         return create_oidc_test_token(self.config, groups=groups, **claims)
+
+    def set_github_userinfo(self, userinfo: GitHubUserInfo) -> None:
+        """Set the GitHub user information to return from the GitHub API.
+
+        Parameters
+        ----------
+        userinfo : `gafaelfawr.providers.github.GitHubUserInfo`
+            User information to use to synthesize GitHub API responses.
+        """
+        http_session: MockClientSession = self.app["safir/http_session"]
+        http_session.set_github_userinfo(userinfo)
 
     def set_oidc_token(self, token: Token) -> None:
         """Set the token that will be returned from the OIDC token endpoint.


### PR DESCRIPTION
Convert GitHub usernames and organizations to lowercase when forming identities and group membership for tokens. Refactor GitHub testing and team name handling.