### PR TITLE
Switch to new LTD username

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -96,6 +96,6 @@ jobs:
 
       - name: Upload to LSST the Docs
         env:
-          LTD_USERNAME: travis
+          LTD_USERNAME: ${{ secrets.LTD_USERNAME }}
           LTD_PASSWORD: ${{ secrets.LTD_PASSWORD }}
         run: ltd upload --product gafaelfawr --gh --dir docs/_build/html


### PR DESCRIPTION
Use the organization-wide secret instead of the legacy travis
username (mostly so that I don't make this mistake when copying
Gafaelfawr configuration to new projects).