### PR TITLE
[DM-26602] Add /.well-known/openid-configuration route

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,12 @@
 Change log
 ##########
 
+1.6.0 (unreleased)
+==================
+
+- Add ``/.well-known/openid-configuration`` route to provide metadata about the internal OpenID Connect server.
+  This follows the OpenID Connect Discovery 1.0 specification.
+
 1.5.0 (2020-09-16)
 ==================
 

--- a/docs/applications.rst
+++ b/docs/applications.rst
@@ -168,8 +168,8 @@ The OpenID Connect client should be configured to request only the ``openid`` sc
 No other scope is supported.
 The client must be able to authenticate by sending a ``client_secret`` parameter in the request to the token endpoint.
 
-Example
--------
+Chronograf example
+------------------
 
 Assuming that Gafaelfawr and Chronograf are deployed on the host ``example.com`` and Chronograf is at the URL ``/chronograf``, here are the environment variables required to configure `Chronograf <https://docs.influxdata.com/chronograf/v1.8/administration/managing-security/#configure-chronograf-to-use-any-oauth-2-0-provider>`__:
 
@@ -183,6 +183,18 @@ Assuming that Gafaelfawr and Chronograf are deployed on the host ``example.com``
 * ``GENERIC_SCOPES``: ``openid``
 * ``PUBLIC_URL``: ``https://example.com/chronograf``
 * ``TOKEN_SECRET``: ``pCY29u3qMTdWCNetOUD3OShsqwPm+pYKDNt6dqy01qw=``
+
+Open Distro for Elasticsearch example
+-------------------------------------
+
+Assuming that Gafaelfawr and Open Distro for Elasticsearch are deployed on the host ``example.com``, here are the settings required to configure `Open Distro for Elasticsearch <https://opendistro.github.io/for-elasticsearch-docs/docs/security/configuration/openid-connect/>`__:
+
+* ``opendistro_security.auth.type``: ``openid``
+* ``opendistro_security.openid.connect_url``: ``https://example.com/.well-known/openid-configuration``
+* ``opendistro_security.openid.client_id``: ``kibana-client-id``
+* ``opendistro_security.openid.client_secret``: ``fb7518beb61d27aaf20675d62778dea9``
+* ``opendistro_security.openid.scope``: ``openid``
+* ``opendistro_security.openid.logout_url``: ``https://example.com/logout``
 
 .. _influxdb:
 

--- a/docs/arch/references.rst
+++ b/docs/arch/references.rst
@@ -26,10 +26,21 @@ __ https://developer.github.com/v3/users/
 
 __ https://openid.net/specs/openid-connect-core-1_0.html
 
+`OpenID Connect Discovery 1.0`__
+    OpenID Connect discovery mechanisms, including the specification for the metadata returned by the provider metadata endpoint.
+
+__ https://openid.net/specs/openid-connect-discovery-1_0.html
+
 `RFC 6749: The OAuth 2.0 Authorization Framework`__
     The specification for the OAuth 2.0 authorization framework, on top of which OpenID Connect was built.
 
 __ https://tools.ietf.org/html/rfc6749
+
+`RFC 6750: Bearer Token Usage`__
+    Documents the syntax for ``WWW-Authenticate`` and ``Authorization`` header fields when using bearer tokens.
+    The attributes returned in a challenge in a ``WWW-Authenticate`` header field are defined here.
+
+__ https://tools.ietf.org/html/rfc6750
 
 `RFC 7517: JSON Web Key (JWK)`__
     The specification of the JSON Web Key format, including JSON Web Key Sets (JWKS).
@@ -40,12 +51,6 @@ __ https://tools.ietf.org/html/rfc7517
     The core specification for the JSON Web Token format.
 
 __ https://tools.ietf.org/html/rfc7519
-
-`RFC 6750: Bearer Token Usage`__
-    Documents the syntax for ``WWW-Authenticate`` and ``Authorization`` header fields when using bearer tokens.
-    The attributes returned in a challenge in a ``WWW-Authenticate`` header field are defined here.
-
-__ https://tools.ietf.org/html/rfc6750
 
 `RFC 7617: The Basic HTTP Authentication Scheme`__
     Documents the syntax for ``WWW-Authenticate`` and ``Authorization`` header fields when using HTTP Basic Authentication.

