### PR TITLE
[DM-32899] Fix database schema initialization

### DIFF
--- a/src/gafaelfawr/cli.py
+++ b/src/gafaelfawr/cli.py
@@ -99,7 +99,7 @@ async def init(settings: Optional[str]) -> None:
     if settings:
         config_dependency.set_settings_path(settings)
     config = await config_dependency()
-    initialize_database(config)
+    await initialize_database(config)
 
 
 @main.command()


### PR DESCRIPTION
Add missing await to gafaelfawr init, which was causing the database
schema to not be initialized.  Add a test for this.