### PR TITLE
[DM-30706] Display expired tokens as expired

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,8 @@ Change log
 3.0.2 (unreleased)
 ==================
 
+- Display expired tokens as expired in the UI instead of showing the delta of the expiration from the current time.
+- Sort token lists in the UI in descending order by last used (not yet populated), then creation date, and only then by the token key.
 - Add a timestamp to all log messages, since not all Kubernetes log viewers show the timestamp added by Kubernetes.
 - Update dependencies.
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,7 +2,7 @@
 Change log
 ##########
 
-3.0.2 (unreleased)
+3.0.2 (2021-06-15)
 ==================
 
 - Display expired tokens as expired in the UI instead of showing the delta of the expiration from the current time.

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -312,9 +312,9 @@ hpack==4.0.0 \
     --hash=sha256:84a076fad3dc9a9f8063ccb8041ef100867b1878b25ef0ee63847a5d53818a6c \
     --hash=sha256:fc41de0c63e687ebffde81187a948221294896f6bdc0ae2312708df339430095
     # via h2
-httpcore==0.13.4 \
-    --hash=sha256:38e09649bb3906c913a2917c4eb3e3b3e11c83d4edebad8b53b7d757abc49267 \
-    --hash=sha256:9fa4c623bb9d2280c009c34658cc6315e4fd425a395145645bee205d827263e4
+httpcore==0.13.6 \
+    --hash=sha256:b0d16f0012ec88d8cc848f5a55f8a03158405f4bca02ee49bc4ca2c1fda49f3e \
+    --hash=sha256:db4c0dcb8323494d01b8c6d812d80091a31e520033e7b0120883d6f52da649ff
     # via
     #   -c requirements/main.txt
     #   httpx
@@ -710,9 +710,9 @@ sphinx-automodapi==0.13 \
     --hash=sha256:e1019336df7f7f0bcbf848eff7b84e7bef71691a57d8b5bda9107a2a046a226a \
     --hash=sha256:f9ebc9c10597f3aab1d93e5a8b1829903eee7c64f5bafb0cf71fd40e5c7d95f0
     # via -r requirements/dev.in
-sphinx-click==3.0.0 \
-    --hash=sha256:5ae8e558ffe3ee976410f2bbd9213d2c1127bd22df1a47099bf179e775f24591 \
-    --hash=sha256:5f0d10a992eae1aa869b22720281eb3f2d0d8fa30364e75db31db52539c70f9e
+sphinx-click==3.0.1 \
+    --hash=sha256:9b24c46f3b8f25fc639f47c97ac0361d9f80d48c2ed6b3917de2865bbdbe1785 \
+    --hash=sha256:e9ee2237e5a6b6620e9996b8214934afdf8f7f9f9fc082482c77be0e4379038e
     # via -r requirements/dev.in
 sphinx-prompt==1.4.0 \
     --hash=sha256:70c8e66d1f36def1e295ed961c7562bbf8fc697eea5191b92b41e4784c264ef5 \
@@ -767,8 +767,8 @@ toml==0.10.2 \
 types-cachetools==0.1.7 \
     --hash=sha256:51a9ca63b1ac73f7238a1836f82ea9252a15d77811da1663e94f2ee984c6485a
     # via -r requirements/dev.in
-types-pyyaml==0.1.8 \
-    --hash=sha256:8db1c8ceed4f6e86d54484e40709ad5f684a2f780308ba7a5e3850be9fb5961a
+types-pyyaml==5.4.1 \
+    --hash=sha256:88c0c5bcb2656a7da25f0ed5a7cfa557edb8191a7f7a71b3aaabd799792c5321
     # via -r requirements/dev.in
 typing-extensions==3.10.0.0 \
     --hash=sha256:0ac0f89795dd19de6b97debb0c6af1c70987fd80a2d62d1958f7e56fcc31b497 \

--- a/requirements/main.txt
+++ b/requirements/main.txt
@@ -275,9 +275,9 @@ hiredis==2.0.0 \
     --hash=sha256:f52010e0a44e3d8530437e7da38d11fb822acfb0d5b12e9cd5ba655509937ca0 \
     --hash=sha256:f8196f739092a78e4f6b1b2172679ed3343c39c61a3e9d722ce6fcf1dac2824a
     # via aioredis
