### PR TITLE
[DM-29095] Add internal and notebook token caching

### DIFF
--- a/requirements/main.in
+++ b/requirements/main.in
@@ -17,6 +17,7 @@ uvicorn[standard]
 # Other dependencies.
 aioredis
 alembic
+cachetools
 click
 cryptography
 kubernetes

--- a/requirements/main.txt
+++ b/requirements/main.txt
@@ -68,7 +68,9 @@ attrs==20.3.0 \
 cachetools==4.2.1 \
     --hash=sha256:1d9d5f567be80f7c07d765e21b814326d78c61eb0c3a637dffc0e5d1796cb2e2 \
     --hash=sha256:f469e29e7aa4cff64d8de4aad95ce76de8ea1125a16c68e0d93f65c3c3dc92e9
-    # via google-auth
+    # via
+    #   -r requirements/main.in
+    #   google-auth
 certifi==2020.12.5 \
     --hash=sha256:1a4995114262bffbc2413b159f2a1a480c969de6e6eb13ee966d470af86af59c \
     --hash=sha256:719a74fb9e33b9bd44cc7f3a8d94bc35e4049deebe19ba7d8e108280cfd59830

--- a/src/gafaelfawr/constants.py
+++ b/src/gafaelfawr/constants.py
@@ -18,6 +18,9 @@ OIDC_AUTHORIZATION_LIFETIME = 60 * 60
 SETTINGS_PATH = "/etc/gafaelfawr/gafaelfawr.yaml"
 """Default configuration path."""
 
+TOKEN_CACHE_SIZE = 10000
+"""How many internal and notebook tokens to cache in memory."""
+
 # The following constants are used for field validation.  Minimum and maximum
 # length are handled separately.
 

