### PR TITLE
[DM-26072] Add support for generating InfluxDB tokens

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,7 @@ Change log
 This release adds a minimalist OpenID Connect server to support protected applications that only understand OpenID Connect.
 The initial implementation is intended to support `Chronograf <https://www.influxdata.com/time-series-platform/chronograf/>`__.
 Other applications may or may not work.
+It also adds optional support for issuing InfluxDB authentication tokens.
 
 - Add support for a password-protected Redis backend.
   This uses a new configuration parameter, ``redis_password_file``, which points to a file containing the password for Redis.
@@ -16,6 +17,9 @@ Other applications may or may not work.
   The authentication endpoint is ``/auth/openid/login`` and the token endpoint is ``/auth/openid/token``.
 - Add a user information endpoint (``/auth/userinfo``) that accepts a JWT and returns its claims.
   Intended primarily for use with OpenID Connect.
+- Add support for issuing InfluxDB authentication tokens via a new ``/auth/tokens/influxdb/new`` route.
+  InfluxDB requires JWTs with the HS256 algorithm and a shared secret.
+  This feature is enabled by configuring the shared secret via the ``issuer.influxdb_secret_file`` configuration option.
 
 1.3.2 (2020-06-08)
 ==================

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -27,6 +27,8 @@ API reference
 
 .. automodapi:: gafaelfawr.handlers.index
 
+.. automodapi:: gafaelfawr.handlers.influxdb
+
 .. automodapi:: gafaelfawr.handlers.login
 
 .. automodapi:: gafaelfawr.handlers.logout

--- a/docs/applications.rst
+++ b/docs/applications.rst
@@ -183,3 +183,25 @@ Assuming that Gafaelfawr and Chronograf are deployed on the host ``example.com``
 * ``GENERIC_SCOPES``: ``openid``
 * ``PUBLIC_URL``: ``https://example.com/chronograf``
 * ``TOKEN_SECRET``: ``pCY29u3qMTdWCNetOUD3OShsqwPm+pYKDNt6dqy01qw=``
+
+.. _influxdb:
+
+Authenticating to InfluxDB
+==========================
+
+.. warning::
+
+   InfluxDB 2.x is not supported.
+   These tokens will only work with InfluxDB 1.x.
+
+Gafaelfawr optionally supports issuing tokens for InfluxDB 1.x authentication.
+To enable this support, set ``issuer.influxdb.enabled`` to true in :ref:`helm-settings`.
+Then, create an ``influxdb-secret`` Vault secret key with the shared key that InfluxDB uses to verify the token.
+This can be any string of characters, such as the results of ``os.urandom(32).hex()``.
+The same secret must be configured in the `InfluxDB configuration file <https://docs.influxdata.com/influxdb/v1.8/administration/authentication_and_authorization/>`__.
+
+This will enable creation of new InfluxDB tokens via the ``/auth/tokens/influxdb/new`` route.
+Users can authenticate to this route with either a web session or a bearer token.
+The result is a JSON object containing a ``token`` key, the contents of which are the bearer token to present to InfluxDB.
+
+The token will contain a ``sub`` claim matching the user's Gafaelfawr username and will expire at the same time as the token or session used to authenticate to this route.

--- a/docs/arch/routes.rst
+++ b/docs/arch/routes.rst
@@ -41,6 +41,10 @@ Gafaelfawr supports the following routes:
 ``/auth/tokens``
     Displays all user-issued tokens for the authenticated user.
 
+``/auth/tokens/influxdb/new``
+    Issue a new InfluxDB token for the authenticated user.
+    The result will be a JSON object with either a ``token`` key containing the token or ``error`` and ``error_description`` keys explaining the error.
+
 ``/auth/tokens/new``
     Displays or handles the form that allows users to issue new tokens.
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -83,6 +83,10 @@ Secrets beginning or ending in whitespace are not supported.
         The expiration period of newly-issued JWTs, in minutes.
         The default is one day.
 
