### PR TITLE
[DM-26682] Fix various issues with InfluxDB tokens

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,15 @@
 Change log
 ##########
 
+1.5.0 (2020-09-16)
+==================
+
+This release fixes some issues with the InfluxDB token issuance support.
+
+- Put the username in the ``username`` field of InfluxDB tokens, not ``sub``.
+- Add a new configuration option, ``issuer.influxdb_username``, and a new Helm chart parameter, ``issuer.influxdb.username``, to force the username field of all issued InfluxDB tokens to a single value.
+  This is useful if one does not want to do user management in InfluxDB and is content with granting all users access to a generic account.
+
 1.4.1 (2020-09-11)
 ==================
 

--- a/docs/applications.rst
+++ b/docs/applications.rst
@@ -204,4 +204,6 @@ This will enable creation of new InfluxDB tokens via the ``/auth/tokens/influxdb
 Users can authenticate to this route with either a web session or a bearer token.
 The result is a JSON object containing a ``token`` key, the contents of which are the bearer token to present to InfluxDB.
 
-The token will contain a ``sub`` claim matching the user's Gafaelfawr username and will expire at the same time as the token or session used to authenticate to this route.
+The token will contain a ``username`` claim matching the user's Gafaelfawr username and will expire at the same time as the token or session used to authenticate to this route.
+
+If you want all InfluxDB tokens to contain the same ``username`` field so that you can use a single generic InfluxDB account, set ``issuer.influxdb.username`` to that value in :ref:`helm-settings`.

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -87,6 +87,9 @@ Secrets beginning or ending in whitespace are not supported.
         File containing the shared secret for issuing InfluxDB tokens.
         If not set, issuance of InfluxDB tokens will be disabled.
 
+    ``influxdb_username`` (optional)
+        If set, force the username in all InfluxDB tokens to this value rather than the authenticated username of the user requesting a token.
+
 ``github`` (optional)
     Configure GitHub authentication.
     Users who go to the ``/login`` route will be sent to GitHub for authentication, and their token created based on their GitHub user metadata.

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -161,6 +161,10 @@ To use that chart, you will need to provide a ``values.yaml`` file with the foll
     Whether to enable InfluxDB token issuance.
     If this is set to true, the Vault secret for Gafaelfawr must contain an ``influxdb-secret`` key.
 
+``issuer.influxdb.username`` (optional)
+    If set, force the username in all InfluxDB tokens to this value rather than the authenticated username of the user requesting a token.
+    Only applicable if InfluxDB token issuance is enabled.
+
 ``github.client_id``
     The client ID for the GitHub OAuth App if using GitHub as the identity provider.
     Only set either this or ``cilogon.client_id``.

--- a/src/gafaelfawr/config.py
+++ b/src/gafaelfawr/config.py
@@ -100,6 +100,9 @@ class IssuerConfig:
     influxdb_secret: Optional[str]
     """Shared secret for issuing InfluxDB authentication tokens."""
 
+    influxdb_username: Optional[str]
+    """The username to set in all InfluxDB tokens."""
+
 
 @dataclass(frozen=True)
 class VerifierConfig:
@@ -356,6 +359,7 @@ class Config:
             username_claim=settings.username_claim,
             uid_claim=settings.uid_claim,
             influxdb_secret=influxdb_secret,
