### PR TITLE
[DM-28898] Use load_incluster_config for Kubernetes

### DIFF
--- a/src/gafaelfawr/storage/kubernetes.py
+++ b/src/gafaelfawr/storage/kubernetes.py
@@ -46,7 +46,7 @@ class KubernetesStorage:
     """
 
     def __init__(self) -> None:
-        kubernetes.config.load_kube_config()
+        kubernetes.config.load_incluster_config()
         self._api = kubernetes.client.CoreV1Api()
 
     @_convert_exception


### PR DESCRIPTION
The examples in the Python library use load_kube_config, but when
running inside a cluster with a mounted service token (the expected
use case), load_incluster_config is the correct initialization
function.