### PR TITLE
[DM-26072] Some cleanup refactoring after InfluxDB/Chronograf support

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,7 +2,7 @@
 Change log
 ##########
 
-1.4.0 (unreleased)
+1.4.0 (2020-08-13)
 ==================
 
 This release adds a minimalist OpenID Connect server to support protected applications that only understand OpenID Connect.

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -1,0 +1,6 @@
+Command-line interface
+======================
+
+.. click:: gafaelfawr.cli:main
+   :prog: gafaelfawr
+   :show-nested:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -26,6 +26,7 @@ extensions = [
     "sphinx-prompt",
     "sphinx_automodapi.automodapi",
     "sphinx_automodapi.smart_resolver",
+    "sphinx_click",
     "documenteer.sphinxext",
 ]
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -24,6 +24,7 @@ Installation
    applications
    configuration
    logging
+   cli
    glossary
    changelog
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -26,6 +26,13 @@ Installation
    logging
    cli
    glossary
+
+Changes
+=======
+
+.. toctree::
+   :maxdepth: 1
+
    changelog
 
 Architecture

--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -21,4 +21,5 @@ pytest-aiohttp
 pytest-sugar
 seqdiag
 sphinx-automodapi==0.12
+sphinx-click
 sphinx-prompt

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -321,6 +321,10 @@ packaging==20.4 \
     --hash=sha256:4357f74f47b9c12db93624a82154e9b120fa8293699949152b22065d556079f8 \
     --hash=sha256:998416ba6962ae7fbd6596850b80e17859a5753ba17c32284f67bfff33784181 \
     # via pytest, pytest-sugar, sphinx
+pbr==5.4.5 \
+    --hash=sha256:07f558fece33b05caf857474a366dfcc00562bca13dd8b47b2b3e22d9f9bf55c \
+    --hash=sha256:579170e23f8e0c2f24b0de612f71f648eccb79fb1322c814ae6b3c07b5ba23e8 \
+    # via sphinx-click
 pillow==7.2.0 \
     --hash=sha256:0295442429645fa16d05bd567ef5cff178482439c9aad0411d3f0ce9b88b3a6f \
     --hash=sha256:06aba4169e78c439d528fdeb34762c3b61a70813527a2c57f0540541e9f433a8 \
@@ -429,6 +433,10 @@ sphinx-automodapi==0.12 \
     --hash=sha256:83bef65c2862fc377c7758efddd9426a6a299bd6e55156389c00ae7216d8e4f4 \
     --hash=sha256:a1338bc0a7f5c9bb317ecf7c7abd489c7cff452098205ef5110f733570516ac0 \
     # via -r requirements/dev.in
+sphinx-click==2.5.0 \
+    --hash=sha256:6848ba2d084ef2feebae0ce3603c1c02a2ba5ded54fb6c0cf24fd01204a945f3 \
+    --hash=sha256:8ba44ca446ba4bb0585069b8aabaa81e833472d6669b36924a398405311d206f \
+    # via -r requirements/dev.in
 sphinx-prompt==1.2.0 \
     --hash=sha256:3255438fa2480863cadbcebb098421f0cece761e0a440f577f891dc6779960e3 \
     --hash=sha256:577f9923f8850acbfc644eb2e1438f76166779aae15a81fc7a47a5aff2941fc7 \
@@ -436,7 +444,7 @@ sphinx-prompt==1.2.0 \
 sphinx==1.7.9 \
     --hash=sha256:217a7705adcb573da5bbe1e0f5cab4fa0bd89fd9342c9159121746f593c2d5a4 \
     --hash=sha256:a602513f385f1d5785ff1ca420d9c7eb1a1b63381733b2f0ea8188a391314a86 \
-    # via documenteer, sphinx-automodapi, sphinx-prompt
+    # via documenteer, sphinx-automodapi, sphinx-click, sphinx-prompt
 sphinxcontrib-serializinghtml==1.1.4 \
     --hash=sha256:eaa0eccc86e982a9b939b2b82d12cc5d013385ba5eadcc7e4fed23f4405f77bc \
     --hash=sha256:f242a81d423f59617a8e5cf16f5d4d74e28ee9a66f9e5b637a18082991db5a9a \
