### PR TITLE
[DM-25183] Enable updates for all dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,3 +14,5 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    allow:
+      - dependency-type: "all"


### PR DESCRIPTION
See if it makes a difference for frozen PIP requirements files to
enable updates for all dependencies, not just directly listed ones.