+            influxdb_username=settings.issuer.influxdb_username,
         )
         verifier_config = VerifierConfig(
             iss=settings.issuer.iss,

--- a/src/gafaelfawr/handlers/influxdb.py
+++ b/src/gafaelfawr/handlers/influxdb.py
@@ -44,5 +44,9 @@ async def get_influxdb(
         context.logger.warning("Not configured", error=str(e))
         response = {"error": "not_supported", "error_description": str(e)}
         return web.json_response(response, status=400)
-    context.logger.info("Issued InfluxDB token")
+    if context.config.issuer.influxdb_username:
+        username = context.config.issuer.influxdb_username
+    else:
+        username = token.username
+    context.logger.info("Issued InfluxDB token", influxdb_username=username)
     return web.json_response({"token": influxdb_token})

--- a/src/gafaelfawr/issuer.py
+++ b/src/gafaelfawr/issuer.py
@@ -76,9 +76,9 @@ class TokenIssuer:
     def issue_influxdb_token(self, token: VerifiedToken) -> str:
         """Issue an InfluxDB-compatible token.
 
-        InfluxDB requires an HS256 JWT with ``sub`` and ``exp`` claims using a
-        shared secret.  Issue such a token based on the user's Gafaelfawr
-        token.
+        InfluxDB requires an HS256 JWT with ``username`` and ``exp`` claims
+        using a shared secret.  Issue such a token based on the user's
+        Gafaelfawr token.
 
         Parameters
         ----------
@@ -95,7 +95,7 @@ class TokenIssuer:
         payload = {
             "exp": token.claims["exp"],
             "iat": int(time.time()),
-            "sub": token.username,
+            "username": token.username,
         }
         return jwt.encode(
             payload, self._config.influxdb_secret, algorithm="HS256"

--- a/src/gafaelfawr/issuer.py
+++ b/src/gafaelfawr/issuer.py
@@ -92,10 +92,14 @@ class TokenIssuer:
         """
         if not self._config.influxdb_secret:
             raise NotConfiguredException("No InfluxDB issuer configuration")
+        if self._config.influxdb_username:
+            username = self._config.influxdb_username
+        else:
+            username = token.username
         payload = {
             "exp": token.claims["exp"],
             "iat": int(time.time()),
-            "username": token.username,
+            "username": username,
         }
         return jwt.encode(
             payload, self._config.influxdb_secret, algorithm="HS256"

--- a/src/gafaelfawr/settings.py
+++ b/src/gafaelfawr/settings.py
@@ -57,6 +57,9 @@ class IssuerSettings(BaseModel):
     influxdb_secret_file: Optional[str] = None
     """File containing shared secret for issuing InfluxDB tokens."""
 
+    influxdb_username: Optional[str] = None
+    """The username to set in all InfluxDB tokens."""
+
 
 class GitHubSettings(BaseModel):
     """pydantic model of GitHub configuration."""

--- a/tests/handlers/influxdb_test.py
+++ b/tests/handlers/influxdb_test.py
@@ -41,7 +41,7 @@ async def test_influxdb(
         influxdb_token, setup.config.issuer.influxdb_secret, algorithm="HS256"
     )
     assert claims == {
-        "sub": token.username,
+        "username": token.username,
         "exp": token.claims["exp"],
         "iat": ANY,
     }

--- a/tests/settings/influxdb-username.yaml.in
+++ b/tests/settings/influxdb-username.yaml.in
@@ -1,0 +1,26 @@
+realm: "testing"
+session_secret_file: "{session_secret_file}"
+redis_url: "dummy"
+proxies:
+  - "10.0.0.0/8"
+after_logout_url: "https://example.com/landing"
+group_mapping:
+  "exec:admin": ["admin"]
+  "exec:test": ["test"]
+  "read:all": ["foo", "admin", "org-a-team"]
+known_scopes:
+  "exec:admin": "admin description"
+  "exec:test": "test description"
+  "read:all": "can read everything"
+issuer:
+  iss: "https://test.example.com/"
+  key_id: "some-kid"
+  key_file: "{issuer_key_file}"
+  influxdb_secret_file: "{influxdb_secret_file}"
+  influxdb_username: "influxdb-user"
+  aud:
+    default: "https://example.com/"
+    internal: "https://example.com/api"
+github:
+  client_id: "some-github-client-id"
+  client_secret_file: "{github_secret_file}"


### PR DESCRIPTION
- Put the username in `username`, not `sub`, for InfluxDB tokens
- Add a new configuration parameter to force the username to a single value