### PR TITLE
[DM-30971] Support pagination of GitHub team results

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ Change log
 3.0.4 (unreleased)
 ==================
 
+- Correctly handle paginated replies from GitHub for the team membership of a user.
 - Depend on Safir 2.x and drop remaining aiohttp dependency paths.
   Remove code that is now supplied by Safir.
   Share one ``httpx.AsyncClient`` across all requests and close it when the application is shut down.

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -44,6 +44,8 @@ API reference
 
 .. automodapi:: gafaelfawr.models.influxdb
 
+.. automodapi:: gafaelfawr.models.link
+
 .. automodapi:: gafaelfawr.models.oidc
 
 .. automodapi:: gafaelfawr.models.state

--- a/src/gafaelfawr/models/link.py
+++ b/src/gafaelfawr/models/link.py
@@ -1,0 +1,46 @@
+"""Representation for a ``Link`` HTTP header."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing import Optional
+
+__all__ = ["LinkData"]
+
+_LINK_REGEX = r' *<(?P<target>[^>]+)>; rel="(?P<type>[^"]+)"'
+"""Matches a component of a valid ``Link`` header."""
+
+
+@dataclass
+class LinkData:
+    """Holds the data returned in an RFC 8288 ``Link`` header."""
+
+    prev_url: Optional[str]
+    """The URL of the previous page, or `None` for the first page."""
+
+    next_url: Optional[str]
+    """The URL of the next page, or `None` for the last page."""
+
+    first_url: Optional[str]
+    """The URL of the first page."""
+
+    @classmethod
+    def from_header(cls, header: Optional[str]) -> LinkData:
+        """Parse an RFC 8288 ``Link`` with pagination URLs."""
+        links = {}
+        if header:
+            elements = header.split(",")
+            for element in elements:
+                match = re.match(_LINK_REGEX, element)
+                if match and match.group("type") in ("prev", "next", "first"):
+                    links[match.group("type")] = match.group("target")
+
+        return cls(
+            prev_url=links.get("prev"),
+            next_url=links.get("next"),
+            first_url=links.get("first"),
+        )

--- a/tests/handlers/api_history_test.py
+++ b/tests/handlers/api_history_test.py
@@ -11,6 +11,7 @@ from urllib.parse import urlencode
 import pytest
 
 from gafaelfawr.models.history import TokenChangeHistoryEntry
+from gafaelfawr.models.link import LinkData
 from gafaelfawr.models.token import (
     AdminTokenRequest,
     TokenData,
@@ -20,7 +21,6 @@ from gafaelfawr.models.token import (
 from gafaelfawr.schema import TokenChangeHistory
 from gafaelfawr.util import current_datetime
 from tests.support.constants import TEST_HOSTNAME
-from tests.support.headers import LinkData
 
 if TYPE_CHECKING:
     from typing import Any, Callable, Dict, List, Optional, Union

--- a/tests/support/headers.py
+++ b/tests/support/headers.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import re
-from dataclasses import dataclass
 from typing import TYPE_CHECKING
 from urllib.parse import parse_qs, urlparse
 
@@ -15,38 +14,7 @@ from gafaelfawr.auth import (
 )
 
 if TYPE_CHECKING:
-    from typing import Dict, List, Optional
-
-
-@dataclass
-class LinkData:
-    """Holds the data returned in an RFC 8288 ``Link`` header."""
-
-    prev_url: Optional[str]
-    """The URL of the previous page, or `None` for the first page."""
-
-    next_url: Optional[str]
-    """The URL of the next page, or `None` for the last page."""
-
-    first_url: str
-    """The URL of the first page."""
-
-    @classmethod
-    def from_header(cls, header: str) -> LinkData:
-        """Parse an RFC 8288 ``Link`` with pagination URLs."""
-        elements = header.split(",")
-        links = {}
-        for element in elements:
-            match = re.match(' *<([^>]+)>; rel="([^"]+)"', element)
-            assert match, f"Unable to parse Link {element}"
-            assert match.group(2) in ("prev", "next", "first")
-            links[match.group(2)] = match.group(1)
-
-        return cls(
-            prev_url=links.get("prev"),
-            next_url=links.get("next"),
-            first_url=links["first"],
-        )
+    from typing import Dict, List
 
 
 def parse_www_authenticate(header: str) -> AuthChallenge:


### PR DESCRIPTION
GitHub paginates the list of teams a user is a member of at 30
teams, and some people have considerably more teams than that.
Add support for pagination and retrieve the full list of teams.
Log all of the information we got from GitHub at debug logging
level.