-httpcore==0.13.4 \
-    --hash=sha256:38e09649bb3906c913a2917c4eb3e3b3e11c83d4edebad8b53b7d757abc49267 \
-    --hash=sha256:9fa4c623bb9d2280c009c34658cc6315e4fd425a395145645bee205d827263e4
+httpcore==0.13.6 \
+    --hash=sha256:b0d16f0012ec88d8cc848f5a55f8a03158405f4bca02ee49bc4ca2c1fda49f3e \
+    --hash=sha256:db4c0dcb8323494d01b8c6d812d80091a31e520033e7b0120883d6f52da649ff
     # via httpx
 httptools==0.2.0 \
     --hash=sha256:01b392a166adcc8bc2f526a939a8aabf89fe079243e1543fd0e7dc1b58d737cb \

--- a/src/gafaelfawr/storage/token.py
+++ b/src/gafaelfawr/storage/token.py
@@ -254,7 +254,11 @@ class TokenDatabaseStore:
             tokens = (
                 self._session.query(SQLToken)
                 .filter_by(username=username)
-                .order_by(SQLToken.token)
+                .order_by(
+                    SQLToken.last_used.desc(),
+                    SQLToken.created.desc(),
+                    SQLToken.token,
+                )
             )
         else:
             tokens = self._session.query(SQLToken).order_by(SQLToken.token)

--- a/tests/pages/tokens.py
+++ b/tests/pages/tokens.py
@@ -62,6 +62,10 @@ class NewTokenModal(BaseModal):
 
 class TokenRow(BaseElement):
     @property
+    def expires(self) -> str:
+        return self.find_element_by_class_name("qa-expires").text
+
+    @property
     def name(self) -> str:
         return self.find_element_by_class_name("qa-token-name").text
 
@@ -79,6 +83,10 @@ class TokenRow(BaseElement):
 
 
 class TokenDataPage(BasePage):
+    @property
+    def expires(self) -> str:
+        return self.find_element_by_class_name("qa-expires").text
+
     @property
     def scopes(self) -> str:
         return self._data.find_element_by_class_name("qa-scopes").text
@@ -106,6 +114,10 @@ class TokenChangeRow(BaseElement):
     @property
     def action(self) -> str:
         return self.find_element_by_class_name("qa-action").text
+
+    @property
+    def expires(self) -> str:
+        return self.find_element_by_class_name("qa-expires").text
 
     @property
     def scopes(self) -> str:

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -4246,6 +4246,7 @@
       "dependencies": {
         "anymatch": "~3.1.1",
         "braces": "~3.0.2",
+        "fsevents": "~2.3.1",
         "glob-parent": "~5.1.0",
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",
@@ -11388,6 +11389,9 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+      "dependencies": {
+        "graceful-fs": "^4.1.6"
+      },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
@@ -16521,6 +16525,7 @@
         "async-cache": "^1.1.0",
         "bl": "^4.0.0",
         "fd": "~0.0.2",
+        "graceful-fs": "^4.2.3",
         "mime": "^2.4.4",
         "negotiator": "~0.6.2"
       },
@@ -18555,6 +18560,7 @@
         "anymatch": "^2.0.0",
         "async-each": "^1.0.1",
         "braces": "^2.3.2",
+        "fsevents": "^1.2.7",
         "glob-parent": "^3.1.0",
         "inherits": "^2.0.3",
         "is-binary-path": "^1.0.0",

--- a/ui/src/components/timestamp.js
+++ b/ui/src/components/timestamp.js
@@ -3,18 +3,30 @@ import fromUnixTime from 'date-fns/fromUnixTime';
 import PropTypes from 'prop-types';
 import React from 'react';
 
