### PR TITLE
[DM-33698] Optimize PostgreSQL for tests

### DIFF
--- a/tests/support/postgresql.conf
+++ b/tests/support/postgresql.conf
@@ -1,0 +1,11 @@
+# Custom PostgreSQL configuration file for tests.
+#
+# This file is bind-mounted into the postgres container by tox-docker when
+# running tests.  It disables safety measures in the database storage so that
+# tests will run faster.  This reduces the time it takes to execute the test
+# suite by about 10%.
+
+listen_addresses = '*'
+fsync = off
+synchronous_commit = off
+full_page_writes = off

--- a/tox.ini
+++ b/tox.ini
@@ -21,6 +21,8 @@ healthcheck_timeout = 1
 healthcheck_retries = 30
 healthcheck_interval = 1
 healthcheck_start_period = 1
+volumes =
+    bind:ro:{toxinidir}/tests/support/postgresql.conf:/etc/postgresql/postgresql.conf
 
 [docker:redis]
 image = redis:latest


### PR DESCRIPTION
Bind-mount a PostgreSQL configuration into the container used for
testing to disable syncing and otherwise try to make PostgreSQL
run a little faster.  This only seems to save about 10%, but every
little bit helps.