@@ -517,7 +525,7 @@ yarl==1.5.1 \
     # via aiohttp
 
 # The following packages are considered to be unsafe in a requirements file:
-setuptools==49.3.0 \
-    --hash=sha256:912c5cdd856fc0261147e81e71cb45c47636c0e3cfe6d64bf442412685277470 \
-    --hash=sha256:a7081c404f4437a0318785d5d18ac79e54f1d583c437f2f004a131d0f48f1ae4 \
+setuptools==49.3.1 \
+    --hash=sha256:1c7b51fba5d83160d540d18b2bf08fd546357488adf9ddbca08cc1e997bd5c18 \
+    --hash=sha256:b90e630c5d6b118357392245a9a3b34d22e06fe94538b4b0830a7b4b693a0e5c \
     # via blockdiag, sphinx

--- a/src/gafaelfawr/exceptions.py
+++ b/src/gafaelfawr/exceptions.py
@@ -85,11 +85,24 @@ class InvalidGrantError(OAuthError):
     hide_error = True
 
 
+class UnsupportedGrantTypeError(OAuthError):
+    """The grant type is not supported.
+
+    This corresponds to the ``unsupported_grant_type`` error in RFC 6749: "The
+    authorization grant type is not supported by the authorization server."
+    """
+
+    error = "unsupported_grant_type"
+    message = "Unsupported grant type"
+
+
 class OAuthBearerError(OAuthError):
     """An error that can be returned as a ``WWW-Authenticate`` challenge.
 
     Represents the subset of OAuth 2.0 errors defined in RFC 6750 as valid
-    errors to return in a ``WWW-Authenticate`` header.
+    errors to return in a ``WWW-Authenticate`` header.  The string form of
+    this exception is suitable for use as the ``error_description`` attribute
+    of a ``WWW-Authenticate`` header.
     """
 
     exception: ClassVar[Type[web.HTTPException]] = web.HTTPBadRequest
@@ -114,13 +127,24 @@ class InvalidTokenError(OAuthBearerError):
 
     This corresponds to the ``invalid_token`` error in RFC 6750: "The access
     token provided is expired, revoked, malformed, or invalid for other