--- a/src/gafaelfawr/token_cache.py
+++ b/src/gafaelfawr/token_cache.py
@@ -1,0 +1,166 @@
+"""Cache for internal and notebook tokens."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from cachetools import LRUCache
+
+from gafaelfawr.constants import TOKEN_CACHE_SIZE
+from gafaelfawr.util import current_datetime
+
+if TYPE_CHECKING:
+    from typing import List, Optional, Tuple
+
+    from gafaelfawr.models.token import Token, TokenData
+    from gafaelfawr.storage.token import TokenRedisStore
+
+__all__ = ["TokenCache"]
+
+
+class TokenCache:
+    """Cache internal and notebook tokens.
+
+    To reduce latency and database query load, notebook and internal tokens
+    for a given parent token are cached in memory and reused as long as the
+    request data matches, the token is still valid, and less than half of its
+    lifetime has passed.
+
+    Parameters
+    ----------
+    config : `gafaelfawr.config.Config`
+        The Gafaelfawr configuration.
+    redis : `aioredis.Redis`
+        The Redis client to use to check validity of the cached token.
+
+    Notes
+    -----
+    The cache storage is process-global.  It isn't protected by a lock and
+    thus isn't thread-safe.  The expectation is that this code will be used by
+    a single-process asyncio server, and scaling will be done by adding more
+    processes.
+
+    Notebook tokens are cached under the key of the parent token and its
+    expiration.  Internal tokens add the service name and the requested
+    scopes.  The expiration of the parent token is included since changing the
+    expiration of a parent token (for a user token for instance) may allow for
+    a longer internal or notebook token, and we don't want to prevent that
+    change by returning a cached token.
+    """
+
+    _cache: LRUCache[Tuple[str, ...], Token] = LRUCache(TOKEN_CACHE_SIZE)
+    """Shared cache storage for the tokens, global to each process."""
+
+    def __init__(self, store: TokenRedisStore) -> None:
+        self._store = store
+
+    async def get_internal_token(
+        self, token_data: TokenData, service: str, scopes: List[str]
+    ) -> Optional[Token]:
+        """Retrieve a cached internal token.
+
+        Parameters
+        ----------
+        token_data : `gafaelfawr.models.token.TokenData`
+            The authentication data for the parent token.
+        service : `str`
+            The service of the internal token.
+        scopes : List[`str`]
+            The scopes the internal token should have.
+
+        Returns
+        -------
+        token : `gafaelfawr.models.token.Token` or `None`
+            The cached token or `None` if no matching token is cached.
+        """
+        key = self._internal_key(token_data, service, scopes)
+        return await self._get_token(key, token_data.scopes)
+
+    async def get_notebook_token(
+        self, token_data: TokenData
+    ) -> Optional[Token]:
+        """Retrieve a cached notebook token.
+
+        Parameters
+        ----------
+        token_data : `gafaelfawr.models.token.TokenData`
+            The authentication data for the parent token.
+
+        Returns
+        -------
+        token : `gafaelfawr.models.token.Token` or `None`
+            The cached token or `None` if no matching token is cached.
+        """
+        key = self._notebook_key(token_data)
+        return await self._get_token(key)
+
+    def store_internal_token(
+        self,
+        token: Token,
+        token_data: TokenData,
+        service: str,
+        scopes: List[str],
+    ) -> None:
+        """Cache an internal token.
+
+        Parameters
+        ----------
+        token : `gafaelfawr.models.token.Token`
+            The token to cache.
+        token_data : `gafaelfawr.models.token.TokenData`
+            The authentication data for the parent token.
+        service : `str`
+            The service of the internal token.
+        scopes : List[`str`]
+            The scopes the internal token should have.
+        """
+        key = self._internal_key(token_data, service, scopes)
+        self._cache[key] = token
+
+    def store_notebook_token(
+        self, token: Token, token_data: TokenData
+    ) -> None:
+        """Cache a notebook token.
+
+        Parameters
+        ----------
+        token : `gafaelfawr.models.token.Token`
+            The token to cache.
+        token_data : `gafaelfawr.models.token.TokenData`
+            The authentication data for the parent token.
+        """
+        key = self._notebook_key(token_data)
+        self._cache[key] = token
+
+    async def _get_token(
+        self, key: Tuple[str, ...], scopes: Optional[List[str]] = None
+    ) -> Optional[Token]:
+        """Retrieve a cached token by key."""
+        token = self._cache.get(key)
+        if not token:
+            return None
+        data = await self._store.get_data(token)
+        if not data:
+            return None
+        if scopes is not None and not (set(data.scopes) <= set(scopes)):
+            return None
+        if data.expires:
+            lifetime = data.expires - data.created
+            remaining = data.expires - current_datetime()
+            print(lifetime, remaining)
+            if remaining.total_seconds() < lifetime.total_seconds() / 2:
+                return None
+        return token
+
+    def _internal_key(
+        self, token_data: TokenData, service: str, scopes: List[str]
+    ) -> Tuple[str, ...]:
+        """Build a cache key for an internal token."""
+        scope = ",".join(sorted(scopes))
+        expires = str(token_data.expires) if token_data.expires else "None"
+        return ("internal", token_data.token.key, expires, service, scope)
+
+    def _notebook_key(self, token_data: TokenData) -> Tuple[str, ...]:
+        """Build a cache key for a notebook token."""
+        expires = str(token_data.expires) if token_data.expires else "None"
+        return ("notebook", token_data.token.key, expires)

--- a/tests/support/setup.py
+++ b/tests/support/setup.py
@@ -83,6 +83,9 @@ class SetupTest:
     This class wraps creating a test FastAPI application, creating a factory
     for building the components, and accessing configuration settings.
 
+    This object should always be created via the :py:meth:`create` method.
+    The constructor should be considered private.
+
     Notes
     -----
     This class is named SetupTest instead of TestSetup because pytest thinks
@@ -156,8 +159,8 @@ class SetupTest:
         self.redis = redis
         self.client = client
         self.session = session
-        self._logger = structlog.get_logger(config.safir.logger_name)
-        assert self._logger
+        self.logger = structlog.get_logger(config.safir.logger_name)
+        assert self.logger
 
     @property
     def factory(self) -> ComponentFactory:
@@ -176,7 +179,7 @@ class SetupTest:
             redis=self.redis,
             http_client=self.client,
             session=self.session,
-            logger=self._logger,
+            logger=self.logger,
         )
 
     def configure(

--- a/tests/token_cache_test.py
+++ b/tests/token_cache_test.py
@@ -1,0 +1,146 @@
+"""Tests for the token cache dependency."""
+
+from __future__ import annotations
+
+from datetime import timedelta
+from typing import TYPE_CHECKING
+
+import pytest
+
+from gafaelfawr.models.token import Token, TokenData, TokenType
+from gafaelfawr.storage.base import RedisStorage
+from gafaelfawr.storage.token import TokenRedisStore
+from gafaelfawr.util import current_datetime
+
+if TYPE_CHECKING:
+    from tests.support.setup import SetupTest
+
+
+@pytest.mark.asyncio
+async def test_basic(setup: SetupTest) -> None:
+    token_data = await setup.create_session_token(scopes=["read:all"])
+    token_service = setup.factory.create_token_service()
+    token_cache = setup.factory.create_token_cache()
+    internal_token = await token_service.get_internal_token(
+        token_data, "some-service", ["read:all"], ip_address="127.0.0.1"
+    )
+    notebook_token = await token_service.get_notebook_token(
+        token_data, ip_address="127.0.0.1"
+    )
+
+    assert internal_token == await token_cache.get_internal_token(
+        token_data, "some-service", ["read:all"]
+    )
+    assert notebook_token == await token_cache.get_notebook_token(token_data)
+
+    # Requesting different internal tokens doesn't work.
+    assert not await token_cache.get_internal_token(
+        token_data, "other-service", ["read:all"]
+    )
+    assert not await token_cache.get_internal_token(
+        token_data, "some-service", []
+    )
+
+    # A different service token for the same user requesting the same
+    # information doesn't get anything back.
+    new_token_data = await setup.create_session_token(scopes=["read:all"])
+    assert not await token_cache.get_internal_token(
+        new_token_data, "some-service", ["read:all"]
+    )
+    assert not await token_cache.get_notebook_token(new_token_data)
+
+    # Changing the scope of the parent token doesn't matter as long as the
+    # internal token is requested with the same scope, as long as the parent
+    # token has that scope.
+    token_data.scopes = ["read:all", "admin:token"]
+    assert internal_token == await token_cache.get_internal_token(
+        token_data, "some-service", ["read:all"]
+    )
+    assert not await token_cache.get_internal_token(
+        token_data, "some-service", ["admin:token"]
+    )
+    token_data.scopes = []
+    assert not await token_cache.get_internal_token(
+        token_data, "some-service", ["read:all"]
+    )
+
+
+@pytest.mark.asyncio
+async def test_invalid(setup: SetupTest) -> None:
+    """Invalid tokens should not be returned even if cached."""
+    token_data = await setup.create_session_token(scopes=["read:all"])
+    token_cache = setup.factory.create_token_cache()
+    internal_token = Token()
+    notebook_token = Token()
+
+    token_cache.store_internal_token(
+        internal_token, token_data, "some-service", ["read:all"]
+    )
+    token_cache.store_notebook_token(notebook_token, token_data)
+
+    assert not await token_cache.get_internal_token(
+        token_data, "some-service", ["read:all"]
+    )
+    assert not await token_cache.get_notebook_token(token_data)
+
+
+@pytest.mark.asyncio
+async def test_expiration(setup: SetupTest) -> None:
+    """The cache is valid until half the lifetime of the child token."""
+    token_data = await setup.create_session_token(scopes=["read:all"])
+    lifetime = setup.config.token_lifetime
+    now = current_datetime()
+    storage = RedisStorage(TokenData, setup.config.session_secret, setup.redis)
+    token_store = TokenRedisStore(storage, setup.logger)
+    token_cache = setup.factory.create_token_cache()
+
+    # Store a token whose expiration is five seconds more than half the
+    # typical token lifetime in the future and cache that token as an internal
+    # token for our session token.
+    created = now - timedelta(seconds=lifetime.total_seconds() // 2)
+    expires = created + setup.config.token_lifetime + timedelta(seconds=5)
+    internal_token_data = TokenData(
+        token=Token(),
+        username=token_data.username,
+        token_type=TokenType.internal,
+        scopes=["read:all"],
+        created=created,
+        expires=expires,
+    )
+    await token_store.store_data(internal_token_data)
+    token_cache.store_internal_token(
+        internal_token_data.token, token_data, "some-service", ["read:all"]
+    )
+
+    # The cache should return this token.
+    assert internal_token_data.token == await token_cache.get_internal_token(
+        token_data, "some-service", ["read:all"]
+    )
+
+    # Now change the expiration to be ten seconds earlier, which should make
+    # the remaining lifetime less than half the total lifetime, and replace
+    # replace the stored token with that new version.
+    internal_token_data.expires = expires - timedelta(seconds=20)
+    await token_store.store_data(internal_token_data)
+
+    # The cache should now decline to return the token.
+    assert not await token_cache.get_internal_token(
+        token_data, "some-service", ["read:all"]
+    )
+
+    # Do the same test with a notebook token.
+    notebook_token_data = TokenData(
+        token=Token(),
+        username=token_data.username,
+        token_type=TokenType.notebook,
+        scopes=["read:all"],
+        created=created,
+        expires=expires,
+    )
+    await token_store.store_data(notebook_token_data)
+    token_cache.store_notebook_token(notebook_token_data.token, token_data)
+    token = notebook_token_data.token
+    assert token == await token_cache.get_notebook_token(token_data)
+    notebook_token_data.expires = expires - timedelta(seconds=20)
+    await token_store.store_data(notebook_token_data)
+    assert not await token_cache.get_notebook_token(token_data)


### PR DESCRIPTION
Cache internal and notebook tokens in a per-process in-memory cache
to reduce the database load.  The cached token is only returned for
the same parent token, only if the parent token expiration has not
changed, and (for internal tokens) the same service and requested
scopes.