### PR TITLE
[DM-27980] Revoke GitHub OAuth grant on logout

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,7 @@ Change log
 - Depend on Safir 2.x and drop remaining aiohttp dependency paths.
   Remove code that is now supplied by Safir.
   Share one ``httpx.AsyncClient`` across all requests and close it when the application is shut down.
+- Fix sorting of tokens retrieved from the admin API to sort by created date before token string.
 
 3.0.3 (2021-06-17)
 ==================

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,10 +2,12 @@
 Change log
 ##########
 
-3.0.4 (unreleased)
+3.1.0 (unreleased)
 ==================
 
 - Correctly handle paginated replies from GitHub for the team membership of a user.
+- On explicit logout (via ``/logout``), revoke the OAuth authorization for the user if they authenticated with GitHub.
+  This forces a re-release of attributes on subsequent authentication, which will make it easier for users to resolve problems with incorrect attribute releases (if, for instance, they attempted to log in before their team membership was complete).
 - Depend on Safir 2.x and drop remaining aiohttp dependency paths.
   Remove code that is now supplied by Safir.
   Share one ``httpx.AsyncClient`` across all requests and close it when the application is shut down.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,7 +2,7 @@
 Change log
 ##########
 
-3.1.0 (unreleased)
+3.1.0 (2021-07-06)
 ==================
 
 - Correctly handle paginated replies from GitHub for the team membership of a user.

--- a/src/gafaelfawr/factory.py
+++ b/src/gafaelfawr/factory.py
@@ -164,8 +164,7 @@ class ComponentFactory:
         """Create an authentication provider.
 
         Create a provider object for the configured external authentication
-        provider.  Takes the incoming request to get access to the per-request
-        logger and the client HTTP session.
+        provider.
 
         Returns
         -------

--- a/src/gafaelfawr/handlers/login.py
+++ b/src/gafaelfawr/handlers/login.py
@@ -199,7 +199,9 @@ async def handle_provider_return(
     # reply from the authentication provider.
     auth_provider = context.factory.create_provider()
     try:
-        user_info = await auth_provider.create_user_info(code, state)
+        user_info = await auth_provider.create_user_info(
+            code, state, context.state
+        )
     except ProviderException as e:
         context.logger.warning("Provider authentication failed", error=str(e))
         raise HTTPException(

--- a/src/gafaelfawr/handlers/logout.py
+++ b/src/gafaelfawr/handlers/logout.py
@@ -31,8 +31,13 @@ async def get_logout(
 
     The user is redirected to the URL given in the rd parameter, if any, and
     otherwise to the after_logout_url configuration setting.
+
+    If the user was logged in via GitHub (and Gafaelfawr is still configured
+    to use GitHub), the GitHub OAuth authorization grant is also revoked.
     """
     if context.state.token:
+        auth_provider = context.factory.create_provider()
+        await auth_provider.logout(context.state)
         context.logger.info("Successful logout")
     else:
         context.logger.info("Logout of already-logged-out session")

--- a/src/gafaelfawr/models/state.py
+++ b/src/gafaelfawr/models/state.py
@@ -36,6 +36,9 @@ class State(BaseState):
     token: Optional[Token] = None
     """Token if the user is authenticated."""
 
+    github: Optional[str] = None
+    """GitHub OAuth token if user authenticated via GitHub."""
+
     return_url: Optional[str] = None
     """Destination URL after completion of login."""
 
@@ -77,6 +80,7 @@ class State(BaseState):
         return cls(
             csrf=data.get("csrf"),
             token=token,
+            github=data.get("github"),
             return_url=data.get("return_url"),
             state=data.get("state"),
         )
@@ -94,6 +98,8 @@ class State(BaseState):
             data["csrf"] = self.csrf
         if self.token:
             data["token"] = str(self.token)
+        if self.github:
+            data["github"] = self.github
         if self.return_url:
             data["return_url"] = self.return_url
         if self.state:

--- a/src/gafaelfawr/providers/base.py
+++ b/src/gafaelfawr/providers/base.py
@@ -6,6 +6,7 @@ from abc import ABCMeta, abstractmethod
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from gafaelfawr.models.state import State
     from gafaelfawr.models.token import TokenUserInfo
 
 __all__ = ["Provider"]
