### PR TITLE
[DM-30907] Fix version in built Docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,8 +1,6 @@
 # Some additional things to ignore beyond what .gitignore already handles.
 # We cannot exclude the .git directory because setuptools_scm requires it.
-docs/
-examples/
-tests/
+ui/.cache/
 ui/node_modules/
 
 # Everything below this point is a copy of .gitignore.

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -129,6 +129,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
       # Reuse the built UI from the ui job.
       - name: Restore UI artifact

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,8 +48,8 @@ FROM dependencies-image AS install-image
 ENV PATH="/opt/venv/bin:$PATH"
 
 # Install the Gafaelfawr Python application.
-COPY . /app
-WORKDIR /app
+COPY . /workdir
+WORKDIR /workdir
 RUN pip install --no-cache-dir .
 
 FROM base-image AS runtime-image


### PR DESCRIPTION
setuptools_scm was generating a development version for the
Gafaelfawr installed in the Docker image instead of a proper
version based on version tags.  Fix this by not excluding
checked-in directories via .dockerignore (since they show up as
local modifications), not using /app as a working directory, and
checking out the tags when building Docker images.