### PR TITLE
[DM-27700] Remove __main__ block in gafaelfawr.cli

### DIFF
--- a/src/gafaelfawr/cli.py
+++ b/src/gafaelfawr/cli.py
@@ -76,7 +76,3 @@ def init(settings: str) -> None:
     config_dependency.set_settings_path(settings)
     config = config_dependency()
     initialize_database(config)
-
-
-if __name__ == "__main__":
-    main()


### PR DESCRIPTION
This isn't required since the entry points are defined in the
build system.