### PR TITLE
[DM-28666] Change /auth/analyze output to be backward compatible

### DIFF
--- a/src/gafaelfawr/handlers/analyze.py
+++ b/src/gafaelfawr/handlers/analyze.py
@@ -35,24 +35,47 @@ class FormattedJSONResponse(JSONResponse):
         ).encode()
 
 
+def token_data_to_analysis(token_data: TokenData) -> Dict[str, Dict[str, Any]]:
+    """Convert the token data to the legacy analysis format.
+
+    This produces the same format (with some missing data) as this route
+    produced when all tokens were JWTs.  These routes are used by JupyterHub
+    for authentication and expected the old format, so this is a backward
+    compatibility shim.  This route can be dropped once JupyterHub has been
+    converted to the new APIs and the UI provides a new way for a user to get
+    information about their current session.
+    """
+    data = {
+        "iat": int(token_data.created.timestamp()),
+        "scope": " ".join(token_data.scopes),
+        "sub": token_data.username,
+        "uid": token_data.username,
+    }
+    if token_data.expires:
+        data["exp"] = int(token_data.expires.timestamp())
+    if token_data.groups:
+        data["isMemberOf"] = [g.dict() for g in token_data.groups]
+    if token_data.name:
+        data["name"] = token_data.name
+    if token_data.uid:
+        data["uidNumber"] = str(token_data.uid)
+    return {"token": {"data": data, "valid": True}}
+
+
 @router.get("/auth/analyze", response_class=FormattedJSONResponse)
 async def get_analyze(
     token_data: TokenData = Depends(authenticate),
     context: RequestContext = Depends(context_dependency),
-) -> Dict[str, Any]:
+) -> Dict[str, Dict[str, Any]]:
     """Analyze a token from a web session."""
-    context.logger.info("Analyzed user session")
-    return {
-        "data": token_data.dict(),
-        "valid": True,
-    }
+    return token_data_to_analysis(token_data)
 
 
 @router.post("/auth/analyze", response_class=FormattedJSONResponse)
 async def post_analyze(
     token_str: str = Form(..., alias="token"),
     context: RequestContext = Depends(context_dependency),
-) -> Dict[str, Any]:
+) -> Dict[str, Dict[str, Any]]:
     """Analyze a token.
 
     Expects a POST with a single parameter, ``token``, containing the token.
@@ -61,19 +84,15 @@ async def post_analyze(
     try:
         token = Token.from_str(token_str)
     except InvalidTokenError as e:
-        return {"errors": [str(e)], "valid": False}
+        return {"token": {"errors": [str(e)], "valid": False}}
 
     token_service = context.factory.create_token_service()
     token_data = await token_service.get_data(token)
     if not token_data:
         return {
-            "data": {"token": {"key": token.key, "secret": token.secret}},
-            "errors": ["Invalid token"],
-            "valid": False,
+            "handle": token.dict(),
+            "token": {"errors": ["Invalid token"], "valid": False},
         }
-
-    context.logger.info("Analyzed user-provided token")
-    return {
-        "data": token_data.dict(),
-        "valid": True,
-    }
+    result = token_data_to_analysis(token_data)
+    result["handle"] = token.dict()
+    return result

--- a/src/gafaelfawr/providers/oidc.py
+++ b/src/gafaelfawr/providers/oidc.py
@@ -147,10 +147,15 @@ class OIDCProvider(Provider):
             raise OIDCException(msg)
 
         # Extract information from it to create the user information.
-        groups = [
-            TokenGroup(name=g["name"], id=g["id"])
-            for g in token.claims.get("isMemberOf", [])
-        ]
+        try:
+            groups = [
+                TokenGroup(name=g["name"], id=int(g["id"]))
+                for g in token.claims.get("isMemberOf", [])
+                if "name" in g and "id" in g
+            ]
+        except Exception as e:
+            msg = f"isMemberOf claim is invalid: {str(e)}"
+            raise OIDCException(msg)
         return TokenUserInfo(
             username=token.username,
             name=token.claims.get("name"),

--- a/tests/support/setup.py
+++ b/tests/support/setup.py
@@ -203,7 +203,7 @@ class SetupTest:
         *,
         kid: Optional[str] = None,
         groups: Optional[List[str]] = None,
-        **claims: str,
+        **claims: Any,
     ) -> VerifiedToken:
         """Create a signed OpenID Connect token.
 

--- a/tests/support/tokens.py
+++ b/tests/support/tokens.py
@@ -11,7 +11,7 @@ from gafaelfawr.constants import ALGORITHM
 from gafaelfawr.models.oidc import OIDCVerifiedToken
 
 if TYPE_CHECKING:
-    from typing import Any, Dict, List, Optional, Union
+    from typing import Any, Dict, List, Optional
 
     from gafaelfawr.config import Config
 
@@ -23,7 +23,7 @@ def create_test_token(
     groups: Optional[List[str]] = None,
     *,
     kid: str = "some-kid",
-    **claims: Union[str, int],
+    **claims: Any,
 ) -> OIDCVerifiedToken:
     """Create a signed token using the configured test issuer.
 
@@ -88,7 +88,7 @@ def create_upstream_oidc_token(
     kid: str,
     *,
     groups: Optional[List[str]] = None,
-    **claims: str,
+    **claims: Any,
 ) -> OIDCVerifiedToken:
     """Create a signed token using the OpenID Connect issuer.
 


### PR DESCRIPTION
Undo a poor choice I made during the FastAPI rewrite to change the
output format of /auth/analyze.  Nublado JupyterHub is using this
for now to retrieve token metadata, so convert the new token data
format to the old format we were previously generating when all
tokens were JWTs and use the same JSON structure.

This code (and route) can be dropped once JupyterHub can switch to
the new API and there's a new UI to show users their login metadata.

Also handle OpenID Connect providers that return invalid isMemberOf
structures, and ignore groups without GIDs (which are sometimes
returned by NCSA).