-    reasons."  The string form of this exception is suitable for use as the
-    ``error_description`` attribute of a ``WWW-Authenticate`` header.
+    reasons."
     """
 
     error = "invalid_token"
     message = "Invalid token"
     exception = web.HTTPUnauthorized
+
+
+class InsufficientScopeError(OAuthBearerError):
+    """The provided token does not have the right authorization scope.
+
+    This corresponds to the ``insufficient_scope`` error in RFC 6750: "The
+    request requires higher privileges than provided by the access token."
+    """
+
+    error = "insufficient_scope"
+    message = "Token missing required scope"
+    exception = web.HTTPForbidden
 
 
 class InvalidSessionHandleException(Exception):

--- a/src/gafaelfawr/handlers/oidc.py
+++ b/src/gafaelfawr/handlers/oidc.py
@@ -213,11 +213,15 @@ async def post_token(request: web.Request) -> web.Response:
         scope=" ".join(sorted(token.scope)),
     )
 
-    # Return the token to the caller.
+    # Return the token to the caller.  The headers are mandated by RFC 6749.
     response = {
         "access_token": token.encoded,
         "token_type": "Bearer",
         "expires_in": token.claims["exp"] - time.time(),
         "id_token": token.encoded,
     }
-    return web.json_response(response)
+    headers = {
+        "Cache-Control": "no-store",
+        "Pragma": "no-cache",
+    }
+    return web.json_response(response, headers=headers)

--- a/src/gafaelfawr/handlers/oidc.py
+++ b/src/gafaelfawr/handlers/oidc.py
@@ -8,7 +8,11 @@ from urllib.parse import parse_qsl, urlencode
 
 from aiohttp import web
 
-from gafaelfawr.exceptions import InvalidRequestError, OAuthError
+from gafaelfawr.exceptions import (
+    InvalidRequestError,
+    OAuthError,
+    UnsupportedGrantTypeError,
+)
 from gafaelfawr.handlers import routes
 from gafaelfawr.handlers.decorators import authenticated_session
 from gafaelfawr.handlers.util import (
@@ -184,21 +188,11 @@ async def post_token(request: web.Request) -> web.Response:
 
     # Check the request parameters.
     if not grant_type or not client_id or not code or not redirect_uri:
-        msg = "Invalid token request"
-        context.logger.warning("Invalid request", error=msg)
-        error = {
-            "error": "invalid_request",
-            "error_description": msg,
-        }
-        return web.json_response(error, status=400)
+        exc: OAuthError = InvalidRequestError("Invalid token request")
+        return generate_json_response(context, exc)
     if grant_type != "authorization_code":
-        msg = f"Invalid grant type {grant_type}"
-        context.logger.warning("Invalid request", error=msg)
-        error = {
-            "error": "unsupported_grant_type",
-            "error_description": msg,
-        }
-        return web.json_response(error, status=400)
+        exc = UnsupportedGrantTypeError(f"Invalid grant type {grant_type}")
+        return generate_json_response(context, exc)
 
     # Redeem the provided code for a token.
     oidc_server = context.factory.create_oidc_server()

--- a/src/gafaelfawr/handlers/util.py
+++ b/src/gafaelfawr/handlers/util.py
@@ -25,9 +25,7 @@ if TYPE_CHECKING:
     from typing import Optional
     from urllib.parse import ParseResult
 
-    from aiohttp import ClientSession
     from aioredis import Redis
-    from cachetools import TTLCache
     from structlog import BoundLogger
 
     from gafaelfawr.config import Config
@@ -92,20 +90,11 @@ class RequestContext:
         This is constructed on the fly at each reference to ensure that we get
         the latest logger, which may have additional bound context.
         """
-        key_cache: TTLCache = self.request.config_dict["gafaelfawr/key_cache"]
-
-        # Tests inject an override http_session in the config dict.
-        http_session: ClientSession = self.request.config_dict.get(
-            "safir/http_session"
-        )
-        if not http_session:
-            http_session = self.request["safir/http_session"]
-
         return ComponentFactory(
             config=self.config,
             redis=self.redis,
-            key_cache=key_cache,
-            http_session=http_session,
+            key_cache=self.request.config_dict["gafaelfawr/key_cache"],
+            http_session=self.request.config_dict["safir/http_session"],
             logger=self.logger,
         )
 

