### PR TITLE
[DM-26072] Add an OpenID Connect server

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,6 @@ repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v3.2.0
     hooks:
-      - id: check-merge-conflict
       - id: check-toml
       - id: check-yaml
         args: [--allow-multiple-documents]

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,8 +5,17 @@ Change log
 1.4.0 (unreleased)
 ==================
 
+This release adds a minimalist OpenID Connect server to support protected applications that only understand OpenID Connect.
+The initial implementation is intended to support `Chronograf <https://www.influxdata.com/time-series-platform/chronograf/>`__.
+Other applications may or may not work.
+
 - Add support for a password-protected Redis backend.
   This uses a new configuration parameter, ``redis_password_file``, which points to a file containing the password for Redis.
+- Add a minimalist OpenID Connect server.
+  The secrets for client connections are read from a file designed by a new configuration parameter, ``oidc_server_secrets_file``.
+  The authentication endpoint is ``/auth/openid/login`` and the token endpoint is ``/auth/openid/token``.
+- Add a user information endpoint (``/auth/userinfo``) that accepts a JWT and returns its claims.
+  Intended primarily for use with OpenID Connect.
 
 1.3.2 (2020-06-08)
 ==================

--- a/README.rst
+++ b/README.rst
@@ -10,6 +10,7 @@ Gafaelfawr is primarily an implementation of the `Token Proxy component <https:/
 
 It authorizes tokens in according to the Nginx's ``auth_request`` directive via it's ``/auth`` endpoint and handles integration with an external identity provider (either with GitHub or OpenID Connect).
 Authentication sessions are stored in Redis.
+It also provides a minimal OpenID Connect server to support protected applications that only understand OpenID Connect.
 
 For full documentation, see `gafaelfawr.lsst.io <https://gafaelfawr.lsst.io/>`__.
 