--- a/docs/arch/routes.rst
+++ b/docs/arch/routes.rst
@@ -98,3 +98,6 @@ Gafaelfawr supports the following routes:
 ``/.well-known/jwks.json``
     Returns the key information used to issue JWTs in JWKS format.
     This can be used by protected applications to retrieve Gafaelfawr's public signing key and independently verify the JWTs issued by Gafaelfawr.
+
+``/.well-known/openid-configuration``
+    Returns the OpenID Connect configuration information for protected applications that want to use Gafaelfawr as an OpenID Connect server.

--- a/src/gafaelfawr/handlers/well_known.py
+++ b/src/gafaelfawr/handlers/well_known.py
@@ -4,10 +4,14 @@ from __future__ import annotations
 
 from aiohttp import web
 
+from gafaelfawr.constants import ALGORITHM
 from gafaelfawr.handlers import routes
 from gafaelfawr.handlers.util import RequestContext
 
-__all__ = ["get_well_known_jwks"]
+__all__ = [
+    "get_well_known_jwks",
+    "get_well_known_openid",
+]
 
 
 @routes.get("/.well-known/jwks.json")
@@ -31,3 +35,38 @@ async def get_well_known_jwks(request: web.Request) -> web.Response:
     jwks = keypair.public_key_as_jwks(kid=context.config.issuer.kid)
     context.logger.info("Returned JWKS")
     return web.json_response({"keys": [jwks]})
+
+
+@routes.get("/.well-known/openid-configuration")
+async def get_well_known_openid(request: web.Request) -> web.Response:
+    """Handler for /.well-known/openid-configuration.
+
+    Serve metadata about our OpenID Connect implementation.
+
+    Parameters
+    ----------
+    request : `aiohttp.web.Request`
+        The incoming request.
+
+    Returns
+    -------
+    response : `aiohttp.web.Response`
+        The outgoing response.
+    """
+    context = RequestContext.from_request(request)
+    base_url = context.config.issuer.iss
+    response = {
+        "issuer": context.config.issuer.iss,
+        "authorization_endpoint": base_url + "/auth/openid/login",
+        "token_endpoint": base_url + "/auth/openid/token",
+        "userinfo_endpoint": base_url + "/auth/userinfo",
+        "jwks_uri": base_url + "/.well-known/jwks.json",
+        "scopes_supported": ["openid"],
+        "response_types_supported": ["code"],
+        "grant_types_supported": ["authorization_code"],
+        "subject_types_supported": ["public"],
+        "id_token_signing_alg_values_supported": [ALGORITHM],
+        "token_endpoint_auth_methods_supported": ["client_secret_post"],
+    }
+    context.logger.info("Returned OpenID Connect configuration")
+    return web.json_response(response)

--- a/tests/handlers/well_known_test.py
+++ b/tests/handlers/well_known_test.py
@@ -11,7 +11,7 @@ if TYPE_CHECKING:
     from tests.setup import SetupTestCallable
 
 
-async def test_well_known(create_test_setup: SetupTestCallable) -> None:
+async def test_well_known_jwks(create_test_setup: SetupTestCallable) -> None:
     setup = await create_test_setup()
 
     r = await setup.client.get("/.well-known/jwks.json")
@@ -36,3 +36,26 @@ async def test_well_known(create_test_setup: SetupTestCallable) -> None:
     # padding is required by RFC 7515 and 7518.
     assert "=" not in result["keys"][0]["n"]
     assert "=" not in result["keys"][0]["e"]
+
+
+async def test_well_known_oidc(create_test_setup: SetupTestCallable) -> None:
+    setup = await create_test_setup()
+
+    r = await setup.client.get("/.well-known/openid-configuration")
+    assert r.status == 200
+    result = await r.json()
+
+    base_url = setup.config.issuer.iss
+    assert result == {
+        "issuer": setup.config.issuer.iss,
+        "authorization_endpoint": base_url + "/auth/openid/login",
+        "token_endpoint": base_url + "/auth/openid/token",
+        "userinfo_endpoint": base_url + "/auth/userinfo",
+        "jwks_uri": base_url + "/.well-known/jwks.json",
+        "scopes_supported": ["openid"],
+        "response_types_supported": ["code"],
+        "grant_types_supported": ["authorization_code"],
+        "subject_types_supported": ["public"],
+        "id_token_signing_alg_values_supported": [ALGORITHM],
+        "token_endpoint_auth_methods_supported": ["client_secret_post"],
+    }


### PR DESCRIPTION
Open Distro for Elasticsearch requires this to discover metadata
about the OpenID Connect implementation.  Implement it and add an
Open Distro for Elasticsearch example.