-export default function Timestamp({ timestamp, past }) {
-  if (!timestamp) return <em>never</em>;
+export default function Timestamp({
+  timestamp,
+  expiration = false,
+  className = undefined,
+}) {
+  if (!timestamp) return <em className={className}>never</em>;
   const date = fromUnixTime(timestamp);
-  const relative = formatDistanceToNow(date, { addSuffix: past });
   const absolute = date.toISOString().replace(/\.0+Z$/, 'Z');
+  if (expiration && date < new Date()) {
+    return (
+      <time title={absolute} dateTime={absolute} className={className}>
+        expired
+      </time>
+    );
+  }
+  const relative = formatDistanceToNow(date, { addSuffix: !expiration });
   return (
-    <time title={absolute} dateTime={absolute}>
+    <time title={absolute} dateTime={absolute} className={className}>
       {relative}
     </time>
   );
 }
 Timestamp.propTypes = {
   timestamp: PropTypes.number.isRequired,
-  past: PropTypes.bool.isRequired,
+  expiration: PropTypes.bool,
+  className: PropTypes.string,
 };

--- a/ui/src/components/tokenChangeTable.js
+++ b/ui/src/components/tokenChangeTable.js
@@ -11,7 +11,7 @@ export default function TokenChangeTable({ data }) {
       {
         Header: 'Event Time',
         // eslint-disable-next-line react/display-name, react/prop-types
-        Cell: ({ value }) => <Timestamp timestamp={value} past />,
+        Cell: ({ value }) => <Timestamp timestamp={value} />,
         accessor: 'event_time',
       },
       {
@@ -63,13 +63,15 @@ export default function TokenChangeTable({ data }) {
       {
         Header: 'Expires',
         // eslint-disable-next-line react/display-name, react/prop-types
-        Cell: ({ value }) => <Timestamp timestamp={value} past={false} />,
+        Cell: ({ value }) => (
+          <Timestamp timestamp={value} className="qa-expires" expiration />
+        ),
         accessor: 'expires',
       },
       {
         Header: 'Old Expires',
         // eslint-disable-next-line react/display-name, react/prop-types
-        Cell: ({ value }) => <Timestamp timestamp={value} past={false} />,
+        Cell: ({ value }) => <Timestamp timestamp={value} expiration />,
         accessor: 'old_expires',
       },
     ],

--- a/ui/src/components/tokenData.js
+++ b/ui/src/components/tokenData.js
@@ -79,19 +79,23 @@ export default function TokenData({ token }) {
           <tr>
             <th scope="row">Created</th>
             <td>
-              <Timestamp timestamp={tokenData.created} past />
+              <Timestamp timestamp={tokenData.created} />
             </td>
           </tr>
           <tr>
             <th scope="row">Last Used</th>
             <td>
-              <Timestamp timestamp={tokenData.last_used} past />
+              <Timestamp timestamp={tokenData.last_used} />
             </td>
           </tr>
           <tr>
             <th scope="row">Expires</th>
             <td>
-              <Timestamp timestamp={tokenData.expires} past={false} />
+              <Timestamp
+                timestamp={tokenData.expires}
+                className="qa-expires"
+                expiration
+              />
             </td>
           </tr>
         </tbody>

--- a/ui/src/components/tokenTable.js
+++ b/ui/src/components/tokenTable.js
@@ -62,13 +62,15 @@ export default function TokenTable({
       {
         Header: 'Created',
         // eslint-disable-next-line react/display-name, react/prop-types
-        Cell: ({ value }) => <Timestamp timestamp={value} past />,
+        Cell: ({ value }) => <Timestamp timestamp={value} />,
         accessor: 'created',
       },
       {
         Header: 'Expires',
         // eslint-disable-next-line react/display-name, react/prop-types
-        Cell: ({ value }) => <Timestamp timestamp={value} past={false} />,
+        Cell: ({ value }) => (
+          <Timestamp timestamp={value} className="qa-expires" expiration />
+        ),
         accessor: 'expires',
       },
     ];


### PR DESCRIPTION
In the UI, display expiration times of expired tokens as "expired"
instead of the delta from the current time.

Sort token lists by lats used (not yet populated), created, and
then alphabetically by token, since this will be more useful.

Reset the database before starting a Selenium test for more
reliable testing with persistent PostgreSQL.

Add an expired session token to the Selenium tests and add a test
for the new expires display behavior.