+    ``influxdb_secret_file`` (optional)
+        File containing the shared secret for issuing InfluxDB tokens.
+        If not set, issuance of InfluxDB tokens will be disabled.
+
 ``github`` (optional)
     Configure GitHub authentication.
     Users who go to the ``/login`` route will be sent to GitHub for authentication, and their token created based on their GitHub user metadata.

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -72,10 +72,15 @@ If you are using it, create a Vault secret with the following keys:
     The GitHub secret, obtained when creating the OAuth App as described above.
     This is not required if you are using CILogin authentication.
 
+``influxdb-secret`` (optional)
+    The shared secret to use for issuing InfluxDB tokens.
+    See :ref:`influxdb` for more information.
+
 ``oidc-server-secrets`` (optional)
     Only used if the Helm chart parameter ``oidc_server.enabled`` is set to true.
     The JSON representation of the OpenID Connect clients.
     Must be a JSON list of objects, each of which must have ``id`` and ``secret`` keys corresponding to the ``client_id`` and ``client_secret`` parameters sent by OpenID Connect clients.
+    See :ref:`openid-connect` for more information.
 
 ``redis-password``
     The password to use for Redis authentication.
@@ -152,6 +157,10 @@ To use that chart, you will need to provide a ``values.yaml`` file with the foll
     The lifetime (in minutes) of the issued JWTs and thus the user's authentication session.
     The default is 1440 (one day).
 
+``issuer.influxdb.enabled`` (optional)
+    Whether to enable InfluxDB token issuance.
+    If this is set to true, the Vault secret for Gafaelfawr must contain an ``influxdb-secret`` key.
+
 ``github.client_id``
     The client ID for the GitHub OAuth App if using GitHub as the identity provider.
     Only set either this or ``cilogon.client_id``.
@@ -171,7 +180,7 @@ To use that chart, you will need to provide a ``values.yaml`` file with the foll
 
 ``oidc_server.enabled``
     Set this to true to enable the OpenID Connect server.
-    If this is set, the Vault secret for Gafaelfawr must contain a ``oidc-server-secrets`` key.
+    If this is set to true, the Vault secret for Gafaelfawr must contain a ``oidc-server-secrets`` key.
 
 ``known_scopes``
     Mapping of scope names to descriptions.

--- a/src/gafaelfawr/config.py
+++ b/src/gafaelfawr/config.py
@@ -97,6 +97,9 @@ class IssuerConfig:
     uid_claim: str
     """Token claim from which to take the UID."""
 
+    influxdb_secret: Optional[str]
+    """Shared secret for issuing InfluxDB authentication tokens."""
+
 
 @dataclass(frozen=True)
 class VerifierConfig:
@@ -300,6 +303,10 @@ class Config:
         if settings.redis_password_file:
             path = settings.redis_password_file
             redis_password = cls._load_secret(path).decode()
+        influxdb_secret = None
+        if settings.issuer.influxdb_secret_file:
+            path = settings.issuer.influxdb_secret_file
+            influxdb_secret = cls._load_secret(path).decode()
         if settings.github:
             path = settings.github.client_secret_file
             github_secret = cls._load_secret(path).decode()
@@ -348,6 +355,7 @@ class Config:
             group_mapping=group_mapping_frozen,
             username_claim=settings.username_claim,
             uid_claim=settings.uid_claim,
