### PR TITLE
[DM-33662] Use more explicit database transactions in tests

### DIFF
--- a/tests/handlers/analyze_test.py
+++ b/tests/handlers/analyze_test.py
@@ -119,14 +119,15 @@ async def test_analyze_token(
     token_data.uid = None
     token_data.groups = None
     token_service = factory.create_token_service()
-    user_token = await token_service.create_user_token(
-        token_data,
-        token_data.username,
-        token_name="foo",
-        scopes=[],
-        expires=None,
-        ip_address="127.0.0.1",
-    )
+    async with factory.session.begin():
+        user_token = await token_service.create_user_token(
+            token_data,
+            token_data.username,
+            token_name="foo",
+            scopes=[],
+            expires=None,
+            ip_address="127.0.0.1",
+        )
     user_token_data = await token_service.get_data(user_token)
     assert user_token_data
 

--- a/tests/services/token_cache_test.py
+++ b/tests/services/token_cache_test.py
@@ -85,12 +85,13 @@ async def test_invalid(factory: ComponentFactory) -> None:
     )
     token_cache.store_notebook_token(notebook_token, token_data)
 
-    assert internal_token != await token_cache.get_internal_token(
-        token_data, "some-service", ["read:all"], "127.0.0.1"
-    )
-    assert notebook_token != await token_cache.get_notebook_token(
-        token_data, "127.0.0.1"
-    )
+    async with factory.session.begin():
+        assert internal_token != await token_cache.get_internal_token(
+            token_data, "some-service", ["read:all"], "127.0.0.1"
+        )
+        assert notebook_token != await token_cache.get_notebook_token(
+            token_data, "127.0.0.1"
+        )
 
 
 @pytest.mark.asyncio

--- a/tests/services/token_test.py
+++ b/tests/services/token_test.py
@@ -604,14 +604,15 @@ async def test_child_token_lifetime(
 
     # Get an internal and notebook token again.  We should get the same ones
     # as last time.
-    new_internal_token = await token_service.get_internal_token(
-        user_token_data, service="a", scopes=[], ip_address="127.0.0.1"
-    )
-    assert new_internal_token == internal_token
-    new_notebook_token = await token_service.get_notebook_token(
-        user_token_data, ip_address="127.0.0.1"
-    )
-    assert new_notebook_token == notebook_token
+    async with factory.session.begin():
+        new_internal_token = await token_service.get_internal_token(
+            user_token_data, service="a", scopes=[], ip_address="127.0.0.1"
+        )
+        assert new_internal_token == internal_token
+        new_notebook_token = await token_service.get_notebook_token(
+            user_token_data, ip_address="127.0.0.1"
+        )
+        assert new_notebook_token == notebook_token
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
A few tests were performing database operations outside of a
transaction, which was blocking use of an async_scoped_session
for Gafaelfawr since the test would then not shut down properly.
Add explicit transactions for those database operations.