@@ -30,7 +31,9 @@ class Provider(metaclass=ABCMeta):
         """
 
     @abstractmethod
-    async def create_user_info(self, code: str, state: str) -> TokenUserInfo:
+    async def create_user_info(
+        self, code: str, state: str, session: State
+    ) -> TokenUserInfo:
         """Given the code from an authentication, create the user information.
 
         Parameters
@@ -39,6 +42,9 @@ class Provider(metaclass=ABCMeta):
             Code returned by a successful authentication.
         state : `str`
             The same random string used for the redirect URL.
+        session : `gafaelfawr.models.state.State`
+            The session state.  The provider may also store data used during
+            logout.
 
         Returns
         -------
@@ -52,4 +58,17 @@ class Provider(metaclass=ABCMeta):
             provider.
         gafaelfawr.exceptions.ProviderException
             The provider responded with an error to a request.
+        """
+
+    @abstractmethod
+    async def logout(self, session: State) -> None:
+        """Called during user logout.
+
+        The authentication provider may revoke the upstream authentication
+        token or take other action during user logout.
+
+        Parameters
+        ----------
+        session : `gafaelfawr.models.state.State`
+            The session state before logout.
         """

--- a/src/gafaelfawr/providers/oidc.py
+++ b/src/gafaelfawr/providers/oidc.py
@@ -18,6 +18,7 @@ if TYPE_CHECKING:
     from structlog.stdlib import BoundLogger
 
     from gafaelfawr.config import OIDCConfig
+    from gafaelfawr.models.state import State
     from gafaelfawr.verify import TokenVerifier
 
 __all__ = ["OIDCProvider"]
@@ -79,7 +80,9 @@ class OIDCProvider(Provider):
         )
         return f"{self._config.login_url}?{urlencode(params)}"
 
-    async def create_user_info(self, code: str, state: str) -> TokenUserInfo:
+    async def create_user_info(
+        self, code: str, state: str, session: State
+    ) -> TokenUserInfo:
         """Given the code from a successful authentication, get a token.
 
         Parameters
@@ -87,7 +90,9 @@ class OIDCProvider(Provider):
         code : `str`
             Code returned by a successful authentication.
         state : `str`
-            The same random string used for the redirect URL.
+            The same random string used for the redirect URL, not used.
+        session : `gafaelfawr.models.state.State`
+            The session state, not used by this provider.
 
         Returns
         -------
@@ -173,3 +178,15 @@ class OIDCProvider(Provider):
             uid=token.uid,
             groups=groups,
         )
+
+    async def logout(self, session: State) -> None:
+        """User logout callback.
+
+        Currently, this does nothing.
+
+        Parameters
+        ----------
+        session : `gafaelfawr.models.state.State`
+            The session state, which contains the GitHub access token.
+        """
+        pass

--- a/src/gafaelfawr/storage/token.py
+++ b/src/gafaelfawr/storage/token.py
@@ -252,18 +252,14 @@ class TokenDatabaseStore:
         tokens : List[`gafaelfawr.models.token.TokenInfo`]
             Information about the tokens.
         """
+        tokens = self._session.query(SQLToken)
         if username:
-            tokens = (
-                self._session.query(SQLToken)
-                .filter_by(username=username)
-                .order_by(
-                    SQLToken.last_used.desc(),
-                    SQLToken.created.desc(),
-                    SQLToken.token,
-                )
-            )
-        else:
-            tokens = self._session.query(SQLToken).order_by(SQLToken.token)
+            tokens = tokens.filter_by(username=username)
+        tokens = tokens.order_by(
+            SQLToken.last_used.desc(),
+            SQLToken.created.desc(),
+            SQLToken.token,
+        )
         return [TokenInfo.from_orm(t) for t in tokens]
 
     def modify(


### PR DESCRIPTION
During the first authentication from GitHub, the user chooses what
data to release to our application.  We have had persistent problems
where the user doesn't release the right data or they are not a
member of the correct organization when they first log on, and then
logging out and back in doesn't necessarily update what information
we can access via the GitHub access token.

On explicit logout, if the user logged on with GitHub, revoke the
OAuth authorization grant so that they're forced to go through the
permission screen again when they log in.  This should hopefully
avoid this issue at the cost of an extra screen when they return
after an explicit logout.