+            influxdb_secret=influxdb_secret,
         )
         verifier_config = VerifierConfig(
             iss=settings.issuer.iss,

--- a/src/gafaelfawr/exceptions.py
+++ b/src/gafaelfawr/exceptions.py
@@ -20,6 +20,7 @@ __all__ = [
     "InvalidTokenClaimsException",
     "InvalidTokenError",
     "MissingClaimsException",
+    "NotConfiguredException",
     "OAuthError",
     "OAuthBearerError",
     "OIDCException",
@@ -128,6 +129,10 @@ class InvalidSessionHandleException(Exception):
 
 class InvalidTokenClaimsException(Exception):
     """A token cannot be issued with the provided claims."""
+
+
+class NotConfiguredException(Exception):
+    """The requested operation was not configured."""
 
 
 class ProviderException(Exception):

--- a/src/gafaelfawr/handlers/__init__.py
+++ b/src/gafaelfawr/handlers/__init__.py
@@ -17,9 +17,13 @@ def init_routes() -> aiohttp.web.RouteTableDef:
     """Initialize the route table for the routes."""
     # Import handlers so that they are registered with the routes table via
     # decorators. This isn't a global import to avoid circular dependencies.
+    #
+    # gafaelfawr.handlers.influxdb must be included before .tokens to ensure
+    # the proper route priority.
     import gafaelfawr.handlers.analyze  # noqa: F401
     import gafaelfawr.handlers.auth  # noqa: F401
     import gafaelfawr.handlers.index  # noqa: F401
+    import gafaelfawr.handlers.influxdb  # noqa: F401
     import gafaelfawr.handlers.login  # noqa: F401
     import gafaelfawr.handlers.logout  # noqa: F401
     import gafaelfawr.handlers.oidc  # noqa: F401

--- a/src/gafaelfawr/handlers/influxdb.py
+++ b/src/gafaelfawr/handlers/influxdb.py
@@ -1,0 +1,48 @@
+"""Handler for generating an InfluxDB token (``/auth/tokens/influxdb/new``)."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from aiohttp import web
+
+from gafaelfawr.exceptions import NotConfiguredException
+from gafaelfawr.handlers import routes
+from gafaelfawr.handlers.decorators import authenticated_token
+from gafaelfawr.handlers.util import RequestContext
+
+if TYPE_CHECKING:
+    from gafaelfawr.tokens import VerifiedToken
+
+__all__ = ["get_influxdb"]
+
+
+@routes.get("/auth/tokens/influxdb/new")
+@authenticated_token
+async def get_influxdb(
+    request: web.Request, token: VerifiedToken
+) -> web.Response:
+    """Return an InfluxDB-compatible JWT.
+
+    Parameters
+    ----------
+    request : `aiohttp.web.Request`
+        The incoming request.
+    token : `gafaelfawr.tokens.VerifiedToken`
+        The user's authentication token.
+
+    Returns
+    -------
+    response : `aiohttp.web.Response`
+        The response.
+    """
+    context = RequestContext.from_request(request)
+    token_issuer = context.factory.create_token_issuer()
+    try:
+        influxdb_token = token_issuer.issue_influxdb_token(token)
+    except NotConfiguredException as e:
+        context.logger.warning("Not configured", error=str(e))
+        response = {"error": "not_supported", "error_description": str(e)}
+        return web.json_response(response, status=400)
+    context.logger.info("Issued InfluxDB token")
+    return web.json_response({"token": influxdb_token})

--- a/src/gafaelfawr/settings.py
+++ b/src/gafaelfawr/settings.py
@@ -54,6 +54,9 @@ class IssuerSettings(BaseModel):
     exp_minutes: int = 1440  # 1 day
     """Number of minutes into the future that a token should expire."""
 
+    influxdb_secret_file: Optional[str] = None
+    """File containing shared secret for issuing InfluxDB tokens."""
+
 
 class GitHubSettings(BaseModel):
     """pydantic model of GitHub configuration."""

--- a/tests/handlers/influxdb_test.py
+++ b/tests/handlers/influxdb_test.py
@@ -1,0 +1,108 @@
+"""Tests for the ``/auth/tokens/influxdb`` route."""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+from unittest.mock import ANY
+
+import jwt
+
+from gafaelfawr.handlers.util import AuthType
+from tests.support.headers import parse_www_authenticate
+
+if TYPE_CHECKING:
+    from _pytest.logging import LogCaptureFixture
+
+    from tests.setup import SetupTestCallable
+
+
+async def test_influxdb(
+    create_test_setup: SetupTestCallable, caplog: LogCaptureFixture
+) -> None:
+    setup = await create_test_setup()
+    token = setup.create_token()
+    assert setup.config.issuer.influxdb_secret
+
+    caplog.clear()
+    r = await setup.client.get(
+        "/auth/tokens/influxdb/new",
+        headers={"X-Auth-Request-Token": token.encoded},
+    )
+
+    assert r.status == 200
+    data = await r.json()
+    assert data == {"token": ANY}
+    influxdb_token = data["token"]
+
+    header = jwt.get_unverified_header(influxdb_token)
+    assert header == {"alg": "HS256", "typ": "JWT"}
+    claims = jwt.decode(
+        influxdb_token, setup.config.issuer.influxdb_secret, algorithm="HS256"
+    )
+    assert claims == {
+        "sub": token.username,
+        "exp": token.claims["exp"],
+        "iat": ANY,
+    }
+
+    log = json.loads(caplog.record_tuples[0][2])
+    assert log == {
+        "event": "Issued InfluxDB token",
+        "level": "info",
+        "logger": "gafaelfawr",
+        "method": "GET",
+        "path": "/auth/tokens/influxdb/new",
+        "remote": "127.0.0.1",
+        "request_id": ANY,
+        "scope": "",
+        "token": token.jti,
+        "user": token.username,
+        "user_agent": ANY,
+    }
+
+
+async def test_no_auth(create_test_setup: SetupTestCallable) -> None:
+    setup = await create_test_setup()
+
+    r = await setup.client.get("/auth/tokens/influxdb/new")
+    assert r.status == 401
+    authenticate = parse_www_authenticate(r.headers["WWW-Authenticate"])
+    assert authenticate.auth_type == AuthType.Bearer
+    assert authenticate.realm == setup.config.realm
+    assert not authenticate.error
+    assert not authenticate.scope
+
+
+async def test_not_configured(
+    create_test_setup: SetupTestCallable, caplog: LogCaptureFixture
+) -> None:
+    setup = await create_test_setup("oidc")
+    token = setup.create_token()
+
+    caplog.clear()
+    r = await setup.client.get(
+        "/auth/tokens/influxdb/new",
+        headers={"X-Auth-Request-Token": token.encoded},
+    )
+    assert r.status == 400
+    assert await r.json() == {
+        "error": "not_supported",
+        "error_description": "No InfluxDB issuer configuration",
+    }
+
+    log = json.loads(caplog.record_tuples[0][2])
+    assert log == {
+        "error": "No InfluxDB issuer configuration",
+        "event": "Not configured",
+        "level": "warning",
+        "logger": "gafaelfawr",
+        "method": "GET",
+        "path": "/auth/tokens/influxdb/new",
+        "remote": "127.0.0.1",
+        "request_id": ANY,
+        "scope": "",
+        "token": token.jti,
+        "user": token.username,
+        "user_agent": ANY,
+    }

--- a/tests/settings/github.yaml.in
+++ b/tests/settings/github.yaml.in
@@ -16,6 +16,7 @@ issuer:
   iss: "https://test.example.com/"
   key_id: "some-kid"
   key_file: "{issuer_key_file}"
+  influxdb_secret_file: "{influxdb_secret_file}"
   aud:
     default: "https://example.com/"
     internal: "https://example.com/api"

--- a/tests/support/app.py
+++ b/tests/support/app.py
@@ -98,6 +98,7 @@ async def create_test_app(
     session_secret_file = store_secret(tmp_path, "session", session_secret)
     issuer_key = RSAKeyPair.generate().private_key_as_pem()
     issuer_key_file = store_secret(tmp_path, "issuer", issuer_key)
+    influxdb_secret_file = store_secret(tmp_path, "influxdb", b"influx-secret")
     github_secret_file = store_secret(tmp_path, "github", b"github-secret")
     oidc_secret_file = store_secret(tmp_path, "oidc", b"oidc-secret")
 
@@ -117,6 +118,7 @@ async def create_test_app(
         issuer_key_file=issuer_key_file,
         github_secret_file=github_secret_file,
         oidc_secret_file=oidc_secret_file,
+        influxdb_secret_file=influxdb_secret_file,
     )
     app = await create_app(
         settings_path=str(settings_path),


### PR DESCRIPTION
InfluxDB expects a simple JWT authenticated with a shared key. Add a new
route to generate such a token based on a user's existing authentication.