### PR TITLE
[DM-28120] Cap FastAPI workers to 10

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,7 +45,7 @@ repos:
         additional_dependencies:
           # Manually mirror dev dependencies related to eslint here
           - babel-eslint@10.1.0
-          - eslint@7.24.0
+          - eslint@7.25.0
           - eslint-config-airbnb@18.2.1
           - eslint-config-prettier@6.15.0
           - eslint-config-wesbos@1.0.1

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,13 @@
 Change log
 ##########
 
+2.0.1 (2021-04-26)
+==================
+
+- Cap workers spawned by the Docker image at 10.
+  The defaults spawned 32 workers in a GKE container, which overwhelmed the available open connections with a micro Cloud SQL server.
+- Update JavaScript dependencies.
+
 2.0.0 (2021-04-23)
 ==================
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -70,5 +70,10 @@ ENV PATH="/opt/venv/bin:$PATH"
 # modified by the virtualenv.
 ENV MODULE_NAME=gafaelfawr.main
 
+# The default starts 40 workers, which exhausts the available connections
+# on a micro Cloud SQL PostgreSQL server and seems excessive since we can
+# scale with Kubernetes.  Cap the workers at 10.
+ENV MAX_WORKERS=10
+
 # Run on port 8080 instead of the FastAPI default for backward compatibility.
 ENV PORT=8080


### PR DESCRIPTION
We're exhausting the number of available connections on our Cloud
SQL instance because FastAPI is starting 40 workers.  This seems
excessive for a single Kubernetes pod; cap the worker count at 10
since we can scale horizontally with more pods.