--- a/docs/_static/flow-oidc.diag
+++ b/docs/_static/flow-oidc.diag
@@ -1,18 +1,18 @@
 seqdiag {
     browser -> app;
-    browser <- app [label = "redirect to /auth/openid/login"];
+    browser <- app [label = "redirect"];
     browser -> gafaelfawr [label = "/auth/openid/login"];
-    browser <- gafaelfawr [label = "redirect to /login"]
+    browser <- gafaelfawr [label = "redirect"]
     browser -> gafaelfawr [label = "/login"];
-    browser <- gafaelfawr [label = "redirect to IdP"];
+    browser <- gafaelfawr [label = "redirect"];
     browser -> IdP [label = "authenticate"];
     browser <- IdP [label = "redirect to /login"];
     browser -> gafaelfawr [label = "/login"];
                gafaelfawr -> IdP [label = "get data"];
                gafaelfawr <- IdP [label = "user data"];
-    browser <- gafaelfawr [label = "redirect to /auth/openid/login"];
+    browser <- gafaelfawr [label = "redirect with session cookie"];
     browser -> gafaelfawr [label = "/auth/openid/login"];
-    browser <- gafaelfawr [label = "redirect to app"];
+    browser <- gafaelfawr [label = "redirect"];
     browser -> app;
                app -> gafaelfawr [label = "/auth/openid/token"];
                app <- gafaelfawr;

--- a/docs/_static/flow-oidc.diag
+++ b/docs/_static/flow-oidc.diag
@@ -1,0 +1,22 @@
+seqdiag {
+    browser -> app;
+    browser <- app [label = "redirect to /auth/openid/login"];
+    browser -> gafaelfawr [label = "/auth/openid/login"];
+    browser <- gafaelfawr [label = "redirect to /login"]
+    browser -> gafaelfawr [label = "/login"];
+    browser <- gafaelfawr [label = "redirect to IdP"];
+    browser -> IdP [label = "authenticate"];
+    browser <- IdP [label = "redirect to /login"];
+    browser -> gafaelfawr [label = "/login"];
+               gafaelfawr -> IdP [label = "get data"];
+               gafaelfawr <- IdP [label = "user data"];
+    browser <- gafaelfawr [label = "redirect to /auth/openid/login"];
+    browser -> gafaelfawr [label = "/auth/openid/login"];
+    browser <- gafaelfawr [label = "redirect to app"];
+    browser -> app;
+               app -> gafaelfawr [label = "/auth/openid/token"];
+               app <- gafaelfawr;
+               app -> gafaelfawr [label = "/auth/userinfo"];
+               app <- gafaelfawr;
+    browser <- app;
+}

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -33,6 +33,8 @@ API reference
 
 .. automodapi:: gafaelfawr.handlers.tokens
 
+.. automodapi:: gafaelfawr.handlers.userinfo
+
 .. automodapi:: gafaelfawr.handlers.util
 
 .. automodapi:: gafaelfawr.handlers.well_known

--- a/docs/applications.rst
+++ b/docs/applications.rst
@@ -1,0 +1,185 @@
+#########################
+Application configuration
+#########################
+
+Protecting a service
+====================
+
+Gafaelfawr's routes must be exposed under the same hostname as the service that it is protecting.
+IF you need to protect services running under multiple hostnames, you will need to configure Gafaelfawr's ingress to add its routes (specifically ``/auth`` and ``/login``) to each of those hostnames.
+
+Authentication and authorization for a service are configured via annotations on the ingress for that service.
+The typical annotations for a web application used via a web browser are:
+
+.. code-block:: yaml
+
+   annotations:
+    kubernetes.io/ingress.class: nginx
+    nginx.ingress.kubernetes.io/auth-method: GET
+    nginx.ingress.kubernetes.io/auth-response-headers: X-Auth-Request-Token
+    nginx.ingress.kubernetes.io/auth-signin: "https://<hostname>/login"
+    nginx.ingress.kubernetes.io/auth-url: "https://<hostname>/auth?scope=<scope>"
+
+Replace ``<hostname>`` with the hostname of the ingress on which the Gafaelfawr routes are configured, and ``<scope>`` with the name of the scope that should be required in order to visit this site.
+
+This will send a request to the Gafaelfawr ``/auth`` route for each request.
+It will find the user's authentication token, check that it is valid, and check that the user has the required scope.
+If the user is not authenticated, they will be redirected to the sign-in URL configured here, which in turn will either send the user to CILogon or to GitHub to authenticate.
+If the user is already authenticated but does not have the desired scope, they will receive a 403 error.
+
+The typical annotations for a API that expects direct requests from programs are:
+
+.. code-block:: yaml
+
+   annotations:
+    kubernetes.io/ingress.class: nginx
+    nginx.ingress.kubernetes.io/auth-method: GET
+    nginx.ingress.kubernetes.io/auth-response-headers: X-Auth-Request-Token
+    nginx.ingress.kubernetes.io/auth-url: "https://<hostname>/auth?scope=<scope>"
+
+The difference in this case is that the 401 error when authentication is not provided will be returned to the client, rather than returning a redirect to the login page.
+
+If the user authenticates and authorizes successfully, the request will be sent to the application.
+Included in the request will be an ``X-Auth-Request-Token`` header containing the user's JWT.
+This will be a reissued token signed by Gafaelfawr.
+
+.. _error-caching:
+
+Disabling error caching
+=======================
+
+Web browsers cache 403 (HTTP Forbidden) error replies by default.
+Unfortunately, NGINX does not pass a ``Cache-Control`` response header from an ``auth_request`` handler back to the client.
+It also does not set ``Cache-Control`` on a 403 response itself, and the Kubernetes ingress-nginx does not provide a configuration knob to change that.
+This can cause user confusion; if they reauthenticate after a 403 error and obtain additional group memberships, they may still get a 403 error when they return to the page they were trying to access even if they now have access.
+
+This can be avoided by setting a custom error page that sets a ``Cache-Control`` header to tell the browser not to cache the error.
+Gafaelfawr provides ``/auth/forbidden`` as a custom error handler for this purpose.
+To use this, add the following annotation to the ingress for the application:
+
+.. code-block:: yaml
+
+   annotations:
+     nginx.ingress.kubernetes.io/configuration-snippet: |
+       error_page 403 = "/auth/forbidden?scope=<scope>";
+
+The parameters to the ``/auth/forbidden`` URL must be the same as the parameters given in the ``auth-url`` annotation.
+The scheme and host of the URL defined for the 403 error must be omitted so that NGINX will generate an internal redirect, which in turn requires (as with the rest of Gafaelfawr) that the Gafaelfawr ``/auth`` route be defined on the same virtual host as the protected application.
+
+Be aware that this will intercept **all** 403 errors from the protected application, not just ones from Gafaelfawr.
+If the protected application returns its own 403 errors, the resulting error will probably be nonsensical, and this facility may not be usable.
+
+.. _auth-config:
+
+Configuring authentication
+==========================
+
+The URL in the ``nginx.ingress.kubernetes.io/auth-url`` annotation accepts several parameters to customize the authentication request.
+
+``scope`` (required)
+    The scope claim that the client JWT must have.
+    May be given multiple times.
+    If given multiple times, the meaning is govered by the ``satisfy`` parameter.
+    Scopes are determined by mapping the group membership provided by the authentication provider, using the ``group_mapping`` configuration directive.
+    See :ref:`settings` for more information.
+
+``satisfy`` (optional)
+    How to interpret multiple ``scope`` parameters.
+    If set to ``all`` (or unset), the user's token must have all of the given scopes.
+    If set to ``any``, the user's token must have one of the given scopes.
+
+``auth_type`` (optional)
+    Controls the authentication type in the challenge returned in ``WWW-Authenticate`` if the user is not authenticated.
+    By default, this is ``bearer``.
+    Applications that want to prompt for HTTP Basic Authentication should set this to ``basic`` instead.
+
+``audience`` (optional)
+    May be set to the value of the ``issuer.aud.internal`` configuration parameter, in which case a new token will be issued from the user's token with all the same claims but with that audience.
+    This newly-issued token will be returned in the ``X-Auth-Request-Token`` header instead of the user's regular token.
+    The intent of this feature is to send an audience-restricted version of a token to an internal service, which may use it to make subrequests to other internal services but should not be able to make requests to public-facing services.
+
+These parameters must be URL-encoded as GET parameters to the ``/auth`` route.
+
+.. _auth-headers:
+
+Additional authentication headers
+=================================
+
+The following headers may be requested by the application by adding them to the ``nginx.ingress.kubernetes.io/auth-response-headers`` annotation for the ingress rule.
+The value of that annotation is a comma-separated list of desired headers.
+
+``X-Auth-Request-Client-Ip``
+    The IP address of the client, as determined after parsing ``X-Forwarded-For`` headers.
+    See :ref:`client-ips` for more information.
+
+``X-Auth-Request-Email``
+    If enabled and the claim is available, this will be set based on the ``email`` claim in the token.
+
+``X-Auth-Request-User``
+    If enabled and the claim is available, this will be set from token based on the ``username_claim`` setting (by default, the ``uid`` claim).
+
+``X-Auth-Request-Uid``
+    If enabled and the claim is available, this will be set from token based on the ``uid_claim`` setting (by default, the ``uidNumber`` claim).
+
+``X-Auth-Request-Groups``
+    If the token lists groups in an ``isMemberOf`` claim, the names of the groups will be returned, comma-separated, in this header.
+
+``X-Auth-Request-Token``
+    If enabled, the encoded token will be sent.
+
+``X-Auth-Request-Token-Scopes``
+    If the token has scopes in the ``scope`` claim or derived from groups listed in ``isMemberOf``, they will be returned in this header.
+
+``X-Auth-Request-Token-Scopes-Accepted``
+    A space-separated list of token scopes the reliant resource accepts.
+    This is configured in the ``nginx.ingress.kubernetes.io/auth-url`` annotation via the ``scope`` parameter.
+
+``X-Auth-Request-Token-Scopes-Satisfy``
+    The strategy the reliant resource uses to determine whether a token satisfies the scope requirements.
+    It will be either ``any`` or ``all``.
+    This is configured in the ``nginx.ingress.kubernetes.io/auth-url`` annotation via the ``satisfy`` parameter.
+
+Verifying tokens
+================
+
+A JWKS for the Gafaelfawr token issuer is available via the ``/.well-known/jwks.json`` route.
+An application may use that URL to retrieve the public key of Gafaelfawr and use it to verify the token signature.
+
+.. _openid-connect:
+
+Using OpenID Connect
+====================
+
+To protect an application that uses OpenID Connect, first set ``oidc_server.enabled`` to true in the :ref:`helm-settings`.
+Then, create (or add to, if already existing) an ``oidc-server-secrets`` Vault secret key.
+The value of the key must be a JSON list, with each list member representing one OpenID Connect client.
+Each list member must be an object with two keys: ``id`` and ``secret``.
+``id`` can be anything informative that you want to use to uniquely represent this OpenID Connect client.
+``secret`` should be a randomly-generated secret that the client will use to authenticate.
+
+Then, configure the client.
+The authorization endpoint is ``/auth/openid/login``.
+The token endpoint is ``/auth/openid/token``.
+The userinfo endpoint is ``/auth/userinfo``.
+The JWKS endpoing is ``/.well-known/jwks.json``.
+As with any other protected application, the client must run on the same URL host as Gafaelfawr, and these endpoints are all at that shared host (and should be specified using ``https``).
+
+The OpenID Connect client should be configured to request only the ``openid`` scope.
+No other scope is supported.
+The client must be able to authenticate by sending a ``client_secret`` parameter in the request to the token endpoint.
+
+Example
+-------
+
+Assuming that Gafaelfawr and Chronograf are deployed on the host ``example.com`` and Chronograf is at the URL ``/chronograf``, here are the environment variables required to configure `Chronograf <https://docs.influxdata.com/chronograf/v1.8/administration/managing-security/#configure-chronograf-to-use-any-oauth-2-0-provider>`__:
+
+* ``GENERIC_CLIENT_ID``: ``chronograf-client-id``
+* ``GENERIC_CLIENT_SECRET``: ``fb7518beb61d27aaf20675d62778dea9``
+* ``GENERIC_AUTH_URL``: ``https://example.com/auth/openid/login``
+* ``GENERIC_TOKEN_URL``: ``https://example.com/auth/openid/token``
+* ``USE_ID_TOKEN``: 1
+* ``JWKS_URL``: ``https://example.com/.well-known/jwks.json``
+* ``GENERIC_API_URL``: ``https://example.com/auth/userinfo``
+* ``GENERIC_SCOPES``: ``openid``
+* ``PUBLIC_URL``: ``https://example.com/chronograf``
+* ``TOKEN_SECRET``: ``pCY29u3qMTdWCNetOUD3OShsqwPm+pYKDNt6dqy01qw=``

--- a/docs/arch/flow.rst
+++ b/docs/arch/flow.rst
@@ -61,3 +61,28 @@ Here are the steps involved in a programmatic access to an application protected
    Alternately, it can be given as either the username or the password of an ``Authorization: Basic`` header, if the other parameter (either username or password) is set to ``x-oauth-basic``.
 #. The request results in an auth subrequest to the ``/auth`` route as in the browser case.
    The ``/auth`` route extracts the session handle from the ``Authorization`` header and then does scope-based authorization as described in the browser flow.
+
+OpenID Connect flow
+===================
+
+.. figure:: /_static/flow-oidc.png
+   :name: Gafaelfawr OpenID Connect flow
+
+   Gafaelfawr OpenID Connect flow
+
+   The ingress has been omitted from this diagram for the sake of simplicity, but plays the same role that it plays in the browser flow above.
+
+Finally, for protected applications that only understand OpenID Connect, Gafaelfawr can act as a simple OpenID Connect server.
+That flow looks like this:
+
+#. The user goes to an application that uses Gafaelfawr as an OpenID Connect authentication provider.
+#. The application redirects the user to ``/auth/openid/login`` with some additional parameters in the URL including the registered client ID and an opaque state parameter.
+#. If the user is not already authenticated, Gafaelfawr redirects the user to ``/login`` to follow the same initial authentication flow as in :ref:`browser-flow`, sending the user back to the same ``/auth/openid/login`` URL once that authentication has completed.
+#. Gafaelfawr validates the login request and then redirects the user back to the protected application, including an authorization code in the URL.
+#. The protected application presents that authorization code to ``/auth/openid/token``.
+#. Gafaelfawr validates that code and returns a JWT representing the user to the protected application.
+   That JWT uses the internal issuer and has a hard-coded scope of ``openid`` to protect against the protected application using it to impersonate the user elsewhere.
+#. The protected application optionally authenticates as the user to ``/auth/userinfo``, using that JWT as a bearer token, and retrieves metadata about the authenticated user.
+
+This is the OpenID Connect authorization code flow.
+See the `OpenID Connect specification <https://openid.net/specs/openid-connect-core-1_0.html>`__ for more information.

--- a/docs/arch/flow.rst
+++ b/docs/arch/flow.rst
@@ -78,6 +78,7 @@ That flow looks like this:
 #. The user goes to an application that uses Gafaelfawr as an OpenID Connect authentication provider.
 #. The application redirects the user to ``/auth/openid/login`` with some additional parameters in the URL including the registered client ID and an opaque state parameter.
 #. If the user is not already authenticated, Gafaelfawr redirects the user to ``/login`` to follow the same initial authentication flow as in :ref:`browser-flow`, sending the user back to the same ``/auth/openid/login`` URL once that authentication has completed.
+   Completion of that authentication process sets a session cookie that is read by ``/auth/openid/login``.
 #. Gafaelfawr validates the login request and then redirects the user back to the protected application, including an authorization code in the URL.
 #. The protected application presents that authorization code to ``/auth/openid/token``.
 #. Gafaelfawr validates that code and returns a JWT representing the user to the protected application.

--- a/docs/arch/overview.rst
+++ b/docs/arch/overview.rst
@@ -9,8 +9,14 @@ Gafaelfawr is deployed as an auth subrequest handler for a Kubernetes cluster th
 
    Gafaelfawr deployment architecture
 
-Gafaelfawr does not talk to the protected application directly or act as a proxy.
+In the normal case, Gafaelfawr does not talk to the protected application directly or act as a proxy.
 Instead, the NGINX ingress makes a subrequest to Gafaelfawr to check the authorization of each request, and may redirect the user to a route served by Gafaelfawr directly for initial authentication, logout, or token maintenance.
 
 Authentication is handled by an external identity provider to which the user will be redirected as necessary.
 Gafaelfawr will also make direct requests to that identity provider to get information about the user after authentication.
+
+For protected applications that only understand OpenID Connect, Gafaelfawr also includes a minimal OpenID Connect server.
+This was designed with just enough features to support `Chronograf`_.
+It may not work with other applications without additional changes.
+
+.. _Chronograf: https://docs.influxdata.com/chronograf/v1.8/administration/managing-security/

--- a/docs/arch/references.rst
+++ b/docs/arch/references.rst
@@ -26,6 +26,11 @@ __ https://developer.github.com/v3/users/
 
 __ https://openid.net/specs/openid-connect-core-1_0.html
 
+`RFC 6749: The OAuth 2.0 Authorization Framework`__
+    The specification for the OAuth 2.0 authorization framework, on top of which OpenID Connect was built.
+
+__ https://tools.ietf.org/html/rfc6749
+
 `RFC 7517: JSON Web Key (JWK)`__
     The specification of the JSON Web Key format, including JSON Web Key Sets (JWKS).
 

--- a/docs/arch/routes.rst
+++ b/docs/arch/routes.rst
@@ -28,6 +28,16 @@ Gafaelfawr supports the following routes:
     If the request method is GET, uses the session handle from the user's session cookie or from an ``Authentication`` header.
     If the request method is POST, uses a session handle or JWT from the ``token`` form parameter, provided in the POST.
 
+``/auth/openid/login``
+    Initiates or completes an OpenID Connect authentication request.
+    The parameters to this route are those for the Authentication Request in the Authorization Code Flow as defined in `OpenID Connect`_.
+
+.. _OpenID Connect: https://openid.net/specs/openid-connect-core-1_0.html
+
+``/auth/openid/token``
+    Retrieves a JWT given an OpenID Connect authorization code obtained via an authentication request.
+    The parameters to this route are those for the Token Request in the Authorization Code Flow in `OpenID Connect`_.
+
 ``/auth/tokens``
     Displays all user-issued tokens for the authenticated user.
 
@@ -37,6 +47,12 @@ Gafaelfawr supports the following routes:
 ``/auth/tokens/<key>``
     Displays details about a user-issued token or processes a revocation request for that token.
     The ``<key>`` portion of the route must be the session key (from a session handle, for example).
+
+``/auth/userinfo``
+    Returns the claims of a JWT, issued by Gafaelfawr, in JSON format.
+    The JWT must be presented as a bearer token in an ``Authorization`` header as defined in `RFC 6750`_.
+
+.. _RFC 6750: https://tools.ietf.org/html/rfc6750
 
 ``/login``
     Initiates or completes an authentication rqeuest.

--- a/docs/arch/security.rst
+++ b/docs/arch/security.rst
@@ -91,6 +91,8 @@ To-do
   This appears not to be supported by the NGINX ingress at present.
 - Optionally do not expose the user's JWT to a protected application.
 - Explore using the nascent support for token reissuance to provide more protection against reuse of JWTs by protected applications.
+- Register the ``redirect_uri`` along with the client for OpenID Connect clients and validate that the requested ``redirect_uri`` matches.
+  This would allow using the OpenID Connect support to authenticate sites on other hosts, including chaining Gafaelfawr instances, since it would allow safely removing the restriction that ``redirect_uri`` must be on the same host as Gafaelfawr.
 
 Logging
 =======

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -73,6 +73,7 @@ intersphinx_mapping = {
     "cachetools": ("https://cachetools.readthedocs.io/en/stable/", None),
     "cryptography": ("https://cryptography.io/en/latest/", None),
     "jwt": ("https://pyjwt.readthedocs.io/en/latest/", None),
+    "multidict": ("https://multidict.readthedocs.io/en/stable/", None),
     "python": ("https://docs.python.org/3/", None),
     "structlog": ("https://www.structlog.org/en/stable/", None),
     "wtforms": ("https://wtforms.readthedocs.io/en/stable/", None),

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -133,6 +133,14 @@ Secrets beginning or ending in whitespace are not supported.
         If given, only JWTs signed by one of the ``kid`` values listed in this configuration key will be verified and all others will be rejected.
         If omitted, any ``kid`` value matching a key that can be retrieved from the OpenID Connect provider's JWKS URL will be accepted.
 
+``oidc_server_secrets_file`` (optional)
+    File defining the clients allowed to use Gafaelfawr as an OpenID Connect server.
+    The contents of this file must be a list of objects in JSON format.
+    Each object in the list must have two keys: ``id`` and ``secret``.
+    ``id`` is the value sent by an OpenID Connect client as the ``client_id``.
+    ``secret`` is the corresponding ``client_secret`` value for that client.
+    See :ref:`openid-connect` for more details.
+
 ``known_scopes`` (optional)
     A dict whose keys are known scope names and whose values are human-language descriptions of that scope.
     Used only to construct the web page where a user can create a new API token with a specific set of scopes.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -4,7 +4,7 @@ Gafaelfawr
 
 Gafaelfawr is the authentication and authorization front-end for the Vera C. Rubin Observatory Science Platform.
 It's primary purpose is to serve as an NGINX ``auth_request`` backend.
-It also provides a web page where people can create and manage long-lived tokens for use outside of a web browser.
+It also provides a web page where people can create and manage long-lived tokens for use outside of a web browser, and can serve as a simple OpenID Connect server.
 As a component of the Science Platform, it is designed for deployment with Kubernetes.
 Gafaelfawr requires the Kubernetes `NGINX ingress controller <https://github.com/kubernetes/ingress-nginx>`__.
 
@@ -18,9 +18,10 @@ Installation
 ============
 
 .. toctree::
-   :maxdepth: 1
+   :maxdepth: 2
 
    install
+   applications
    configuration
    logging
    glossary
@@ -30,7 +31,7 @@ Architecture
 ============
 
 .. toctree::
-   :maxdepth: 1
+   :maxdepth: 2
 
    arch/overview
    arch/flow
@@ -44,7 +45,7 @@ Development guide
 =================
 
 .. toctree::
-   :maxdepth: 1
+   :maxdepth: 2
 
    dev/development
    dev/release

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -72,6 +72,11 @@ If you are using it, create a Vault secret with the following keys:
     The GitHub secret, obtained when creating the OAuth App as described above.
     This is not required if you are using CILogin authentication.
 
+``oidc-server-secrets`` (optional)
+    Only used if the Helm chart parameter ``oidc_server.enabled`` is set to true.
+    The JSON representation of the OpenID Connect clients.
+    Must be a JSON list of objects, each of which must have ``id`` and ``secret`` keys corresponding to the ``client_id`` and ``client_secret`` parameters sent by OpenID Connect clients.
+
 ``redis-password``
     The password to use for Redis authentication.
     This should be set to a long, randomly-generated alphanumeric string.
@@ -88,6 +93,8 @@ You will reference the path to this secret in Vault when configuring the Helm ch
 
 If you are not using the standard Helm chart, you can use Kubernetes secrets directly or use Vault secrets with a different naming or organization.
 You will specify the paths to the secrets in the Gafaelfawr configuration, as documented at :ref:`settings`.
+
+.. _helm-settings:
 
 Helm deployment
 ===============
@@ -162,6 +169,10 @@ To use that chart, you will need to provide a ``values.yaml`` file with the foll
     Can be used to set parameters like ``skin`` or ``selected_idp``.
     See the `CILogon OIDC documentation <https://www.cilogon.org/oidc>`__ for more information.
 
+``oidc_server.enabled``
+    Set this to true to enable the OpenID Connect server.
+    If this is set, the Vault secret for Gafaelfawr must contain a ``oidc-server-secrets`` key.
+
 ``known_scopes``
     Mapping of scope names to descriptions.
     This is used to populate the new token creation page.
@@ -177,149 +188,3 @@ For an example, see `the configuration for the LSST Science Platform deployments
 
 The Helm chart will generate a Gafaelfawr configuration file via a ``ConfigMap`` resource.
 See :ref:`settings` if you need to understand that configuration file or fine-tune its settings.
-
-Application configuration
-=========================
-
-Protecting a service
---------------------
-
-Gafaelfawr's routes must be exposed under the same hostname as the service that it is protecting.
-IF you need to protect services running under multiple hostnames, you will need to configure Gafaelfawr's ingress to add its routes (specifically ``/auth`` and ``/login``) to each of those hostnames.
-
-Authentication and authorization for a service are configured via annotations on the ingress for that service.
-The typical annotations for a web application used via a web browser are:
-
-.. code-block:: yaml
-
-   annotations:
-    kubernetes.io/ingress.class: nginx
-    nginx.ingress.kubernetes.io/auth-method: GET
-    nginx.ingress.kubernetes.io/auth-response-headers: X-Auth-Request-Token
-    nginx.ingress.kubernetes.io/auth-signin: "https://<hostname>/login"
-    nginx.ingress.kubernetes.io/auth-url: "https://<hostname>/auth?scope=<scope>"
-
-Replace ``<hostname>`` with the hostname of the ingress on which the Gafaelfawr routes are configured, and ``<scope>`` with the name of the scope that should be required in order to visit this site.
-
-This will send a request to the Gafaelfawr ``/auth`` route for each request.
-It will find the user's authentication token, check that it is valid, and check that the user has the required scope.
-If the user is not authenticated, they will be redirected to the sign-in URL configured here, which in turn will either send the user to CILogon or to GitHub to authenticate.
-If the user is already authenticated but does not have the desired scope, they will receive a 403 error.
-
-The typical annotations for a API that expects direct requests from programs are:
-
-.. code-block:: yaml
-
-   annotations:
-    kubernetes.io/ingress.class: nginx
-    nginx.ingress.kubernetes.io/auth-method: GET
-    nginx.ingress.kubernetes.io/auth-response-headers: X-Auth-Request-Token
-    nginx.ingress.kubernetes.io/auth-url: "https://<hostname>/auth?scope=<scope>"
-
-The difference in this case is that the 401 error when authentication is not provided will be returned to the client, rather than returning a redirect to the login page.
-
-If the user authenticates and authorizes successfully, the request will be sent to the application.
-Included in the request will be an ``X-Auth-Request-Token`` header containing the user's JWT.
-This will be a reissued token signed by Gafaelfawr.
-
-.. _error-caching:
-
-Disabling error caching
------------------------
-
-Web browsers cache 403 (HTTP Forbidden) error replies by default.
-Unfortunately, NGINX does not pass a ``Cache-Control`` response header from an ``auth_request`` handler back to the client.
-It also does not set ``Cache-Control`` on a 403 response itself, and the Kubernetes ingress-nginx does not provide a configuration knob to change that.
-This can cause user confusion; if they reauthenticate after a 403 error and obtain additional group memberships, they may still get a 403 error when they return to the page they were trying to access even if they now have access.
-
-This can be avoided by setting a custom error page that sets a ``Cache-Control`` header to tell the browser not to cache the error.
-Gafaelfawr provides ``/auth/forbidden`` as a custom error handler for this purpose.
-To use this, add the following annotation to the ingress for the application:
-
-.. code-block:: yaml
-
-   annotations:
-     nginx.ingress.kubernetes.io/configuration-snippet: |
-       error_page 403 = "/auth/forbidden?scope=<scope>";
-
-The parameters to the ``/auth/forbidden`` URL must be the same as the parameters given in the ``auth-url`` annotation.
-The scheme and host of the URL defined for the 403 error must be omitted so that NGINX will generate an internal redirect, which in turn requires (as with the rest of Gafaelfawr) that the Gafaelfawr ``/auth`` route be defined on the same virtual host as the protected application.
-
-Be aware that this will intercept **all** 403 errors from the protected application, not just ones from Gafaelfawr.
-If the protected application returns its own 403 errors, the resulting error will probably be nonsensical, and this facility may not be usable.
-
-.. _auth-config:
-
-Configuring authentication
---------------------------
-
-The URL in the ``nginx.ingress.kubernetes.io/auth-url`` annotation accepts several parameters to customize the authentication request.
-
-``scope`` (required)
-    The scope claim that the client JWT must have.
-    May be given multiple times.
-    If given multiple times, the meaning is govered by the ``satisfy`` parameter.
-    Scopes are determined by mapping the group membership provided by the authentication provider, using the ``group_mapping`` configuration directive.
-    See :ref:`settings` for more information.
-
-``satisfy`` (optional)
-    How to interpret multiple ``scope`` parameters.
-    If set to ``all`` (or unset), the user's token must have all of the given scopes.
-    If set to ``any``, the user's token must have one of the given scopes.
-
-``auth_type`` (optional)
-    Controls the authentication type in the challenge returned in ``WWW-Authenticate`` if the user is not authenticated.
-    By default, this is ``bearer``.
-    Applications that want to prompt for HTTP Basic Authentication should set this to ``basic`` instead.
-
-``audience`` (optional)
-    May be set to the value of the ``issuer.aud.internal`` configuration parameter, in which case a new token will be issued from the user's token with all the same claims but with that audience.
-    This newly-issued token will be returned in the ``X-Auth-Request-Token`` header instead of the user's regular token.
-    The intent of this feature is to send an audience-restricted version of a token to an internal service, which may use it to make subrequests to other internal services but should not be able to make requests to public-facing services.
-
-These parameters must be URL-encoded as GET parameters to the ``/auth`` route.
-
-.. _auth-headers:
-
-Additional authentication headers
----------------------------------
-
-The following headers may be requested by the application by adding them to the ``nginx.ingress.kubernetes.io/auth-response-headers`` annotation for the ingress rule.
-The value of that annotation is a comma-separated list of desired headers.
-
-``X-Auth-Request-Client-Ip``
-    The IP address of the client, as determined after parsing ``X-Forwarded-For`` headers.
-    See :ref:`client-ips` for more information.
-
-``X-Auth-Request-Email``
-    If enabled and the claim is available, this will be set based on the ``email`` claim in the token.
-
-``X-Auth-Request-User``
-    If enabled and the claim is available, this will be set from token based on the ``username_claim`` setting (by default, the ``uid`` claim).
-
-``X-Auth-Request-Uid``
-    If enabled and the claim is available, this will be set from token based on the ``uid_claim`` setting (by default, the ``uidNumber`` claim).
-
-``X-Auth-Request-Groups``
-    If the token lists groups in an ``isMemberOf`` claim, the names of the groups will be returned, comma-separated, in this header.
-
-``X-Auth-Request-Token``
-    If enabled, the encoded token will be sent.
-
-``X-Auth-Request-Token-Scopes``
-    If the token has scopes in the ``scope`` claim or derived from groups listed in ``isMemberOf``, they will be returned in this header.
-
-``X-Auth-Request-Token-Scopes-Accepted``
-    A space-separated list of token scopes the reliant resource accepts.
-    This is configured in the ``nginx.ingress.kubernetes.io/auth-url`` annotation via the ``scope`` parameter.
-
-``X-Auth-Request-Token-Scopes-Satisfy``
-    The strategy the reliant resource uses to determine whether a token satisfies the scope requirements.
-    It will be either ``any`` or ``all``.
-    This is configured in the ``nginx.ingress.kubernetes.io/auth-url`` annotation via the ``satisfy`` parameter.
-
-Verifying tokens
-----------------
-
-A JWKS for the Gafaelfawr token issuer is available via the ``/.well-known/jwks.json`` route.
-An application may use that URL to retrieve the public key of Gafaelfawr and use it to verify the token signature.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,8 +52,11 @@ whitelist_externals =
 commands =
     python docs/_static/architecture.py
     seqdiag docs/_static/flow.diag
+    seqdiag docs/_static/flow-oidc.diag
     convert -background white -alpha remove -alpha off docs/_static/flow.png docs/_static/flow-fixed.png
     mv docs/_static/flow-fixed.png docs/_static/flow.png
+    convert -background white -alpha remove -alpha off docs/_static/flow-oidc.png docs/_static/flow-oidc-fixed.png
+    mv docs/_static/flow-oidc-fixed.png docs/_static/flow-oidc.png
     sphinx-build -n -T -b html -d {envtmpdir}/doctrees docs docs/_build/html
 
 [testenv:run]

--- a/src/gafaelfawr/constants.py
+++ b/src/gafaelfawr/constants.py
@@ -2,3 +2,6 @@
 
 ALGORITHM = "RS256"
 """JWT algorithm to use for all tokens."""
+
+OIDC_AUTHORIZATION_LIFETIME = 60 * 60
+"""How long (in seconds) an authorization code is good for."""

--- a/src/gafaelfawr/exceptions.py
+++ b/src/gafaelfawr/exceptions.py
@@ -7,9 +7,7 @@ from typing import TYPE_CHECKING
 from aiohttp import web
 
 if TYPE_CHECKING:
-    from typing import ClassVar, Dict, Type
-
-    from structlog import BoundLogger
+    from typing import ClassVar, Type
 
 __all__ = [
     "DeserializeException",
@@ -55,16 +53,8 @@ class OAuthError(Exception):
     message: ClassVar[str] = "Unknown error"
     """The summary message to use when logging this error."""
 
-    def as_dict(self) -> Dict[str, str]:
-        """Return the JSON form of this exception, ready for serialization."""
-        return {
-            "error": self.error,
-            "error_description": str(self),
-        }
-
-    def log_warning(self, logger: BoundLogger) -> None:
-        """Log this error to the provided logger."""
-        logger.warning("%s", self.message, error=str(self))
+    hide_error: ClassVar[bool] = False
+    """Whether to hide the details of the error from the client."""
 
 
 class InvalidClientError(OAuthError):
@@ -91,12 +81,7 @@ class InvalidGrantError(OAuthError):
 
     error = "invalid_grant"
     message = "Invalid authorization code"
-
-    def as_dict(self) -> Dict[str, str]:
-        return {
-            "error": self.error,
-            "error_description": self.message,
-        }
+    hide_error = True
 
 
 class OAuthBearerError(OAuthError):

--- a/src/gafaelfawr/exceptions.py
+++ b/src/gafaelfawr/exceptions.py
@@ -15,7 +15,7 @@ __all__ = [
     "GitHubException",
     "InvalidClientError",
     "InvalidGrantError",
-    "InvalidRequestException",
+    "InvalidRequestError",
     "InvalidSessionHandleException",
     "InvalidTokenClaimsException",
     "InvalidTokenException",
@@ -89,7 +89,7 @@ class InvalidGrantError(OIDCServerError):
         }
 
 
-class InvalidRequestException(Exception):
+class InvalidRequestError(OIDCServerError):
     """The provided Authorization header could not be parsed.
 
     This corresponds to the ``invalid_request`` error in RFC 6749 and 6750:
@@ -97,6 +97,9 @@ class InvalidRequestException(Exception):
     parameter or parameter value, repeats the same parameter, uses more than
     one method for including an access token, or is otherwise malformed."
     """
+
+    error = "invalid_request"
+    message = "Invalid request"
 
 
 class InvalidSessionHandleException(Exception):

--- a/src/gafaelfawr/exceptions.py
+++ b/src/gafaelfawr/exceptions.py
@@ -6,6 +6,8 @@ __all__ = [
     "DeserializeException",
     "FetchKeysException",
     "GitHubException",
+    "InvalidClientException",
+    "InvalidGrantException",
     "InvalidRequestException",
     "InvalidSessionHandleException",
     "InvalidTokenClaimsException",
@@ -13,6 +15,7 @@ __all__ = [
     "MissingClaimsException",
     "OIDCException",
     "ProviderException",
+    "UnauthorizedClientException",
     "UnknownAlgorithmException",
     "UnknownKeyIdException",
     "VerifyTokenException",
@@ -28,13 +31,33 @@ class DeserializeException(Exception):
     """
 
 
+class InvalidClientException(Exception):
+    """The provided client_id and client_secret could not be validated.
+
+    This corresponds to the ``invalid_client`` error in RFC 6749: "Client
+    authentication failed (e.g., unknown client, no client authentication
+    included, or unsupported authentication method)."
+    """
+
+
+class InvalidGrantException(Exception):
+    """The provided authorization code is not valid.
+
+    This corresponds to the ``invalid_grant`` error in RFC 6749: "The provided
+    authorization grant (e.g., authorization code, resource owner credentials)
+    or refresh token is invalid, expired, revoked, does not match the
+    redirection URI used in the authorization request, or was issued to
+    another client."
+    """
+
+
 class InvalidRequestException(Exception):
     """The provided Authorization header could not be parsed.
 
-    This corresponds to the ``invalid_request`` error in RFC 6750: "The
-    request is missing a required parameter, includes an unsupported parameter
-    or parameter value, repeats the same parameter, uses more than one method
-    for including an access token, or is otherwise malformed."
+    This corresponds to the ``invalid_request`` error in RFC 6749 and 6750:
+    "The request is missing a required parameter, includes an unsupported
+    parameter or parameter value, repeats the same parameter, uses more than
+    one method for including an access token, or is otherwise malformed."
     """
 
 
@@ -66,6 +89,13 @@ class GitHubException(ProviderException):
 
 class OIDCException(ProviderException):
     """The OpenID Connect provider returned an error from an API call."""
+
+
+class UnauthorizedClientException(Exception):
+    """The client is not authorized to request an authorization code.
+
+    This corresponds to the ``unauthorized_client`` error in RFC 6749.
+    """
 
 
 class VerifyTokenException(Exception):

--- a/src/gafaelfawr/handlers/__init__.py
+++ b/src/gafaelfawr/handlers/__init__.py
@@ -24,6 +24,7 @@ def init_routes() -> aiohttp.web.RouteTableDef:
     import gafaelfawr.handlers.logout  # noqa: F401
     import gafaelfawr.handlers.oidc  # noqa: F401
     import gafaelfawr.handlers.tokens  # noqa: F401
+    import gafaelfawr.handlers.userinfo  # noqa: F401
     import gafaelfawr.handlers.well_known  # noqa: F401
 
     return routes

--- a/src/gafaelfawr/handlers/__init__.py
+++ b/src/gafaelfawr/handlers/__init__.py
@@ -22,6 +22,7 @@ def init_routes() -> aiohttp.web.RouteTableDef:
     import gafaelfawr.handlers.index  # noqa: F401
     import gafaelfawr.handlers.login  # noqa: F401
     import gafaelfawr.handlers.logout  # noqa: F401
+    import gafaelfawr.handlers.oidc  # noqa: F401
     import gafaelfawr.handlers.tokens  # noqa: F401
     import gafaelfawr.handlers.well_known  # noqa: F401
 

--- a/src/gafaelfawr/handlers/auth.py
+++ b/src/gafaelfawr/handlers/auth.py
@@ -306,7 +306,7 @@ async def get_token_from_request(
 
     Raises
     ------
-    InvalidRequestException
+    gafaelfawr.exceptions.InvalidRequestException
         The Authorization header was malformed.
     gafaelfawr.handlers.util.InvalidTokenException
         A token was provided but it could not be verified.
@@ -359,7 +359,7 @@ def parse_authorization(context: RequestContext) -> Optional[str]:
 
     Raises
     ------
-    InvalidRequestException
+    gafaelfawr.exceptions.InvalidRequestException
         If the Authorization header is malformed.
 
     Notes

--- a/src/gafaelfawr/handlers/auth.py
+++ b/src/gafaelfawr/handlers/auth.py
@@ -16,7 +16,7 @@ from gafaelfawr.handlers.util import (
     AuthError,
     AuthType,
     RequestContext,
-    error_as_www_authenticate,
+    generate_challenge,
     parse_authorization,
     verify_token,
 )
@@ -156,10 +156,9 @@ async def get_auth(request: web.Request) -> web.Response:
     try:
         token = await get_token_from_request(context)
     except InvalidRequestError as e:
-        e.log_warning(context.logger)
-        raise error_as_www_authenticate(context, auth_config.auth_type, e)
+        raise generate_challenge(context, auth_config.auth_type, e)
     except InvalidTokenError as e:
-        e.log_warning(context.logger)
+        context.logger.warning("%s", e.message, error=str(e))
         challenge = AuthChallenge(
             auth_type=auth_config.auth_type,
             realm=context.config.realm,

--- a/src/gafaelfawr/handlers/decorators.py
+++ b/src/gafaelfawr/handlers/decorators.py
@@ -145,6 +145,7 @@ def authenticated_session(route: SessionRoute) -> Route:
             token=auth_session.token.jti,
             user=auth_session.token.username,
             scope=" ".join(sorted(auth_session.token.scope)),
+            token_source="cookie",
         )
 
         return await route(request, auth_session)

--- a/src/gafaelfawr/handlers/decorators.py
+++ b/src/gafaelfawr/handlers/decorators.py
@@ -1,0 +1,270 @@
+"""Authentication decorators for route handlers."""
+
+from __future__ import annotations
+
+from functools import wraps
+from typing import TYPE_CHECKING
+from urllib.parse import urlencode, urlparse
+
+from aiohttp import web
+from aiohttp_session import get_session
+
+from gafaelfawr.exceptions import InvalidRequestError, InvalidTokenException
+from gafaelfawr.handlers.util import (
+    AuthChallenge,
+    AuthError,
+    AuthType,
+    RequestContext,
+    verify_token,
+)
+from gafaelfawr.session import SessionHandle
+
+if TYPE_CHECKING:
+    from typing import Any, Awaitable, Callable
+
+    from gafaelfawr.session import Session
+    from gafaelfawr.tokens import VerifiedToken
+
+    Route = Callable[[web.Request], Awaitable[Any]]
+    AuthenticatedRoute = Callable[[web.Request, VerifiedToken], Awaitable[Any]]
+    SessionRoute = Callable[[web.Request, Session], Awaitable[Any]]
+
+__all__ = [
+    "authenticated_jwt",
+    "authenticated_session",
+    "authenticated_token",
+]
+
+
+def authenticated_jwt(route: AuthenticatedRoute) -> Route:
+    """Deocrator to mark a route as requiring JWT authentication.
+
+    The JWT must be provided as a bearer token in an Authorization header.  If
+    the token is missing or invalid, return a 401 error to the caller.  Used
+    to protect OpenID Connect routes.
+
+    Parameters
+    ----------
+    route : `typing.Callable`
+        The route that requires authentication.  The token is extracted from
+        the incoming request headers, verified, and then passed as a second
+        argument of type `gafaelfawr.tokens.VerifiedToken` to the route.
+
+    Returns
+    -------
+    response : `typing.Callable`
+        The decorator generator.
+
+    Raises
+    ------
+    aiohttp.web.HTTPException
+        If no token is present or the token cannot be verified.
+    """
+
+    @wraps(route)
+    async def authenticated_route(request: web.Request) -> web.Response:
+        context = RequestContext.from_request(request)
+
+        try:
+            unverified_token = parse_authorization(context)
+        except InvalidRequestError as e:
+            msg = "Invalid Authorization header"
+            context.logger.warning(msg, error=str(e))
+            challenge = AuthChallenge(
+                auth_type=AuthType.Bearer,
+                realm=context.config.realm,
+                error=AuthError.invalid_request,
+                error_description=str(e),
+            )
+            headers = {"WWW-Authenticate": challenge.as_header()}
+            raise web.HTTPBadRequest(
+                headers=headers, reason=str(e), text=str(e)
+            )
+        try:
+            token = verify_token(context, unverified_token)
+        except InvalidTokenException as e:
+            context.logger.warning("Invalid token", error=str(e))
+            challenge = AuthChallenge(
+                auth_type=AuthType.Bearer,
+                realm=context.config.realm,
+                error=AuthError.invalid_token,
+                error_description=str(e),
+            )
+            headers = {"WWW-Authenticate": challenge.as_header()}
+            raise web.HTTPUnauthorized(
+                headers=headers, reason=str(e), text=str(e)
+            )
+
+        # Add user information to the logger.
+        context.rebind_logger(
+            token=token.jti,
+            user=token.username,
+            scope=" ".join(sorted(token.scope)),
+        )
+
+        return await route(request, token)
+
+    return authenticated_route
+
+
+def authenticated_session(route: SessionRoute) -> Route:
+    """Decorator to mark a route as requiring authentication with a session.
+
+    The authentication session is passed as an additional parameter to the
+    wrapped function.  If there is no session, returns a redirect to the
+    ``/login`` route with the current URL as the return URL.
+
+    Parameters
+    ----------
+    route : `typing.Callable`
+        The route that requires authentication.  The session handle is
+        extracted from the cookies, converted to a session, and passed as a
+        second argument of type `~gafaelfawr.session.Session` to the route.
+
+    Returns
+    -------
+    response : `typing.Callable`
+        The decorator generator.
+
+    Raises
+    ------
+    aiohttp.web.HTTPException
+        The redirect to the ``/login`` route if the user is not authenticated.
+    """
+
+    @wraps(route)
+    async def authenticated_route(request: web.Request) -> Any:
+        context = RequestContext.from_request(request)
+
+        # Retrieve the session.
+        session = await get_session(request)
+        auth_session = None
+        if "handle" in session:
+            handle = SessionHandle.from_str(session["handle"])
+            session_store = context.factory.create_session_store()
+            auth_session = await session_store.get_session(handle)
+
+        # If there is no active session, redirect to /login.
+        if not auth_session:
+            login_base_url = str(request.app.router["login"].url_for())
+            query = urlencode({"rd": str(request.url)})
+            login_url = urlparse(login_base_url)._replace(query=query).geturl()
+            context.logger.info("Redirecting user for authentication")
+            raise web.HTTPFound(login_url)
+
+        # On success, add some context to the logger.
+        context.rebind_logger(
+            token=auth_session.token.jti,
+            user=auth_session.token.username,
+            scope=" ".join(sorted(auth_session.token.scope)),
+        )
+
+        return await route(request, auth_session)
+
+    return authenticated_route
+
+
+def authenticated_token(route: AuthenticatedRoute) -> Route:
+    """Decorator to mark a route as requiring authentication with a token.
+
+    The authorization token is extracted from the X-Auth-Request-Token header
+    and verified, and then passed as an additional parameter to the wrapped
+    function.  If the token is missing or invalid, returns a 401 error to the
+    user.
+
+    Parameters
+    ----------
+    route : `typing.Callable`
+        The route that requires authentication.  The token is passed as a
+        second argument of type `gafaelfawr.tokens.VerifiedToken` to the
+        route.
+
+    Returns
+    -------
+    response : `typing.Callable`
+        The decorator generator.
+
+    Raises
+    ------
+    aiohttp.web.HTTPException
+        If no token is present or the token cannot be verified.
+    """
+
+    @wraps(route)
+    async def authenticated_route(request: web.Request) -> Any:
+        context = RequestContext.from_request(request)
+
+        if not request.headers.get("X-Auth-Request-Token"):
+            msg = "No authentication token found"
+            context.logger.warning(msg)
+            challenge = AuthChallenge(AuthType.Bearer, context.config.realm)
+            headers = {"WWW-Authenticate": challenge.as_header()}
+            raise web.HTTPUnauthorized(headers=headers, reason=msg, text=msg)
+
+        encoded_token = request.headers["X-Auth-Request-Token"]
+        try:
+            token = verify_token(context, encoded_token)
+        except InvalidTokenException as e:
+            error = "Failed to authenticate token"
+            context.logger.warning(error, error=str(e))
+            challenge = AuthChallenge(
+                auth_type=AuthType.Bearer,
+                realm=context.config.realm,
+                error=AuthError.invalid_token,
+                error_description=f"{error}: {str(e)}",
+            )
+            headers = {"WWW-Authenticate": challenge.as_header()}
+            raise web.HTTPUnauthorized(
+                headers=headers, reason=error, text=challenge.error_description
+            )
+
+        # On success, add some context to the logger.
+        context.rebind_logger(
+            token=token.jti,
+            user=token.username,
+            scope=" ".join(sorted(token.scope)),
+        )
+
+        return await route(request, token)
+
+    return authenticated_route
+
+
+def parse_authorization(context: RequestContext) -> str:
+    """Find a JWT in the Authorization header.
+
+    Requires the ``Bearer`` authorization type.  Rebinds the logging context
+    to include the source of the token, if one is found.
+
+    Parameters
+    ----------
+    context : `gafaelfawr.handlers.util.RequestContext`
+        The context of the incoming request.
+
+    Returns
+    -------
+    handle_or_token : `str` or `None`
+        The handle or token if one was found, otherwise None.
+
+    Raises
+    ------
+    gafaelfawr.exceptions.InvalidRequestError
+        If no token is present or the Authorization header cannot be parsed.
+    """
+    header = context.request.headers.get("Authorization")
+    if not header:
+        msg = "No authentication token found"
+        context.logger.warning(msg)
+        challenge = AuthChallenge(AuthType.Bearer, context.config.realm)
+        headers = {"WWW-Authenticate": challenge.as_header()}
+        raise web.HTTPUnauthorized(headers=headers, reason=msg, text=msg)
+
+    if " " not in header:
+        raise InvalidRequestError("malformed Authorization header")
+    auth_type, auth_blob = header.split(" ")
+    if auth_type.lower() == "bearer":
+        context.rebind_logger(token_source="bearer")
+        return auth_blob
+    else:
+        msg = f"unkonwn Authorization type {auth_type}"
+        raise InvalidRequestError(msg)

--- a/src/gafaelfawr/handlers/decorators.py
+++ b/src/gafaelfawr/handlers/decorators.py
@@ -14,7 +14,7 @@ from gafaelfawr.handlers.util import (
     AuthChallenge,
     AuthType,
     RequestContext,
-    error_as_www_authenticate,
+    generate_challenge,
     parse_authorization,
     verify_token,
 )
@@ -69,8 +69,7 @@ def authenticated_jwt(route: AuthenticatedRoute) -> Route:
         try:
             unverified_token = parse_authorization(context)
         except InvalidRequestError as e:
-            e.log_warning(context.logger)
-            raise error_as_www_authenticate(context, AuthType.Bearer, e)
+            raise generate_challenge(context, AuthType.Bearer, e)
         if not unverified_token:
             msg = "No authentication token found"
             context.logger.warning(msg)
@@ -80,8 +79,7 @@ def authenticated_jwt(route: AuthenticatedRoute) -> Route:
         try:
             token = verify_token(context, unverified_token)
         except InvalidTokenError as e:
-            e.log_warning(context.logger)
-            raise error_as_www_authenticate(context, AuthType.Bearer, e)
+            raise generate_challenge(context, AuthType.Bearer, e)
 
         # Add user information to the logger.
         context.rebind_logger(
@@ -194,8 +192,7 @@ def authenticated_token(route: AuthenticatedRoute) -> Route:
         try:
             token = verify_token(context, encoded_token)
         except InvalidTokenError as e:
-            e.log_warning(context.logger)
-            raise error_as_www_authenticate(context, AuthType.Bearer, e)
+            raise generate_challenge(context, AuthType.Bearer, e)
 
         # On success, add some context to the logger.
         context.rebind_logger(

--- a/src/gafaelfawr/handlers/login.py
+++ b/src/gafaelfawr/handlers/login.py
@@ -153,7 +153,7 @@ async def handle_provider_return(request: web.Request) -> web.Response:
         msg = "Authentication state mismatch"
         raise web.HTTPForbidden(reason=msg, text=msg)
     return_url = session.pop("rd")
-    context.logger = context.logger.bind(return_url=return_url)
+    context.rebind_logger(return_url=return_url)
 
     # Build a session based on the reply from the authentication provider.
     auth_provider = context.factory.create_provider()
@@ -170,14 +170,12 @@ async def handle_provider_return(request: web.Request) -> web.Response:
     # Store the session and send the user back to what they were doing.
     session = await new_session(request)
     session["handle"] = auth_session.handle.encode()
-    context.logger = context.logger.bind(
-        user=auth_session.token.username,
-        token=auth_session.token.jti,
-        scope=" ".join(sorted(auth_session.token.scope)),
-    )
     context.logger.info(
         "Successfully authenticated user %s (%s)",
         auth_session.token.username,
         auth_session.token.uid,
+        user=auth_session.token.username,
+        token=auth_session.token.jti,
+        scope=" ".join(sorted(auth_session.token.scope)),
     )
     raise web.HTTPSeeOther(return_url)

--- a/src/gafaelfawr/handlers/login.py
+++ b/src/gafaelfawr/handlers/login.py
@@ -4,14 +4,13 @@ from __future__ import annotations
 
 import base64
 import os
-from urllib.parse import urlparse
 
 from aiohttp import ClientError, web
 from aiohttp_session import get_session, new_session
 
 from gafaelfawr.exceptions import ProviderException
 from gafaelfawr.handlers import routes
-from gafaelfawr.handlers.util import RequestContext
+from gafaelfawr.handlers.util import RequestContext, validate_return_url
 
 __all__ = ["get_login"]
 
@@ -82,18 +81,7 @@ async def redirect_to_provider(request: web.Request) -> web.Response:
     return_url = request.query.get("rd")
     if not return_url:
         return_url = request.headers.get("X-Auth-Request-Redirect")
-
-    # Validate the return URL, including that it's at the same host as this
-    # request.
-    if not return_url:
-        msg = "No destination URL specified"
-        context.logger.warning(msg)
-        raise web.HTTPBadRequest(reason=msg, text=msg)
-    context.logger = context.logger.bind(return_url=return_url)
-    if urlparse(return_url).hostname != request.url.raw_host:
-        msg = f"Redirect URL not at {request.host}"
-        context.logger.warning(msg)
-        raise web.HTTPBadRequest(reason=msg, text=msg)
+    validate_return_url(context, return_url)
     session["rd"] = return_url
 
     # Reuse the existing state if one already exists in the session cookie.

--- a/src/gafaelfawr/handlers/oidc.py
+++ b/src/gafaelfawr/handlers/oidc.py
@@ -11,10 +11,7 @@ from aiohttp import web
 
 from gafaelfawr.exceptions import InvalidRequestError, OAuthError
 from gafaelfawr.handlers import routes
-from gafaelfawr.handlers.decorators import (
-    authenticated_jwt,
-    authenticated_session,
-)
+from gafaelfawr.handlers.decorators import authenticated_session
 from gafaelfawr.handlers.util import RequestContext, validate_return_url
 from gafaelfawr.storage.oidc import OIDCAuthorizationCode
 
@@ -25,9 +22,8 @@ if TYPE_CHECKING:
     from multidict import MultiDictProxy
 
     from gafaelfawr.session import Session
-    from gafaelfawr.tokens import VerifiedToken
 
-__all__ = ["get_login", "get_userinfo", "post_token"]
+__all__ = ["get_login", "post_token"]
 
 
 @dataclass
@@ -290,27 +286,3 @@ async def post_token(request: web.Request) -> web.Response:
         "id_token": token.encoded,
     }
     return web.json_response(response)
-
-
-@routes.get("/auth/openid/userinfo")
-@authenticated_jwt
-async def get_userinfo(
-    request: web.Request, token: VerifiedToken
-) -> web.Response:
-    """Return information about the holder of a JWT.
-
-    Parameters
-    ----------
-    request : `aiohttp.web.Request`
-        The incoming request.
-    token : `gafaelfawr.tokens.VerifiedToken`
-        The token of the authenticated user.
-
-    Returns
-    -------
-    response : `aiohttp.web.Response`
-        The response.
-    """
-    context = RequestContext.from_request(request)
-    context.logger.info("Returned user information")
-    return web.json_response(token.claims)

--- a/src/gafaelfawr/handlers/oidc.py
+++ b/src/gafaelfawr/handlers/oidc.py
@@ -202,7 +202,7 @@ async def post_token(request: web.Request) -> web.Response:
         )
     except OAuthError as e:
         e.log_warning(context.logger)
-        return web.json_response(e.as_dict, status=400)
+        return web.json_response(e.as_dict(), status=400)
 
     # Log the token redemption.
     context.logger.info(

--- a/src/gafaelfawr/handlers/oidc.py
+++ b/src/gafaelfawr/handlers/oidc.py
@@ -1,0 +1,392 @@
+"""Handler for minimalist OpenID Connect (``/auth/openid``)."""
+
+from __future__ import annotations
+
+import time
+from functools import wraps
+from typing import TYPE_CHECKING, cast
+from urllib.parse import parse_qsl, urlencode, urlparse
+
+from aiohttp import web
+from aiohttp_session import get_session
+
+from gafaelfawr.exceptions import (
+    InvalidClientException,
+    InvalidGrantException,
+    InvalidRequestException,
+    InvalidSessionHandleException,
+    InvalidTokenException,
+    UnauthorizedClientException,
+)
+from gafaelfawr.handlers import routes
+from gafaelfawr.handlers.util import (
+    AuthChallenge,
+    AuthError,
+    AuthType,
+    RequestContext,
+    verify_token,
+)
+from gafaelfawr.session import SessionHandle
+from gafaelfawr.storage.oidc import OIDCAuthorizationCode
+
+if TYPE_CHECKING:
+    from typing import Awaitable, Callable, Optional
+
+    from multidict import MultiDictProxy
+
+    from gafaelfawr.tokens import VerifiedToken
+
+    Route = Callable[[web.Request], Awaitable[web.Response]]
+    AuthenticatedRoute = Callable[
+        [web.Request, VerifiedToken], Awaitable[web.Response]
+    ]
+
+__all__ = ["get_login", "get_userinfo", "post_token"]
+
+
+def authenticated_jwt(route: AuthenticatedRoute) -> Route:
+    """Deocrator to mark a route as requiring JWT authentication.
+
+    The JWT must be provided as a bearer token in an Authorization header.  If
+    the token is missing or invalid, return a 401 error to the caller.  Used
+    to protect OpenID Connect routes.
+
+    Parameters
+    ----------
+    route : `typing.Callable`
+        The route that requires authentication.  The token is extracted from
+        the incoming request headers, verified, and then passed as a second
+        argument of type `gafaelfawr.tokens.VerifiedToken` to the route.
+
+    Returns
+    -------
+    response : `typing.Callable`
+        The decorator generator.
+
+    Raises
+    ------
+    aiohttp.web.HTTPException
+        If no token is present or the token cannot be verified.
+    """
+
+    @wraps(route)
+    async def authenticated_route(request: web.Request) -> web.Response:
+        context = RequestContext.from_request(request)
+
+        try:
+            unverified_token = parse_authorization(context)
+        except InvalidRequestException as e:
+            msg = "Invalid Authorization header"
+            context.logger.warning(msg, error=str(e))
+            challenge = AuthChallenge(
+                auth_type=AuthType.Bearer,
+                realm=context.config.realm,
+                error=AuthError.invalid_request,
+                error_description=str(e),
+            )
+            headers = {"WWW-Authenticate": challenge.as_header()}
+            raise web.HTTPBadRequest(
+                headers=headers, reason=str(e), text=str(e)
+            )
+        try:
+            token = verify_token(context, unverified_token)
+        except InvalidTokenException as e:
+            context.logger.warning("Invalid token", error=str(e))
+            challenge = AuthChallenge(
+                auth_type=AuthType.Bearer,
+                realm=context.config.realm,
+                error=AuthError.invalid_token,
+                error_description=str(e),
+            )
+            headers = {"WWW-Authenticate": challenge.as_header()}
+            raise web.HTTPUnauthorized(
+                headers=headers, reason=str(e), text=str(e)
+            )
+
+        # Add user information to the logger.
+        context.logger = context.logger.bind(
+            token=token.jti,
+            user=token.username,
+            scope=" ".join(sorted(token.scope)),
+        )
+        request["safir/logger"] = context.logger
+
+        return await route(request, token)
+
+    return authenticated_route
+
+
+def parse_authorization(context: RequestContext) -> str:
+    """Find a JWT in the Authorization header.
+
+    Requires the ``Bearer`` authorization type.  Rebinds the logging context
+    to include the source of the token, if one is found.
+
+    Parameters
+    ----------
+    context : `gafaelfawr.handlers.util.RequestContext`
+        The context of the incoming request.
+
+    Returns
+    -------
+    handle_or_token : `str` or `None`
+        The handle or token if one was found, otherwise None.
+
+    Raises
+    ------
+    gafaelfawr.exceptions.InvalidRequestException
+        If no token is present or the Authorization header cannot be parsed.
+    """
+    header = context.request.headers.get("Authorization")
+    if not header:
+        msg = "No authentication token found"
+        context.logger.warning(msg)
+        challenge = AuthChallenge(AuthType.Bearer, context.config.realm)
+        headers = {"WWW-Authenticate": challenge.as_header()}
+        raise web.HTTPUnauthorized(headers=headers, reason=msg, text=msg)
+
+    if " " not in header:
+        raise InvalidRequestException("malformed Authorization header")
+    auth_type, auth_blob = header.split(" ")
+    if auth_type.lower() == "bearer":
+        context.logger = context.logger.bind(token_source="bearer")
+        return auth_blob
+    else:
+        msg = f"unkonwn Authorization type {auth_type}"
+        raise InvalidRequestException(msg)
+
+
+@routes.get("/auth/openid/login")
+async def get_login(request: web.Request) -> web.Response:
+    """Authenticate the user for an OpenID Connect server flow.
+
+    Authenticates the user and then returns an authorization code to the
+    OpenID Connect client via redirect.
+
+    Parameters
+    ----------
+    request : `aiohttp.web.Request`
+        The incoming request.
+
+    Returns
+    -------
+    response : `aiohttp.web.Response`
+        The response (not used).
+
+    Raises
+    ------
+    aiohttp.web.HTTPException
+        The redirect or exception.
+    """
+    context = RequestContext.from_request(request)
+
+    # Get the parameters from the login request.
+    response_type = request.query.get("response_type")
+    scope = request.query.get("scope")
+    client_id = request.query.get("client_id")
+    state = request.query.get("state")
+    return_url = request.query.get("redirect_uri")
+    if response_type != "code" or not client_id or not scope:
+        msg = "Malformed OpenID Connect login request"
+        context.logger.warning("Invalid request", error=msg)
+        raise web.HTTPBadRequest(reason=msg, text=msg)
+    if scope != "openid":
+        msg = "Scope of login request must be openid"
+        context.logger.warning("Invalid request", error=msg)
+        raise web.HTTPBadRequest(reason=msg, text=msg)
+
+    # Parse and validate the return URL, including that it's at the same host
+    # as this request.
+    if not return_url:
+        msg = "No destination URL specified"
+        context.logger.warning("Invalid request", error=msg)
+        raise web.HTTPBadRequest(reason=msg, text=msg)
+    context.logger = context.logger.bind(return_url=return_url)
+    parsed_return_url = urlparse(return_url)
+    if parsed_return_url.hostname != request.url.raw_host:
+        msg = f"Redirect URL not at {request.host}"
+        context.logger.warning("Invalid request", error=msg)
+        raise web.HTTPBadRequest(reason=msg, text=msg)
+    if parsed_return_url.query:
+        return_query = parse_qsl(parsed_return_url.query)
+    else:
+        return_query = []
+
+    # Get the user's session.  If they are not already authenticated, send
+    # them to the login endpoint.
+    session = await get_session(request)
+    auth_session = None
+    if "handle" in session:
+        handle = SessionHandle.from_str(session["handle"])
+        session_store = context.factory.create_session_store()
+        auth_session = await session_store.get_session(handle)
+    if not auth_session:
+        login_base_url = str(request.app.router["login"].url_for())
+        login_url = urlparse(login_base_url)._replace(
+            query=urlencode({"rd": str(request.url)})
+        )
+        context.logger.info("Redirecting user for authentication")
+        raise web.HTTPFound(login_url.geturl())
+
+    # Get an authorization code, returning an error via redirect if needed.
+    oidc_server = context.factory.create_oidc_server()
+    try:
+        code = await oidc_server.issue_code(client_id, return_url, handle)
+    except UnauthorizedClientException as e:
+        query = [
+            ("error", "unauthorized_client"),
+            ("error_description", str(e)),
+        ]
+        if state:
+            query.append(("state", state))
+        return_query.extend(query)
+        error_url = parsed_return_url._replace(query=urlencode(return_query))
+        context.logger.warning(
+            "Unauthorized OpenID Connect client", error=str(e)
+        )
+        raise web.HTTPFound(error_url.geturl())
+
+    # Return the authorization code to the client via redirect.
+    query = [("code", code.encode())]
+    if state:
+        query.append(("state", state))
+    return_query.extend(query)
+    redirect_url = parsed_return_url._replace(query=urlencode(return_query))
+    context.logger.info("Returned OpenID Connect authorization code")
+    raise web.HTTPFound(redirect_url.geturl())
+
+
+def get_form_value(data: MultiDictProxy, key: str) -> Optional[str]:
+    """Retrieve a string from form data.
+
+    This handles encoding issues and returns `None` if one of the fields is
+    unexpectedly a file upload.
+
+    Parameters
+    ----------
+    data : `multidict.MultiDictProxy`
+        The form data.
+    key : `str`
+        The field to extract.
+
+    Returns
+    -------
+    value : `str` or `None`
+        The value, or `None` if this field wasn't present or if it was a file
+        upload.
+    """
+    value = data.get(key)
+    if not value:
+        return None
+    elif isinstance(value, str):
+        return value
+    elif isinstance(value, bytes):
+        return value.decode()
+    else:
+        return None
+
+
+@routes.post("/auth/openid/token")
+async def post_token(request: web.Request) -> web.Response:
+    """Redeem an authorization code for a token.
+
+    Parameters
+    ----------
+    request : `aiohttp.web.Request`
+        The incoming request.
+
+    Returns
+    -------
+    response : `aiohttp.web.Response`
+        The response.
+    """
+    context = RequestContext.from_request(request)
+    data = await request.post()
+    grant_type = get_form_value(data, "grant_type")
+    client_id = get_form_value(data, "client_id")
+    client_secret = get_form_value(data, "client_secret")
+    encoded_code = get_form_value(data, "code")
+    redirect_uri = get_form_value(data, "redirect_uri")
+
+    # Check the request parameters.
+    if not grant_type or not client_id or not encoded_code or not redirect_uri:
+        msg = "Invalid token request"
+        context.logger.warning("Invalid request", error=msg)
+        error = {
+            "error": "invalid_request",
+            "error_description": msg,
+        }
+        return web.json_response(error, status=400)
+    if grant_type != "authorization_code":
+        msg = f"Invalid grant type {grant_type}"
+        context.logger.warning("Invalid request", error=msg)
+        error = {
+            "error": "unsupported_grant_type",
+            "error_description": msg,
+        }
+        return web.json_response(error, status=400)
+
+    # Redeem the provided code for a token.
+    oidc_server = context.factory.create_oidc_server()
+    try:
+        code = OIDCAuthorizationCode.from_str(encoded_code)
+        token = await oidc_server.redeem_code(
+            client_id,
+            client_secret,
+            redirect_uri,
+            cast(OIDCAuthorizationCode, code),
+        )
+    except InvalidSessionHandleException as e:
+        context.logger.warning("Cannot parse authorization code", error=str(e))
+        error = {
+            "error": "invalid_grant",
+            "error_description": "Invalid authorization code",
+        }
+        return web.json_response(error, status=400)
+    except InvalidClientException as e:
+        context.logger.warning("Unauthorized client", error=str(e))
+        error = {
+            "error": "invalid_client",
+            "error_description": str(e),
+        }
+        return web.json_response(error, status=400)
+    except InvalidGrantException as e:
+        context.logger.warning("Invalid authorization code", error=str(e))
+        error = {
+            "error": "invalid_grant",
+            "error_description": "Invalid authorization code",
+        }
+        return web.json_response(error, status=400)
+
+    # Return the token to the caller.
+    response = {
+        "access_token": token.encoded,
+        "token_type": "Bearer",
+        "expires_in": token.claims["exp"] - time.time(),
+        "id_token": token.encoded,
+    }
+    return web.json_response(response)
+
+
+@routes.get("/auth/openid/userinfo")
+@authenticated_jwt
+async def get_userinfo(
+    request: web.Request, token: VerifiedToken
+) -> web.Response:
+    """Return information about the holder of a JWT.
+
+    Parameters
+    ----------
+    request : `aiohttp.web.Request`
+        The incoming request.
+    token : `gafaelfawr.tokens.VerifiedToken`
+        The token of the authenticated user.
+
+    Returns
+    -------
+    response : `aiohttp.web.Response`
+        The response.
+    """
+    context = RequestContext.from_request(request)
+    context.logger.info("Returned user information")
+    return web.json_response(token.claims)

--- a/src/gafaelfawr/handlers/oidc.py
+++ b/src/gafaelfawr/handlers/oidc.py
@@ -9,7 +9,7 @@ from urllib.parse import parse_qsl, urlencode
 
 from aiohttp import web
 
-from gafaelfawr.exceptions import InvalidRequestError, OIDCServerError
+from gafaelfawr.exceptions import InvalidRequestError, OAuthError
 from gafaelfawr.handlers import routes
 from gafaelfawr.handlers.decorators import (
     authenticated_jwt,
@@ -152,7 +152,7 @@ async def get_login(request: web.Request, session: Session) -> web.Response:
     # Parse the authentication request.
     try:
         auth_request = AuthenticationRequest.from_context(context)
-    except OIDCServerError as e:
+    except OAuthError as e:
         e.log_warning(context.logger)
         return_url = build_return_url(auth_request, **e.as_dict())
         raise web.HTTPFound(return_url)
@@ -269,7 +269,7 @@ async def post_token(request: web.Request) -> web.Response:
         token = await oidc_server.redeem_code(
             client_id, client_secret, redirect_uri, authorization_code,
         )
-    except OIDCServerError as e:
+    except OAuthError as e:
         e.log_warning(context.logger)
         return web.json_response(e.as_dict, status=400)
 

--- a/src/gafaelfawr/handlers/oidc.py
+++ b/src/gafaelfawr/handlers/oidc.py
@@ -326,6 +326,15 @@ async def post_token(request: web.Request) -> web.Response:
         e.log_warning(context.logger)
         return web.json_response(e.as_dict, status=400)
 
+    # Log the token redemption.
+    context.logger.info(
+        "Retrieved token for user %s via OpenID Connect",
+        token.username,
+        user=token.username,
+        token=token.jti,
+        scope=" ".join(sorted(token.scope)),
+    )
+
     # Return the token to the caller.
     response = {
         "access_token": token.encoded,

--- a/src/gafaelfawr/handlers/tokens.py
+++ b/src/gafaelfawr/handlers/tokens.py
@@ -96,12 +96,11 @@ def authenticated(route: AuthenticatedRoute) -> Route:
             )
 
         # On success, add some context to the logger.
-        context.logger = context.logger.bind(
+        context.rebind_logger(
             token=token.jti,
             user=token.username,
             scope=" ".join(sorted(token.scope)),
         )
-        request["safir/logger"] = context.logger
 
         return await route(request, token)
 

--- a/src/gafaelfawr/handlers/userinfo.py
+++ b/src/gafaelfawr/handlers/userinfo.py
@@ -1,0 +1,40 @@
+"""Handler for the user information route (``/auth/userinfo``)."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from aiohttp import web
+
+from gafaelfawr.handlers import routes
+from gafaelfawr.handlers.decorators import authenticated_jwt
+from gafaelfawr.handlers.util import RequestContext
+
+if TYPE_CHECKING:
+    from gafaelfawr.tokens import VerifiedToken
+
+__all__ = ["get_userinfo"]
+
+
+@routes.get("/auth/userinfo")
+@authenticated_jwt
+async def get_userinfo(
+    request: web.Request, token: VerifiedToken
+) -> web.Response:
+    """Return information about the holder of a JWT.
+
+    Parameters
+    ----------
+    request : `aiohttp.web.Request`
+        The incoming request.
+    token : `gafaelfawr.tokens.VerifiedToken`
+        The token of the authenticated user.
+
+    Returns
+    -------
+    response : `aiohttp.web.Response`
+        The response.
+    """
+    context = RequestContext.from_request(request)
+    context.logger.info("Returned user information")
+    return web.json_response(token.claims)

--- a/src/gafaelfawr/handlers/util.py
+++ b/src/gafaelfawr/handlers/util.py
@@ -200,7 +200,7 @@ def validate_return_url(
 
     Raises
     ------
-    aiohttp.web.HTTPError
+    aiohttp.web.HTTPException
         An appropriate error if the return URL was invalid or missing.
     """
     if not return_url:

--- a/src/gafaelfawr/handlers/util.py
+++ b/src/gafaelfawr/handlers/util.py
@@ -12,7 +12,11 @@ from urllib.parse import urlparse
 import jwt
 from aiohttp import web
 
-from gafaelfawr.exceptions import InvalidRequestError, InvalidTokenException
+from gafaelfawr.exceptions import (
+    InvalidRequestError,
+    InvalidTokenError,
+    OAuthBearerError,
+)
 from gafaelfawr.factory import ComponentFactory
 from gafaelfawr.tokens import Token
 
@@ -36,66 +40,6 @@ __all__ = [
     "validate_return_url",
     "verify_token",
 ]
-
-
-class AuthType(Enum):
-    """Authentication types for the WWW-Authenticate header."""
-
-    Basic = auto()
-    Bearer = auto()
-
-
-class AuthError(Enum):
-    """Valid authentication errors for a WWW-Authenticate header.
-
-    Defined in RFC 6750.
-    """
-
-    invalid_request = auto()
-    invalid_token = auto()
-    insufficient_scope = auto()
-
-
-@dataclass
-class AuthChallenge:
-    """Represents the components of a WWW-Authenticate header."""
-
-    auth_type: AuthType
-    """The authentication type (the first part of the header)."""
-
-    realm: str
-    """The value of the realm attribute."""
-
-    error: Optional[AuthError] = None
-    """The value of the error attribute if present."""
-
-    error_description: Optional[str] = None
-    """The value of the error description attribute if present."""
-
-    scope: Optional[str] = None
-    """The value of the scope attribute if present."""
-
-    def as_header(self) -> str:
-        """Construct the WWW-Authenticate header for this challenge.
-
-        Returns
-        -------
-        header : `str`
-            Contents of the WWW-Authenticate header.
-        """
-        if self.auth_type == AuthType.Basic or not self.error:
-            return f'{self.auth_type.name} realm="{self.realm}"'
-
-        error_description = self.error_description
-        if error_description:
-            # Strip invalid characters from the description.
-            error_description = re.sub(r'["\\]', "", error_description)
-        info = f'realm="{self.realm}", error="{self.error.name}"'
-        if error_description:
-            info += f', error_description="{error_description}"'
-        if self.scope:
-            info += f', scope="{self.scope}"'
-        return f"{self.auth_type.name} {info}"
 
 
 @dataclass
@@ -177,6 +121,95 @@ class RequestContext:
         """
         self.logger = self.logger.bind(**values)
         self.request["safir/logger"] = self.logger
+
+
+class AuthType(Enum):
+    """Authentication types for the WWW-Authenticate header."""
+
+    Basic = auto()
+    Bearer = auto()
+
+
+class AuthError(Enum):
+    """Valid authentication errors for a WWW-Authenticate header.
+
+    Defined in RFC 6750.
+    """
+
+    invalid_request = auto()
+    invalid_token = auto()
+    insufficient_scope = auto()
+
+
+@dataclass
+class AuthChallenge:
+    """Represents the components of a WWW-Authenticate header."""
+
+    auth_type: AuthType
+    """The authentication type (the first part of the header)."""
+
+    realm: str
+    """The value of the realm attribute."""
+
+    error: Optional[AuthError] = None
+    """The value of the error attribute if present."""
+
+    error_description: Optional[str] = None
+    """The value of the error description attribute if present."""
+
+    scope: Optional[str] = None
+    """The value of the scope attribute if present."""
+
+    def as_header(self) -> str:
+        """Construct the WWW-Authenticate header for this challenge.
+
+        Returns
+        -------
+        header : `str`
+            Contents of the WWW-Authenticate header.
+        """
+        if self.auth_type == AuthType.Basic or not self.error:
+            return f'{self.auth_type.name} realm="{self.realm}"'
+
+        error_description = self.error_description
+        if error_description:
+            # Strip invalid characters from the description.
+            error_description = re.sub(r'["\\]', "", error_description)
+        info = f'realm="{self.realm}", error="{self.error.name}"'
+        if error_description:
+            info += f', error_description="{error_description}"'
+        if self.scope:
+            info += f', scope="{self.scope}"'
+        return f"{self.auth_type.name} {info}"
+
+
+def error_as_www_authenticate(
+    context: RequestContext, auth_type: AuthType, exc: OAuthBearerError
+) -> web.HTTPException:
+    """Convert an exception into an HTTP error.
+
+    Parameters
+    ----------
+    context : `RequestContext`
+        The context of the incoming request.
+    auth_type : `AuthType`
+        The type of authentication to request.
+    exc : `gafaelfawr.exceptions.OAuthBearerError`
+        An exception representing a bearer token error.
+
+    Returns
+    -------
+    aiohttp.web.HTTPException
+        A prepopulated `~aiohttp.web.HTTPException` object ready for raising.
+    """
+    challenge = AuthChallenge(
+        auth_type=auth_type,
+        realm=context.config.realm,
+        error=AuthError[exc.error],
+        error_description=str(exc),
+    )
+    headers = {"WWW-Authenticate": challenge.as_header()}
+    return exc.exception(headers=headers, reason=exc.message, text=str(exc))
 
 
 def parse_authorization(
@@ -306,7 +339,7 @@ def verify_token(context: RequestContext, encoded_token: str) -> VerifiedToken:
 
     Raises
     ------
-    gafaelfawr.exceptions.InvalidTokenException
+    gafaelfawr.exceptions.InvalidTokenError
         If the token could not be verified.
     gafaelfawr.exceptions.MissingClaimsException
         If the token is missing required claims.
@@ -316,4 +349,4 @@ def verify_token(context: RequestContext, encoded_token: str) -> VerifiedToken:
     try:
         return token_verifier.verify_internal_token(token)
     except jwt.InvalidTokenError as e:
-        raise InvalidTokenException(str(e))
+        raise InvalidTokenError(str(e))

--- a/src/gafaelfawr/handlers/util.py
+++ b/src/gafaelfawr/handlers/util.py
@@ -312,13 +312,13 @@ def validate_return_url(
     if not return_url:
         msg = "No destination URL specified"
         context.logger.warning("Bad return URL", error=msg)
-        raise web.HTTPBadRequest(reason=msg, text=msg)
+        raise web.HTTPBadRequest(reason="Bad return URL", text=msg)
     context.rebind_logger(return_url=return_url)
     parsed_return_url = urlparse(return_url)
     if parsed_return_url.hostname != context.request.url.raw_host:
         msg = f"URL is not at {context.request.host}"
         context.logger.warning("Bad return URL", error=msg)
-        raise web.HTTPBadRequest(reason=msg, text=msg)
+        raise web.HTTPBadRequest(reason="Bad return URL", text=msg)
     return parsed_return_url
 
 

--- a/src/gafaelfawr/handlers/util.py
+++ b/src/gafaelfawr/handlers/util.py
@@ -163,6 +163,20 @@ class RequestContext:
             logger=self.logger,
         )
 
+    def rebind_logger(self, **values: Optional[str]) -> None:
+        """Add the given values to the logging context.
+
+        Also updates the logging context stored in the request object in case
+        the request context later needs to be recreated from the request.
+
+        Parameters
+        ----------
+        **values : `str` or `None`
+            Additional values that should be added to the logging context.
+        """
+        self.logger = self.logger.bind(**values)
+        self.request["safir/logger"] = self.logger
+
 
 def validate_return_url(
     context: RequestContext, return_url: Optional[str]
@@ -193,7 +207,7 @@ def validate_return_url(
         msg = "No destination URL specified"
         context.logger.warning("Bad return URL", error=msg)
         raise web.HTTPBadRequest(reason=msg, text=msg)
-    context.logger = context.logger.bind(return_url=return_url)
+    context.rebind_logger(return_url=return_url)
     parsed_return_url = urlparse(return_url)
     if parsed_return_url.hostname != context.request.url.raw_host:
         msg = f"URL is not at {context.request.host}"

--- a/src/gafaelfawr/oidc.py
+++ b/src/gafaelfawr/oidc.py
@@ -78,6 +78,10 @@ class OIDCServer:
         self._session_store = session_store
         self._logger = logger
 
+    def is_valid_client(self, client_id: str) -> bool:
+        """Whether a client_id is a valid registered client."""
+        return any((c.client_id == client_id for c in self._config.clients))
+
     async def issue_code(
         self, client_id: str, redirect_uri: str, session_handle: SessionHandle
     ) -> OIDCAuthorizationCode:
@@ -103,7 +107,7 @@ class OIDCServer:
             The provided client ID is not registered as an OpenID Connect
             client.
         """
-        if not any((c.client_id == client_id for c in self._config.clients)):
+        if not self.is_valid_client(client_id):
             raise UnauthorizedClientException(f"Unknown client ID {client_id}")
         return await self._authorization_store.create(
             client_id, redirect_uri, session_handle

--- a/src/gafaelfawr/oidc.py
+++ b/src/gafaelfawr/oidc.py
@@ -1,0 +1,211 @@
+"""OpenID Connect identity provider support."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from gafaelfawr.exceptions import (
+    DeserializeException,
+    InvalidClientException,
+    InvalidGrantException,
+    UnauthorizedClientException,
+)
+from gafaelfawr.session import SessionHandle
+
+if TYPE_CHECKING:
+    from typing import Optional
+
+    from structlog import BoundLogger
+
+    from gafaelfawr.config import OIDCServerConfig
+    from gafaelfawr.issuer import TokenIssuer
+    from gafaelfawr.storage.oidc import (
+        OIDCAuthorizationCode,
+        OIDCAuthorizationStore,
+    )
+    from gafaelfawr.storage.session import SessionStore
+    from gafaelfawr.tokens import VerifiedToken
+
+__all__ = ["OIDCServer"]
+
+
+class OIDCServer:
+    """Minimalist OpenID Connect identity provider.
+
+    This provides just enough of the OpenID Connect protocol to satisfy
+    Chronograf (and possibly some other applications).  It is the underlying
+    implementation of the ``/auth/openid`` routes.
+
+    Parameters
+    ----------
+    authorization_store : `gafaelfawr.storage.oidc.OIDCAuthorizationStore`
+        The underlying storage for OpenID Connect authorizations.
+    issuer : `gafaelfawr.issuer.TokenIssuer`
+        JWT issuer.
+    session_store : `gafaelfawr.storage.session.SessionStore`
+        Storage for authentication sessions.
+    logger : `structlog.BoundLogger`
+        Logger for diagnostics.
+
+    Notes
+    -----
+    Expects the following flow:
+
+    #. User is sent to ``/auth/openid/login`` for initial authentication.
+    #. User is redirected back to the application with an authorization code.
+    #. Application submits code to ``/auth/openid/token``.
+    #. Application receives an access token and an ID token (the same).
+    #. Application gets user information from ``/auth/openid/userinfo``.
+
+    The handler code in :py:mod:`gafaelfawr.handlers.oidc` is responsible
+    for parsing the requests from the user.  This object creates the
+    authorization code (with its associated Redis entry) for step 2, and then
+    returns the token for that code in step 4.
+    """
+
+    def __init__(
+        self,
+        *,
+        config: OIDCServerConfig,
+        authorization_store: OIDCAuthorizationStore,
+        issuer: TokenIssuer,
+        session_store: SessionStore,
+        logger: BoundLogger,
+    ) -> None:
+        self._config = config
+        self._authorization_store = authorization_store
+        self._issuer = issuer
+        self._session_store = session_store
+        self._logger = logger
+
+    async def issue_code(
+        self, client_id: str, redirect_uri: str, session_handle: SessionHandle
+    ) -> OIDCAuthorizationCode:
+        """Issue a new authorization code.
+
+        Parameters
+        ----------
+        client_id : `str`
+            The client ID with access to this authorization.
+        redirect_uri : `str`
+            The intended return URI for this authorization.
+        session_handle : `gafaelfawr.session.SessionHandle`
+            The handle for the underlying authentication session.
+
+        Returns
+        -------
+        code : `gafaelfawr.session.SessionHandle`
+            The OpenID Connect authorization code.
+
+        Raises
+        ------
+        gafaelfawr.exceptions.UnauthorizedClientException
+            The provided client ID is not registered as an OpenID Connect
+            client.
+        """
+        if not any((c.client_id == client_id for c in self._config.clients)):
+            raise UnauthorizedClientException(f"unknown client ID {client_id}")
+        return await self._authorization_store.create(
+            client_id, redirect_uri, session_handle
+        )
+
+    async def redeem_code(
+        self,
+        client_id: str,
+        client_secret: Optional[str],
+        redirect_uri: str,
+        code: OIDCAuthorizationCode,
+    ) -> VerifiedToken:
+        """Redeem an authorization code.
+
+        Parameters
+        ----------
+        client_id : `str`
+            The client ID of the OpenID Connect client.
+        client_secret : `str` or `None`
+            The secret for that client.  A secret of `None` will never be
+            valid, but is accepted so that error handling can be unified.
+        redirect_uri : `str`
+            The return URI of the OpenID Connect client.
+        code : `gafaelfawr.session.SessionHandle`
+            The OpenID Connect authorization code.
+
+        Returns
+        -------
+        token : `gafaelfawr.tokens.VerifiedToken`
+            A newly-issued JWT for this client.
+
+        Raises
+        ------
+        gafaelfawr.exceptions.InvalidClientException
+            If the client ID is not known or the client secret does not match
+            the client ID.
+        gafaelfawr.exceptions.InvalidGrantException
+            If the code is not valid, the client is not allowed to use it,
+            or the underlying authorization or session does not exist.
+        """
+        self._check_client_secret(client_id, client_secret)
+        try:
+            authorization = await self._authorization_store.get(code)
+        except DeserializeException as e:
+            msg = f"Cannot get authorization for {code.key}: {str(e)}"
+            raise InvalidGrantException(msg)
+        if not authorization:
+            msg = f"Unknown authoriation code {code.key}"
+            raise InvalidGrantException(msg)
+
+        if authorization.client_id != client_id:
+            msg = (
+                f"Authorization client ID mismatch for {code.key}:"
+                f" {authorization.client_id} != {client_id}"
+            )
+            raise InvalidGrantException(msg)
+        if authorization.redirect_uri != redirect_uri:
+            msg = (
+                f"Authorization redirect URI mismatch for {code.key}:"
+                f" {authorization.redirect_uri} != {redirect_uri}"
+            )
+            raise InvalidGrantException(msg)
+
+        session = await self._session_store.get_session(
+            authorization.session_handle
+        )
+        if not session:
+            msg = f"Invalid underlying session for authorization {code.key}"
+            raise InvalidGrantException(msg)
+        token = self._issuer.reissue_token(
+            session.token, jti=code.key, scope="openid", internal=True
+        )
+
+        # The code is valid and we're going to return success, so delete it
+        # from Redis so that it cannot be reused.
+        await self._authorization_store.delete(code)
+        return token
+
+    def _check_client_secret(
+        self, client_id: str, client_secret: Optional[str]
+    ) -> None:
+        """Check that the client ID and client secret match.
+
+        Parameters
+        ----------
+        client_id : `str`
+            The OpenID Connect client ID.
+        client_secret : `str` or `None`
+            The secret for that client ID.
+
+        Raises
+        ------
+        gafaelfawr.exceptions.InvalidClientException
+            If the client ID isn't known or the secret doesn't match.
+        """
+        if not client_secret:
+            raise InvalidClientException("No client_secret provided")
+        for client in self._config.clients:
+            if client.client_id == client_id:
+                if client.client_secret == client_secret:
+                    return
+                else:
+                    msg = f"Invalid secret for {client_id}"
+                    raise InvalidClientException(msg)
+        raise InvalidClientException(f"Unknown client ID {client_id}")

--- a/src/gafaelfawr/oidc.py
+++ b/src/gafaelfawr/oidc.py
@@ -104,7 +104,7 @@ class OIDCServer:
             client.
         """
         if not any((c.client_id == client_id for c in self._config.clients)):
-            raise UnauthorizedClientException(f"unknown client ID {client_id}")
+            raise UnauthorizedClientException(f"Unknown client ID {client_id}")
         return await self._authorization_store.create(
             client_id, redirect_uri, session_handle
         )

--- a/src/gafaelfawr/oidc.py
+++ b/src/gafaelfawr/oidc.py
@@ -155,7 +155,7 @@ class OIDCServer:
             msg = f"Cannot get authorization for {code.key}: {str(e)}"
             raise InvalidGrantError(msg)
         if not authorization:
-            msg = f"Unknown authoriation code {code.key}"
+            msg = f"Unknown authorization code {code.key}"
             raise InvalidGrantError(msg)
 
         if authorization.client_id != client_id:

--- a/src/gafaelfawr/settings.py
+++ b/src/gafaelfawr/settings.py
@@ -165,6 +165,9 @@ class Settings(BaseModel):
     oidc: Optional[OIDCSettings] = None
     """Settings for the OpenID Connect authentication provider."""
 
+    oidc_server_secrets_file: Optional[str] = None
+    """Path to file containing OpenID Connect client secrets in JSON."""
+
     known_scopes: Dict[str, str] = {}
     """Known scopes (the keys) and their descriptions (the values)."""
 

--- a/src/gafaelfawr/storage/oidc.py
+++ b/src/gafaelfawr/storage/oidc.py
@@ -1,0 +1,208 @@
+"""Storage for OpenID Connect authorizations."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING, cast
+
+from gafaelfawr.constants import OIDC_AUTHORIZATION_LIFETIME
+from gafaelfawr.exceptions import DeserializeException
+from gafaelfawr.session import SessionHandle
+from gafaelfawr.storage.base import Serializable
+
+if TYPE_CHECKING:
+    from typing import Optional
+
+    from gafaelfawr.storage.base import RedisStorage
+
+__all__ = [
+    "OIDCAuthorization",
+    "OIDCAuthorizationCode",
+    "OIDCAuthorizationStore",
+]
+
+
+class OIDCAuthorizationCode(SessionHandle):
+    """An OpenID Connect authorization code.
+
+    Identical to a session handle in behavior.  This class exists to give it a
+    new type for better type checking.
+    """
+
+
+@dataclass
+class OIDCAuthorization(Serializable):
+    """Represents an authorization for an OpenID Connect client.
+
+    This is the object created during login and stored in Redis.  The returned
+    authorization code points to it and allows it to be retrieved so that an
+    OpenID Connect client can redeem the code for a token.
+
+    Notes
+    -----
+    The authorization code is represented by the `OIDCAuthorizationCode`
+    class.  It consists of a key and a secret.  The key corresponds to the
+    Redis key under which the session is stored.  The combined key and secret
+    must match the handle stored inside the encrypted Redis object.  This
+    approach prevents someone with access to list the Redis keys from using a
+    Redis key directly as an authorization code.
+
+    The corresponding token is not stored directly in this session entry.
+    Instead, it stores a handle for the user's underlying authentication
+    session, from which a token can be retrieved.
+    """
+
+    code: OIDCAuthorizationCode
+    """The authorization code."""
+
+    client_id: str
+    """The client that is allowed to use this authorization."""
+
+    redirect_uri: str
+    """The redirect URI for which this authorization is intended."""
+
+    session_handle: SessionHandle
+    """The underlying authentication session for the user."""
+
+    created_at: datetime
+    """When the authorization was created."""
+
+    @classmethod
+    def create(
+        cls, client_id: str, redirect_uri: str, session_handle: SessionHandle
+    ) -> OIDCAuthorization:
+        """Create a new OpenID Connect authorization.
+
+        Parameters
+        ----------
+        client_id : `str`
+            The client that is allowed to use this authorization.
+        redirect_uri : `str`
+            The redirect URI for which this authorization is intended.
+        session_handle : `gafaelfawr.session.SessionHandle`
+            A handle for the underlying authentication session.
+
+        Returns
+        -------
+        code : `OIDCAuthorization`
+            The newly-created session.
+        """
+        return cls(
+            code=OIDCAuthorizationCode(),
+            client_id=client_id,
+            redirect_uri=redirect_uri,
+            session_handle=session_handle,
+            created_at=datetime.now(timezone.utc),
+        )
+
+    @classmethod
+    def from_json(cls, data: str) -> OIDCAuthorization:
+        authorization = json.loads(data)
+        code = OIDCAuthorizationCode.from_str(authorization["code"])
+        return cls(
+            code=cast(OIDCAuthorizationCode, code),
+            client_id=authorization["client_id"],
+            redirect_uri=authorization["redirect_uri"],
+            session_handle=SessionHandle.from_str(
+                authorization["session_handle"]
+            ),
+            created_at=datetime.fromtimestamp(
+                authorization["created_at"], tz=timezone.utc
+            ),
+        )
+
+    @property
+    def lifetime(self) -> int:
+        now = datetime.now(timezone.utc)
+        age = int((now - self.created_at).total_seconds())
+        return OIDC_AUTHORIZATION_LIFETIME - age
+
+    def to_json(self) -> str:
+        data = {
+            "code": self.code.encode(),
+            "client_id": self.client_id,
+            "redirect_uri": self.redirect_uri,
+            "session_handle": self.session_handle.encode(),
+            "created_at": int(self.created_at.timestamp()),
+        }
+        return json.dumps(data)
+
+
+class OIDCAuthorizationStore:
+    """Stores and retrieves OpenID Connect authorizations.
+
+    Parameters
+    ----------
+    storage : `gafaelfawr.storage.base.RedisStorage`
+        The underlying storage for `OIDCAuthorization`.
+    """
+
+    def __init__(self, storage: RedisStorage[OIDCAuthorization]) -> None:
+        self._storage = storage
+
+    async def create(
+        self, client_id: str, redirect_uri: str, session_handle: SessionHandle
+    ) -> OIDCAuthorizationCode:
+        """Create a new OpenID Connect authorization and return its code.
+
+        Parameters
+        ----------
+        client_id : `str`
+            The client ID with access to this authorization.
+        redirect_uri : `str`
+            The intended return URI for this authorization.
+        session_handle : `gafaelfawr.session.SessionHandle`
+            The handle for the underlying authentication session.
+
+        Returns
+        -------
+        code : `gafaelfawr.session.SessionHandle`
+            The code for a newly-created and stored authorization.
+        """
+        authorization = OIDCAuthorization.create(
+            client_id, redirect_uri, session_handle
+        )
+        key = f"oidc:{authorization.code.key}"
+        await self._storage.store(key, authorization)
+        return authorization.code
+
+    async def delete(self, code: OIDCAuthorizationCode) -> None:
+        """Delete an OpenID Connect authorization.
+
+        Parameters
+        ----------
+        code : `gafaelfawr.session.SessionHandle`
+            The authorization code.
+        """
+        await self._storage.delete(f"oidc:{code.key}")
+
+    async def get(
+        self, code: OIDCAuthorizationCode
+    ) -> Optional[OIDCAuthorization]:
+        """Retrieve an OpenID Connect authorization.
+
+        Parameters
+        ----------
+        code : `gafaelfawr.session.SessionHandle`
+            The authorization code.
+
+        Returns
+        -------
+        authorization : `OIDCAuthorization` or `None`
+            The corresponding authorization, or `None` if no such
+            authorization exists.
+
+        Raises
+        ------
+        gafaelfawr.exceptions.DeserializeException
+            If the authorization exists but cannot be deserialized.
+        """
+        authorization = await self._storage.get(f"oidc:{code.key}")
+        if not authorization:
+            return None
+        if authorization.code != code:
+            msg = "Secret does not match stored authorization"
+            raise DeserializeException(msg)
+        return authorization

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,11 +12,12 @@ from tests.support.app import create_test_app
 
 if TYPE_CHECKING:
     from pathlib import Path
-    from typing import Any, Awaitable, Callable, Iterable
+    from typing import Any, Awaitable, Callable, Iterable, List, Optional
 
     from aiohttp import web
     from aiohttp.pytest_plugin.test_utils import TestClient
 
+    from gafaelfawr.config import OIDCClient
     from tests.setup import SetupTestCallable
 
 
@@ -81,7 +82,11 @@ def create_test_setup(
     """
 
     async def _create_test_setup(
-        environment: str = "github", client: bool = True, **settings: Any,
+        environment: str = "github",
+        *,
+        client: bool = True,
+        oidc_clients: Optional[List[OIDCClient]] = None,
+        **settings: Any,
     ) -> SetupTest:
         """Create a test setup for a given environment.
 
@@ -92,6 +97,9 @@ def create_test_setup(
         client : `bool`, optional
             If set to `False`, do not start a test application or create a
             client.
+        oidc_clients : List[`gafaelfawr.config.OIDCClient`], optional
+            If present, serialize the provided OpenID Connect clients into
+            a secret and include its path in the configuration.
         **settings : `typing.Any`
             Settings that override settings from the configuration file.
 
@@ -101,7 +109,10 @@ def create_test_setup(
             An object encapsulating the test setup.
         """
         app = await create_test_app(
-            tmp_path, environment=environment, **settings
+            tmp_path,
+            environment=environment,
+            oidc_clients=oidc_clients,
+            **settings,
         )
         if client:
             client = await aiohttp_client(app)

--- a/tests/handlers/auth_test.py
+++ b/tests/handlers/auth_test.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import base64
-import re
 import time
 from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING
@@ -12,58 +11,11 @@ from unittest.mock import ANY
 import jwt
 
 from gafaelfawr.constants import ALGORITHM
-from gafaelfawr.handlers.util import AuthChallenge, AuthError, AuthType
+from gafaelfawr.handlers.util import AuthError, AuthType
+from tests.support.headers import parse_www_authenticate
 
 if TYPE_CHECKING:
     from tests.setup import SetupTestCallable
-
-
-def parse_www_authenticate(header: str) -> AuthChallenge:
-    """Parse a ``WWW-Authenticate`` header into this representation.
-
-    A ``WWW-Authenticate`` header consists of one or mor challenges, each of
-    which is an auth type, whitespace, and a series of attributes in the form
-    of key="value", separated by a comma and whitespace.
-
-    We only support a single challenge here, since Gafaelfawr only returns a
-    single challenge.
-    """
-    auth_type_name, info = header.split(None, 1)
-    auth_type = AuthType[auth_type_name]
-
-    # A half-assed regex parser for the WWW-Authenticate header.
-    #
-    # Repeatedly match key/value pairs in the form key="value" and iterate
-    # on them as matches.  The key will be match group 1 and the value will
-    # be match group 2.
-    #
-    # Each attribute has to either start at the beginning of the portion of
-    # the header after the auth type (\A) or follow a previous attribute with
-    # a comma and whitespace (,\s*), ensuring there isn't any extraneous junk
-    # in the header.
-    error = None
-    error_description = None
-    scope = None
-    for attribute in re.finditer(r'(?:\A|,\s*)([^ "=]+)="([^"]+)"', info):
-        if attribute.group(1) == "realm":
-            realm = attribute.group(2)
-        elif attribute.group(1) == "error":
-            error = attribute.group(2)
-        elif attribute.group(1) == "error_description":
-            error_description = attribute.group(2)
-        elif attribute.group(1) == "scope":
-            scope = attribute.group(2)
-        else:
-            assert False, f"unexpected attribute {attribute.group(1)}"
-    assert realm
-
-    return AuthChallenge(
-        auth_type=auth_type,
-        realm=realm,
-        error=AuthError[error] if error else None,
-        error_description=error_description,
-        scope=scope,
-    )
 
 
 async def test_no_auth(create_test_setup: SetupTestCallable) -> None:

--- a/tests/handlers/oidc_test.py
+++ b/tests/handlers/oidc_test.py
@@ -1,0 +1,112 @@
+"""Tests for the /auth/openid routes."""
+
+from __future__ import annotations
+
+import time
+from typing import TYPE_CHECKING
+from unittest.mock import ANY
+from urllib.parse import parse_qs, urlparse
+
+from gafaelfawr.config import OIDCClient
+from gafaelfawr.providers.github import GitHubUserInfo
+from gafaelfawr.session import SessionHandle
+from gafaelfawr.tokens import Token
+
+if TYPE_CHECKING:
+    from tests.setup import SetupTestCallable
+
+
+async def test_login(create_test_setup: SetupTestCallable) -> None:
+    clients = [OIDCClient(client_id="some-id", client_secret="some-secret")]
+    setup = await create_test_setup(oidc_clients=clients)
+    userinfo = GitHubUserInfo(
+        name="GitHub User",
+        username="githubuser",
+        uid=123456,
+        email="githubuser@example.com",
+        teams=[],
+    )
+    await setup.github_login(userinfo)
+
+    # Log in
+    return_url = f"https://{setup.client.host}:4444/foo?a=bar&b=baz"
+    r = await setup.client.get(
+        "/auth/openid/login",
+        params={
+            "response_type": "code",
+            "scope": "openid",
+            "client_id": "some-id",
+            "state": "random-state",
+            "redirect_uri": return_url,
+        },
+        allow_redirects=False,
+    )
+    assert r.status == 302
+    url = urlparse(r.headers["Location"])
+    assert url.scheme == "https"
+    assert url.netloc == f"{setup.client.host}:4444"
+    assert url.path == "/foo"
+    assert url.query
+    query = parse_qs(url.query)
+    assert query == {
+        "a": ["bar"],
+        "b": ["baz"],
+        "code": [ANY],
+        "state": ["random-state"],
+    }
+    code = query["code"][0]
+
+    # Redeem the code for a token and check the result.
+    r = await setup.client.post(
+        "/auth/openid/token",
+        data={
+            "grant_type": "authorization_code",
+            "client_id": "some-id",
+            "client_secret": "some-secret",
+            "code": code,
+            "redirect_uri": return_url,
+        },
+    )
+    assert r.status == 200
+    data = await r.json()
+    assert data == {
+        "access_token": ANY,
+        "token_type": "Bearer",
+        "expires_in": ANY,
+        "id_token": ANY,
+    }
+    assert data["access_token"] == data["id_token"]
+    verifier = setup.factory.create_token_verifier()
+    token = verifier.verify_internal_token(Token(encoded=data["id_token"]))
+    expected_claims = {
+        "act": {
+            "aud": setup.config.issuer.aud,
+            "iss": setup.config.issuer.iss,
+            "jti": ANY,
+        },
+        "aud": setup.config.issuer.aud_internal,
+        "email": "githubuser@example.com",
+        "exp": ANY,
+        "iat": ANY,
+        "iss": setup.config.issuer.iss,
+        "jti": SessionHandle.from_str(code).key,
+        "name": "GitHub User",
+        "scope": "openid",
+        "sub": "githubuser",
+        "uid": "githubuser",
+        "uidNumber": "123456",
+    }
+    assert token.claims == expected_claims
+    now = time.time()
+    expected_exp = now + setup.config.issuer.exp_minutes * 60
+    assert expected_exp - 5 <= token.claims["exp"] <= expected_exp
+    assert now - 5 <= token.claims["iat"] <= now
+
+    # Test the user information endpoint.
+    r = await setup.client.get(
+        "/auth/openid/userinfo",
+        headers={"Authorization": f"Bearer {token.encoded}"},
+    )
+    assert r.status == 200
+    data = await r.json()
+    assert data == expected_claims

--- a/tests/handlers/oidc_test.py
+++ b/tests/handlers/oidc_test.py
@@ -101,12 +101,3 @@ async def test_login(create_test_setup: SetupTestCallable) -> None:
     expected_exp = now + setup.config.issuer.exp_minutes * 60
     assert expected_exp - 5 <= token.claims["exp"] <= expected_exp
     assert now - 5 <= token.claims["iat"] <= now
-
-    # Test the user information endpoint.
-    r = await setup.client.get(
-        "/auth/openid/userinfo",
-        headers={"Authorization": f"Bearer {token.encoded}"},
-    )
-    assert r.status == 200
-    data = await r.json()
-    assert data == expected_claims

--- a/tests/handlers/tokens_test.py
+++ b/tests/handlers/tokens_test.py
@@ -49,7 +49,7 @@ async def test_tokens_invalid_auth(
     assert r.status == 401
     data = json.loads(caplog.record_tuples[-1][2])
     assert data == {
-        "event": "Failed to authenticate token",
+        "event": "Invalid token",
         "error": "Not enough segments",
         "level": "warning",
         "logger": "gafaelfawr",

--- a/tests/handlers/userinfo_test.py
+++ b/tests/handlers/userinfo_test.py
@@ -1,0 +1,140 @@
+"""Tests for the ``/auth/userinfo`` route."""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+from unittest.mock import ANY
+
+from gafaelfawr.handlers.util import AuthError, AuthType
+from tests.support.headers import parse_www_authenticate
+
+if TYPE_CHECKING:
+    from _pytest.logging import LogCaptureFixture
+
+    from tests.setup import SetupTestCallable
+
+
+async def test_userinfo(
+    create_test_setup: SetupTestCallable, caplog: LogCaptureFixture
+) -> None:
+    setup = await create_test_setup()
+    token = setup.create_token()
+
+    caplog.clear()
+    r = await setup.client.get(
+        "/auth/userinfo", headers={"Authorization": f"Bearer {token.encoded}"},
+    )
+    assert r.status == 200
+    data = await r.json()
+    assert data == token.claims
+
+    log = json.loads(caplog.record_tuples[0][2])
+    assert log == {
+        "event": "Returned user information",
+        "level": "info",
+        "logger": "gafaelfawr",
+        "method": "GET",
+        "path": "/auth/userinfo",
+        "remote": "127.0.0.1",
+        "request_id": ANY,
+        "scope": "",
+        "token": token.jti,
+        "token_source": "bearer",
+        "user": token.username,
+        "user_agent": ANY,
+    }
+
+
+async def test_no_auth(
+    create_test_setup: SetupTestCallable, caplog: LogCaptureFixture
+) -> None:
+    setup = await create_test_setup()
+
+    caplog.clear()
+    r = await setup.client.get("/auth/userinfo")
+    assert r.status == 401
+    authenticate = parse_www_authenticate(r.headers["WWW-Authenticate"])
+    assert authenticate.auth_type == AuthType.Bearer
+    assert authenticate.realm == setup.config.realm
+    assert not authenticate.error
+    assert not authenticate.scope
+
+    log = json.loads(caplog.record_tuples[0][2])
+    assert log == {
+        "event": "No authentication token found",
+        "level": "warning",
+        "logger": "gafaelfawr",
+        "method": "GET",
+        "path": "/auth/userinfo",
+        "remote": "127.0.0.1",
+        "request_id": ANY,
+        "user_agent": ANY,
+    }
+
+
+async def test_invalid(
+    create_test_setup: SetupTestCallable, caplog: LogCaptureFixture
+) -> None:
+    setup = await create_test_setup()
+    token = setup.create_token()
+
+    caplog.clear()
+    r = await setup.client.get(
+        "/auth/userinfo", headers={"Authorization": f"token {token.encoded}"}
+    )
+    assert r.status == 400
+    authenticate = parse_www_authenticate(r.headers["WWW-Authenticate"])
+    assert authenticate.auth_type == AuthType.Bearer
+    assert authenticate.realm == setup.config.realm
+    assert authenticate.error == AuthError.invalid_request
+    assert authenticate.error_description == "Unknown Authorization type token"
+
+    log = json.loads(caplog.record_tuples[0][2])
+    assert log == {
+        "error": "Unknown Authorization type token",
+        "event": "Invalid request",
+        "level": "warning",
+        "logger": "gafaelfawr",
+        "method": "GET",
+        "path": "/auth/userinfo",
+        "remote": "127.0.0.1",
+        "request_id": ANY,
+        "user_agent": ANY,
+    }
+
+    r = await setup.client.get(
+        "/auth/userinfo", headers={"Authorization": f"bearer{token.encoded}"}
+    )
+    assert r.status == 400
+    authenticate = parse_www_authenticate(r.headers["WWW-Authenticate"])
+    assert authenticate.auth_type == AuthType.Bearer
+    assert authenticate.realm == setup.config.realm
+    assert authenticate.error == AuthError.invalid_request
+    assert authenticate.error_description == "Malformed Authorization header"
+
+    caplog.clear()
+    r = await setup.client.get(
+        "/auth/userinfo",
+        headers={"Authorization": f"bearer XXX{token.encoded}"},
+    )
+    assert r.status == 401
+    authenticate = parse_www_authenticate(r.headers["WWW-Authenticate"])
+    assert authenticate.auth_type == AuthType.Bearer
+    assert authenticate.realm == setup.config.realm
+    assert authenticate.error == AuthError.invalid_token
+    assert authenticate.error_description
+
+    log = json.loads(caplog.record_tuples[0][2])
+    assert log == {
+        "error": ANY,
+        "event": "Invalid token",
+        "level": "warning",
+        "logger": "gafaelfawr",
+        "method": "GET",
+        "path": "/auth/userinfo",
+        "remote": "127.0.0.1",
+        "request_id": ANY,
+        "token_source": "bearer",
+        "user_agent": ANY,
+    }

--- a/tests/oidc_test.py
+++ b/tests/oidc_test.py
@@ -1,0 +1,130 @@
+"""Tests for the OpenIdServer class."""
+
+from __future__ import annotations
+
+import json
+import time
+from typing import TYPE_CHECKING
+from unittest.mock import ANY
+
+import pytest
+from cryptography.fernet import Fernet
+
+from gafaelfawr.config import OIDCClient
+from gafaelfawr.exceptions import (
+    InvalidClientException,
+    InvalidGrantException,
+    UnauthorizedClientException,
+)
+from gafaelfawr.storage.oidc import OIDCAuthorizationCode
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from tests.setup import SetupTestCallable
+
+
+async def test_issue_code(
+    tmp_path: Path, create_test_setup: SetupTestCallable
+) -> None:
+    clients = [OIDCClient(client_id="some-id", client_secret="some-secret")]
+    setup = await create_test_setup(client=False, oidc_clients=clients)
+    oidc_server = setup.factory.create_oidc_server()
+    handle = await setup.create_session()
+    redirect_uri = "https://example.com/"
+
+    assert setup.config.oidc_server
+    assert list(setup.config.oidc_server.clients) == clients
+
+    with pytest.raises(UnauthorizedClientException):
+        await oidc_server.issue_code("unknown-client", redirect_uri, handle)
+
+    code = await oidc_server.issue_code("some-id", redirect_uri, handle)
+    encrypted_code = await setup.redis.get(f"oidc:{code.key}")
+    assert encrypted_code
+    fernet = Fernet(setup.config.session_secret.encode())
+    serialized_code = json.loads(fernet.decrypt(encrypted_code))
+    assert serialized_code == {
+        "code": code.encode(),
+        "client_id": "some-id",
+        "redirect_uri": redirect_uri,
+        "session_handle": handle.encode(),
+        "created_at": ANY,
+    }
+    now = time.time()
+    assert now - 2 < serialized_code["created_at"] < now
+
+
+async def test_redeem_code(
+    tmp_path: Path, create_test_setup: SetupTestCallable
+) -> None:
+    clients = [
+        OIDCClient(client_id="client-1", client_secret="client-1-secret"),
+        OIDCClient(client_id="client-2", client_secret="client-2-secret"),
+    ]
+    setup = await create_test_setup(client=False, oidc_clients=clients)
+    oidc_server = setup.factory.create_oidc_server()
+    handle = await setup.create_session()
+    redirect_uri = "https://example.com/"
+    code = await oidc_server.issue_code("client-2", redirect_uri, handle)
+
+    token = await oidc_server.redeem_code(
+        "client-2", "client-2-secret", redirect_uri, code
+    )
+    assert token.claims == {
+        "act": {
+            "aud": setup.config.issuer.aud,
+            "iss": setup.config.issuer.iss,
+            "jti": ANY,
+        },
+        "aud": setup.config.issuer.aud_internal,
+        "email": "some-user@example.com",
+        "iat": ANY,
+        "exp": ANY,
+        "iss": setup.config.issuer.iss,
+        "jti": code.key,
+        "scope": "openid",
+        "sub": "some-user",
+        "uid": "some-user",
+        "uidNumber": "1000",
+    }
+
+    assert not await setup.redis.get(f"oidc:{code.key}")
+
+
+async def test_redeem_code_errors(
+    tmp_path: Path, create_test_setup: SetupTestCallable
+) -> None:
+    clients = [
+        OIDCClient(client_id="client-1", client_secret="client-1-secret"),
+        OIDCClient(client_id="client-2", client_secret="client-2-secret"),
+    ]
+    setup = await create_test_setup(client=False, oidc_clients=clients)
+    oidc_server = setup.factory.create_oidc_server()
+    handle = await setup.create_session()
+    redirect_uri = "https://example.com/"
+    code = await oidc_server.issue_code("client-2", redirect_uri, handle)
+
+    with pytest.raises(InvalidClientException):
+        await oidc_server.redeem_code(
+            "some-client", "some-secret", redirect_uri, code
+        )
+    with pytest.raises(InvalidClientException):
+        await oidc_server.redeem_code(
+            "client-2", "some-secret", redirect_uri, code
+        )
+    with pytest.raises(InvalidGrantException):
+        await oidc_server.redeem_code(
+            "client-2",
+            "client-2-secret",
+            redirect_uri,
+            OIDCAuthorizationCode(),
+        )
+    with pytest.raises(InvalidGrantException):
+        await oidc_server.redeem_code(
+            "client-1", "client-1-secret", redirect_uri, code
+        )
+    with pytest.raises(InvalidGrantException):
+        await oidc_server.redeem_code(
+            "client-2", "client-2-secret", "https://foo.example.com/", code
+        )

--- a/tests/oidc_test.py
+++ b/tests/oidc_test.py
@@ -12,8 +12,8 @@ from cryptography.fernet import Fernet
 
 from gafaelfawr.config import OIDCClient
 from gafaelfawr.exceptions import (
-    InvalidClientException,
-    InvalidGrantException,
+    InvalidClientError,
+    InvalidGrantError,
     UnauthorizedClientException,
 )
 from gafaelfawr.storage.oidc import OIDCAuthorizationCode
@@ -105,26 +105,26 @@ async def test_redeem_code_errors(
     redirect_uri = "https://example.com/"
     code = await oidc_server.issue_code("client-2", redirect_uri, handle)
 
-    with pytest.raises(InvalidClientException):
+    with pytest.raises(InvalidClientError):
         await oidc_server.redeem_code(
             "some-client", "some-secret", redirect_uri, code
         )
-    with pytest.raises(InvalidClientException):
+    with pytest.raises(InvalidClientError):
         await oidc_server.redeem_code(
             "client-2", "some-secret", redirect_uri, code
         )
-    with pytest.raises(InvalidGrantException):
+    with pytest.raises(InvalidGrantError):
         await oidc_server.redeem_code(
             "client-2",
             "client-2-secret",
             redirect_uri,
             OIDCAuthorizationCode(),
         )
-    with pytest.raises(InvalidGrantException):
+    with pytest.raises(InvalidGrantError):
         await oidc_server.redeem_code(
             "client-1", "client-1-secret", redirect_uri, code
         )
-    with pytest.raises(InvalidGrantException):
+    with pytest.raises(InvalidGrantError):
         await oidc_server.redeem_code(
             "client-2", "client-2-secret", "https://foo.example.com/", code
         )

--- a/tests/support/headers.py
+++ b/tests/support/headers.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
 def parse_www_authenticate(header: str) -> AuthChallenge:
     """Parse a ``WWW-Authenticate`` header into this representation.
 
-    A ``WWW-Authenticate`` header consists of one or mor challenges, each of
+    A ``WWW-Authenticate`` header consists of one or more challenges, each of
     which is an auth type, whitespace, and a series of attributes in the form
     of key="value", separated by a comma and whitespace.
 

--- a/tests/support/headers.py
+++ b/tests/support/headers.py
@@ -3,8 +3,13 @@
 from __future__ import annotations
 
 import re
+from typing import TYPE_CHECKING
+from urllib.parse import parse_qs, urlparse
 
 from gafaelfawr.handlers.util import AuthChallenge, AuthError, AuthType
+
+if TYPE_CHECKING:
+    from typing import Dict, List
 
 
 def parse_www_authenticate(header: str) -> AuthChallenge:
@@ -53,3 +58,21 @@ def parse_www_authenticate(header: str) -> AuthChallenge:
         error_description=error_description,
         scope=scope,
     )
+
+
+def query_from_url(url: str) -> Dict[str, List[str]]:
+    """Parse a URL and return its query.
+
+    Parameters
+    ----------
+    url : `str`
+        The URL.
+
+    Returns
+    -------
+    query : Dict[`str`, List[`str`]]
+        The query in the form returned by :py:func:`urllib.parse.parse_qs`.
+    """
+    parsed_url = urlparse(url)
+    assert parsed_url.query
+    return parse_qs(parsed_url.query)

--- a/tests/support/headers.py
+++ b/tests/support/headers.py
@@ -1,0 +1,55 @@
+"""Test helper functions to parse HTTP headers."""
+
+from __future__ import annotations
+
+import re
+
+from gafaelfawr.handlers.util import AuthChallenge, AuthError, AuthType
+
+
+def parse_www_authenticate(header: str) -> AuthChallenge:
+    """Parse a ``WWW-Authenticate`` header into this representation.
+
+    A ``WWW-Authenticate`` header consists of one or mor challenges, each of
+    which is an auth type, whitespace, and a series of attributes in the form
+    of key="value", separated by a comma and whitespace.
+
+    We only support a single challenge here, since Gafaelfawr only returns a
+    single challenge.
+    """
+    auth_type_name, info = header.split(None, 1)
+    auth_type = AuthType[auth_type_name]
+
+    # A half-assed regex parser for the WWW-Authenticate header.
+    #
+    # Repeatedly match key/value pairs in the form key="value" and iterate
+    # on them as matches.  The key will be match group 1 and the value will
+    # be match group 2.
+    #
+    # Each attribute has to either start at the beginning of the portion of
+    # the header after the auth type (\A) or follow a previous attribute with
+    # a comma and whitespace (,\s*), ensuring there isn't any extraneous junk
+    # in the header.
+    error = None
+    error_description = None
+    scope = None
+    for attribute in re.finditer(r'(?:\A|,\s*)([^ "=]+)="([^"]+)"', info):
+        if attribute.group(1) == "realm":
+            realm = attribute.group(2)
+        elif attribute.group(1) == "error":
+            error = attribute.group(2)
+        elif attribute.group(1) == "error_description":
+            error_description = attribute.group(2)
+        elif attribute.group(1) == "scope":
+            scope = attribute.group(2)
+        else:
+            assert False, f"unexpected attribute {attribute.group(1)}"
+    assert realm
+
+    return AuthChallenge(
+        auth_type=auth_type,
+        realm=realm,
+        error=AuthError[error] if error else None,
+        error_description=error_description,
+        scope=scope,
+    )


### PR DESCRIPTION
This adds a simple OpenID Connect server that should be sufficient for Chronograf.
It also includes some supporting refactoring changes:

- Helper function for generating `WWW-Authenticate` challenges
- Merge `Authorization` header parsing
- Centralize the route decorators in one module
- Add a helper function to rebind the request logger
- Refactor verification of a return URL