--- a/tests/handlers/auth_logging_test.py
+++ b/tests/handlers/auth_logging_test.py
@@ -103,6 +103,7 @@ async def test_authorization_failed(
     data = json.loads(caplog.record_tuples[-1][2])
     assert data == {
         "auth_uri": "/foo",
+        "error": "Token missing required scope",
         "event": "Token missing required scope",
         "level": "warning",
         "logger": "gafaelfawr",

--- a/tests/handlers/influxdb_test.py
+++ b/tests/handlers/influxdb_test.py
@@ -8,7 +8,7 @@ from unittest.mock import ANY
 
 import jwt
 
-from gafaelfawr.handlers.util import AuthType
+from gafaelfawr.handlers.util import AuthErrorChallenge, AuthType
 from tests.support.headers import parse_www_authenticate
 
 if TYPE_CHECKING:
@@ -68,10 +68,9 @@ async def test_no_auth(create_test_setup: SetupTestCallable) -> None:
     r = await setup.client.get("/auth/tokens/influxdb/new")
     assert r.status == 401
     authenticate = parse_www_authenticate(r.headers["WWW-Authenticate"])
+    assert not isinstance(authenticate, AuthErrorChallenge)
     assert authenticate.auth_type == AuthType.Bearer
     assert authenticate.realm == setup.config.realm
-    assert not authenticate.error
-    assert not authenticate.scope
 
 
 async def test_not_configured(

--- a/tests/handlers/oidc_test.py
+++ b/tests/handlers/oidc_test.py
@@ -95,6 +95,8 @@ async def test_login(
         },
     )
     assert r.status == 200
+    assert r.headers["Cache-Control"] == "no-store"
+    assert r.headers["Pragma"] == "no-cache"
     data = await r.json()
     assert data == {
         "access_token": ANY,

--- a/tests/handlers/oidc_test.py
+++ b/tests/handlers/oidc_test.py
@@ -389,7 +389,7 @@ async def test_token_errors(
     log = json.loads(caplog.record_tuples[0][2])
     assert log == {
         "error": "Invalid grant type bogus",
-        "event": "Invalid request",
+        "event": "Unsupported grant type",
         "level": "warning",
         "logger": "gafaelfawr",
         "method": "POST",

--- a/tests/handlers/tokens_test.py
+++ b/tests/handlers/tokens_test.py
@@ -26,8 +26,8 @@ async def test_tokens_no_auth(
 
     data = json.loads(caplog.record_tuples[-1][2])
     assert data == {
-        "event": "No authentication token found",
-        "level": "warning",
+        "event": "No token found, returning unauthorized",
+        "level": "info",
         "logger": "gafaelfawr",
         "method": "GET",
         "path": "/auth/tokens",

--- a/tests/support/app.py
+++ b/tests/support/app.py
@@ -41,12 +41,10 @@ def build_settings(tmp_path: Path, template_name: str, **kwargs: Path) -> Path:
     """
     template_file = template_name + ".yaml.in"
     template_path = Path(__file__).parent.parent / "settings" / template_file
-    with template_path.open("r") as f:
-        template = f.read()
+    template = template_path.read_text()
     settings = template.format(**kwargs)
     settings_path = tmp_path / "gafaelfawr.yaml"
-    with settings_path.open("w") as f:
-        f.write(settings)
+    settings_path.write_text(settings)
     return settings_path
 
 
@@ -63,8 +61,7 @@ def store_secret(tmp_path: Path, name: str, secret: bytes) -> Path:
         The value of the secret.
     """
     secret_path = tmp_path / name
-    with secret_path.open(mode="wb") as f:
-        f.write(secret)
+    secret_path.write_bytes(secret)
     return secret_path
 
 

--- a/tests/support/headers.py
+++ b/tests/support/headers.py
@@ -6,7 +6,12 @@ import re
 from typing import TYPE_CHECKING
 from urllib.parse import parse_qs, urlparse
 
-from gafaelfawr.handlers.util import AuthChallenge, AuthError, AuthType
+from gafaelfawr.handlers.util import (
+    AuthChallenge,
+    AuthError,
+    AuthErrorChallenge,
+    AuthType,
+)
 
 if TYPE_CHECKING:
     from typing import Dict, List
@@ -51,13 +56,18 @@ def parse_www_authenticate(header: str) -> AuthChallenge:
             assert False, f"unexpected attribute {attribute.group(1)}"
     assert realm
 
-    return AuthChallenge(
-        auth_type=auth_type,
-        realm=realm,
-        error=AuthError[error] if error else None,
-        error_description=error_description,
-        scope=scope,
-    )
+    if error:
+        assert error_description
+        return AuthErrorChallenge(
+            auth_type=auth_type,
+            realm=realm,
+            error=AuthError[error],
+            error_description=error_description,
+            scope=scope,
+        )
+    else:
+        assert not error_description
+        return AuthChallenge(auth_type=auth_type, realm=realm)
 
 
 def query_from_url(url: str) -> Dict[str, List[str]]:


### PR DESCRIPTION
- Add RFC-mandated headers to the OIDC token route
- Use the `authenticated_session` decorator for the `/auth/analyze` route
- Suppress subheadings for the changelog in the documentation
- Add command-line documentation
- Unify error handling and standardize on using exceptions with helper functions
- Simplify `RequestContext` creation
- Use shared code for validating logout redirects
- Simplify use of `Path` objects in tests