### PR TITLE
[DM-24810] Support multiple X-Forwarded-Proto headers

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,7 +2,7 @@
 Change log
 ##########
 
-1.3.2 (unreleased)
+1.3.2 (2020-06-08)
 ==================
 
 - Work around an NGINX ingress bug in 1.39.1 by allowing multiple ``X-Forwarded-Proto`` headers in the incoming request.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,12 @@
 Change log
 ##########
 
+1.3.2 (unreleased)
+==================
+
+- Work around an NGINX ingress bug in 1.39.1 by allowing multiple ``X-Forwarded-Proto`` headers in the incoming request.
+- Document how to configure NGINX ingress with the official Helm chart to support logging accurate client IPs.
+
 1.3.1 (2020-05-29)
 ==================
 

--- a/docs/logging.rst
+++ b/docs/logging.rst
@@ -108,6 +108,18 @@ Making this work properly requires some additional configuration:
    This comes with some caveats and drawbacks.
    See `this Medium post <https://medium.com/pablo-perez/k8s-externaltrafficpolicy-local-or-cluster-40b259a19404>`__ for more details.
 
+If you are using the `NGINX ingress Helm chart <https://github.com/helm/charts/tree/master/stable/nginx-ingress>`__, you can make both of the required NGINX ingress changes with the following ``values.yaml`` file:
+
+.. code-block:: yaml
+
+   nginx-ingress:
+     controller:
+       config:
+         compute-full-forwarded-for: "true"
+         use-forwarded-headers: "true"
+       service:
+         externalTrafficPolicy: Local
+
 For the curious, here are the details of why these changes are required.
 
 Determining the client IP from ``X-Forwarded-For`` is complicated because Gafaelfawr's ``/auth`` route is called via an NGINX ``auth_request`` directive.

--- a/tests/x_forwarded_test.py
+++ b/tests/x_forwarded_test.py
@@ -151,4 +151,4 @@ async def test_too_many_headers(aiohttp_client: TestClientCallable) -> None:
             ("X-Forwarded-Host", "example.com"),
         ],
     )
-    assert resp.status == 400
+    assert resp.status == 200


### PR DESCRIPTION
Work around a bug in version 1.39.1 of the Kubernetes NGINX ingress
by allowing multiple X-Forwarded-Proto headers in the incoming
request.

Add documentation for how to configure the NGINX ingress using the
Helm chart to get correct client IP addresses in logs.