### PR TITLE
Avoid react-alert-template-basic 1.0.1

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -16,7 +16,7 @@
         "prop-types": "^15.7.2",
         "react": "^17.0.2",
         "react-alert": "^7.0.3",
-        "react-alert-template-basic": "^1.0.0",
+        "react-alert-template-basic": "1.0.0 || ^1.0.2",
         "react-aria-modal": "^4.0.0",
         "react-datepicker": "^3.8.0",
         "react-dom": "^17.0.2",

--- a/ui/package.json
+++ b/ui/package.json
@@ -24,7 +24,7 @@
     "prop-types": "^15.7.2",
     "react": "^17.0.2",
     "react-alert": "^7.0.3",
-    "react-alert-template-basic": "^1.0.0",
+    "react-alert-template-basic": "1.0.0 || ^1.0.2",
     "react-aria-modal": "^4.0.0",
     "react-datepicker": "^3.8.0",
     "react-dom": "^17.0.2",


### PR DESCRIPTION
Version 1.0.1 doesn't work with eslint for some reason.  Assume
this is an usptream bug and avoid that version.