### PR TITLE
[DM-33718] Refactor LDAP handling

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,13 @@
 Change log
 ##########
 
+3.6.0 (unreleased)
+==================
+
+- Add support for retrieving the user's numeric UID from LDAP when authenticating with an OpenID Connect provider.
+- Add required dependency for LDAP support to the Docker image.
+- Update dependencies.
+
 3.5.1 (2022-01-14)
 ==================
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -78,6 +78,8 @@ API reference
 
 .. automodapi:: gafaelfawr.storage.kubernetes
 
+.. automodapi:: gafaelfawr.storage.ldap
+
 .. automodapi:: gafaelfawr.storage.oidc
 
 .. automodapi:: gafaelfawr.storage.token

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -61,6 +61,7 @@ default_role = "py:obj"
 
 intersphinx_mapping = {
     "aioredis": ("https://aioredis.readthedocs.io/en/stable/", None),
+    "bonsai": ("https://bonsai.readthedocs.io/en/latest/", None),
     "cryptography": ("https://cryptography.io/en/latest/", None),
     "jwt": ("https://pyjwt.readthedocs.io/en/latest/", None),
     "python": ("https://docs.python.org/3/", None),

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -274,8 +274,6 @@ There is one additional option under ``config.oidc`` that you may want to set:
     A mapping of additional parameters to send to the login route.
     Can be used to set additional configuration options for some OpenID Connect providers.
 
-.. _scopes:
-
 LDAP groups
 -----------
 
@@ -297,12 +295,34 @@ You may need to set the following additional options under ``config.ldap`` depen
     The object class from which group information should be looked up.
     Default: ``posixGroup``.
 
-``config.ldap.groupMember``
+``config.ldap.groupMemberAttr``
     The member attribute of that object class.
     The values must match the username returned in the token from the OpenID Connect authentication server.
     Default: ``member``.
 
 The name of each group will be taken from the ``cn`` attribute and the numeric UID will be taken from the ``gidNumber`` attribute.
+
+LDAP numeric UID
+----------------
+
+By default, Gafaelfawr takes the user's numeric UID from the upstream provider via the ``uidNumber`` claim in the ID token.
+If LDAP is used for group information, the numeric UID can also be obtained from LDAP.
+To do this, add the following configuration:
+
+.. code-block:: yaml
+
+   config:
+     ldap:
+       uidBaseDn: "<base-dn-for-search>"
+
+The user object will be located by searching for a ``uid`` attribute equal to the username returned in the token from the OpenID Connect authentication server.
+By default, the numeric UID will be the first value of the ``uidNumber`` attribute of that object.
+You can override the attribute containing the UID number with:
+
+``config.ldap.uidAttr``
+    The attribute containing the numeric UID of a user.
+
+.. _scopes:
 
 Scopes
 ------

--- a/src/gafaelfawr/config.py
+++ b/src/gafaelfawr/config.py
@@ -140,17 +140,8 @@ class LDAPSettings(BaseModel):
     supported.
     """
 
-    uid_number_attr: Optional[str] = None
-    """LDAP uid attribute.
-
-    Default None to not use LDAP to determine the uid number of user and
-    instead to use the uid number from the token (if present).
-    Usually ``uidNumber``, , as specified in :rfc:`2307` and `RFC 2307bis
-    <https://datatracker.ietf.org/doc/html/draft-howard-rfc2307bis-02>`__.
-    """
-
     base_dn: str
-    """Base DN to use when executing LDAP search."""
+    """Base DN to use when executing an LDAP search for user groups."""
 
     group_object_class: str = "posixGroup"
     """LDAP group object class.
@@ -159,10 +150,25 @@ class LDAPSettings(BaseModel):
     <https://datatracker.ietf.org/doc/html/draft-howard-rfc2307bis-02>`__.
     """
 
-    group_member: str = "member"
+    group_member_attr: str = "member"
     """LDAP group member attribute.
 
     ``memberuid`` in :rfc:`2307` and ``member`` in `RFC 2307bis
+    <https://datatracker.ietf.org/doc/html/draft-howard-rfc2307bis-02>`__.
+    """
+
+    uid_base_dn: Optional[str] = None
+    """Base DN to use when executing an LDAP search for a UID number.
+
+    If this is not set, the UID number of the user will be taken from the
+    upstream authentication source (either the GitHub UID number or the
+    configured attribute of the OpenID Connect ID token.
+    """
+
+    uid_attr: str = "uidNumber"
+    """LDAP uid attribute, used if ``uid_base_dn`` is set.
+
+    Usually ``uidNumber``, as specified in :rfc:`2307` and `RFC 2307bis
     <https://datatracker.ietf.org/doc/html/draft-howard-rfc2307bis-02>`__.
     """
 
@@ -478,14 +484,6 @@ class LDAPConfig:
     base_dn: str
     """Base DN to use when executing LDAP search."""
 
-    uid_number_attr: Optional[str] = None
-    """LDAP attribute name for userid number
-
-    If set, this will override the uid number as defined in the token.
-    Usually ``uidNumber``, as specified in :rfc:`2307` and `RFC 2307bis
-    <https://datatracker.ietf.org/doc/html/draft-howard-rfc2307bis-02>`__.
-    """
-
     group_object_class: str = "posixGroup"
     """LDAP group object class.
 
@@ -493,10 +491,25 @@ class LDAPConfig:
     <https://datatracker.ietf.org/doc/html/draft-howard-rfc2307bis-02>`__.
     """
 
-    group_member: str = "member"
+    group_member_attr: str = "member"
     """LDAP group member attribute.
 
     ``memberuid`` in :rfc:`2307` and ``member`` in `RFC 2307bis
+    <https://datatracker.ietf.org/doc/html/draft-howard-rfc2307bis-02>`__.
+    """
+
+    uid_base_dn: Optional[str] = None
+    """Base DN to use when executing an LDAP search for a UID number.
+
+    If this is not set, the UID number of the user will be taken from the
+    upstream authentication source (either the GitHub UID number or the
+    configured attribute of the OpenID Connect ID token.
+    """
+
+    uid_attr: str = "uidNumber"
+    """LDAP uid attribute, used if ``uid_base_dn`` is set.
+
+    Usually ``uidNumber``, as specified in :rfc:`2307` and `RFC 2307bis
     <https://datatracker.ietf.org/doc/html/draft-howard-rfc2307bis-02>`__.
     """
 
@@ -779,10 +792,11 @@ class Config:
         if settings.ldap and settings.ldap.url:
             ldap_config = LDAPConfig(
                 url=settings.ldap.url,
-                uid_number_attr=settings.ldap.uid_number_attr,
                 base_dn=settings.ldap.base_dn,
                 group_object_class=settings.ldap.group_object_class,
-                group_member=settings.ldap.group_member,
+                group_member_attr=settings.ldap.group_member_attr,
+                uid_base_dn=settings.ldap.uid_base_dn,
+                uid_attr=settings.ldap.uid_attr,
             )
         log_level = os.getenv("SAFIR_LOG_LEVEL", settings.loglevel)
         config = cls(

--- a/src/gafaelfawr/factory.py
+++ b/src/gafaelfawr/factory.py
@@ -31,6 +31,7 @@ from .storage.admin import AdminStore
 from .storage.base import RedisStorage
 from .storage.history import AdminHistoryStore, TokenChangeHistoryStore
 from .storage.kubernetes import KubernetesStorage
+from .storage.ldap import LDAPStorage
 from .storage.oidc import OIDCAuthorization, OIDCAuthorizationStore
 from .storage.token import TokenDatabaseStore, TokenRedisStore
 from .verify import TokenVerifier
@@ -201,9 +202,12 @@ class ComponentFactory:
             )
         elif self._config.oidc:
             token_verifier = self.create_token_verifier()
+            ldap_storage = None
+            if self._config.ldap:
+                ldap_storage = LDAPStorage(self._config.ldap, self._logger)
             return OIDCProvider(
                 config=self._config.oidc,
-                ldap_config=self._config.ldap,
+                ldap_storage=ldap_storage,
                 verifier=token_verifier,
                 http_client=self._http_client,
                 logger=self._logger,

--- a/src/gafaelfawr/models/oidc.py
+++ b/src/gafaelfawr/models/oidc.py
@@ -152,11 +152,6 @@ class OIDCVerifiedToken(OIDCToken):
 
     username: str = Field(..., title="The value of the username claim")
 
-    uid: Optional[int] = Field(
-        None,
-        title="The value of the claim named by the uid_claim config setting",
-    )
-
     jti: Optional[str] = Field(
         None, title="The jti (JWT ID) claim from the token"
     )

--- a/src/gafaelfawr/providers/oidc.py
+++ b/src/gafaelfawr/providers/oidc.py
@@ -157,8 +157,9 @@ class OIDCProvider(Provider):
             token = await self._verifier.verify_oidc_token(unverified_token)
             uid = None
             if self._ldap_storage:
-                uid = await self._ldap_storage.get_uid(token.username)
-                groups = await self._ldap_storage.get_groups(token.username)
+                async with self._ldap_storage.connect() as conn:
+                    uid = await conn.get_uid(token.username)
+                    groups = await conn.get_groups(token.username)
             else:
                 groups = self._verifier.get_groups_from_token(token)
             if not uid:

--- a/src/gafaelfawr/providers/oidc.py
+++ b/src/gafaelfawr/providers/oidc.py
@@ -153,7 +153,7 @@ class OIDCProvider(Provider):
 
         # If self._ldap_config.uid_number_attr is None, then assume we want
         # the uid from the token.  Otherwise, get it from LDAP.
-        uid_from_ldap = self._ldap_config and self._ldap_config.uid_number_attr
+        uid_from_ldap = self._ldap_config and self._ldap_config.uid_base_dn
         try:
             token = await self._verifier.verify_oidc_token(
                 unverified_token, verify_uid=not uid_from_ldap
@@ -229,13 +229,13 @@ class OIDCProvider(Provider):
             not valid (attribute not in LDAP or result value not an integer).
         """
         assert self._ldap_config
-        attr = self._ldap_config.uid_number_attr
+        attr = self._ldap_config.uid_attr
         search = f"(&(uid={username}))"
 
         self._logger.debug(
             "Querying LDAP for UID number",
             ldap_url=self._ldap_config.url,
-            ldap_base=self._ldap_config.base_dn,
+            ldap_base=self._ldap_config.uid_base_dn,
             ldap_search=search,
         )
 
@@ -284,7 +284,7 @@ class OIDCProvider(Provider):
         """
         assert self._ldap_config
         group_class = self._ldap_config.group_object_class
-        member_attr = self._ldap_config.group_member
+        member_attr = self._ldap_config.group_member_attr
         search = f"(&(objectClass={group_class})({member_attr}={username}))"
 
         self._logger.debug(

--- a/src/gafaelfawr/storage/ldap.py
+++ b/src/gafaelfawr/storage/ldap.py
@@ -1,0 +1,175 @@
+"""LDAP storage layer for Gafaelfawr."""
+
+from __future__ import annotations
+
+from typing import List, Optional
+
+import bonsai
+from structlog.stdlib import BoundLogger
+
+from ..config import LDAPConfig
+from ..exceptions import LDAPException
+from ..models.token import TokenGroup
+
+__all__ = ["LDAPStorage"]
+
+
+class LDAPStorage:
+    """LDAP storage layer.
+
+    This abstracts retrieving authorization information and user metadata from
+    LDAP.
+
+    Parameters
+    ----------
+    config : `gafaelfawr.config.LDAPConfig`
+        Configuration for LDAP searches.
+    logger : `structlog.stdlib.BoundLogger`
+        Logger for debug messages and errors.
+
+    Notes
+    -----
+    Currently, a new LDAP connection is opened for each LDAP search.  This is
+    not ideal; ideally, LDAP searches should use a managed connection pool or
+    otherwise maintain open connections.  However, it's unclear how bonsai
+    handles open connections that are closed by the LDAP server due to an idle
+    timeout, and thus whether doing that would cause stability issues if the
+    LDAP search volume is low.  This will require future exploration.
+    """
+
+    def __init__(self, config: LDAPConfig, logger: BoundLogger) -> None:
+        self._config = config
+        self._client = bonsai.LDAPClient(config.url)
+        self._logger = logger.bind(
+            ldap_url=self._config.url,
+            ldap_base=self._config.uid_base_dn,
+        )
+
+    async def get_uid(self, username: str) -> Optional[int]:
+        """Get the numeric UID of a user.
+
+        Parameters
+        ----------
+        username : `str`
+            Username of the user.
+
+        Returns
+        -------
+        uid_number : `int` or `None`
+            The numeric UID of the user from LDAP, or `None` if Gafaelfawr was
+            not configured to get the UID from LDAP (in which case the caller
+            should fall back to other sources of the UID).
+
+        Raises
+        ------
+        gafaelfawr.exceptions.LDAPException
+            The lookup of ``uid_number_attr`` in the LDAP server was not valid
+            (connection to the LDAP server failed, attribute not found in
+            LDAP, result value not an integer).
+        """
+        if not self._config.uid_base_dn:
+            return None
+
+        search = f"(&(uid={username}))"
+        self._logger.debug(
+            "Querying LDAP for UID number", ldap_search=search, user=username
+        )
+
+        try:
+            async with self._client.connect(is_async=True) as conn:
+                results = await conn.search(
+                    self._config.uid_base_dn,
+                    bonsai.LDAPSearchScope.ONE,
+                    search,
+                    attrlist=[self._config.uid_attr],
+                )
+        except bonsai.LDAPError as e:
+            self._logger.error(
+                "Cannot query LDAP for UID number",
+                error=str(e),
+                ldap_search=search,
+                user=username,
+            )
+            raise LDAPException("Error querying LDAP for UID number")
+
+        for result in results:
+            try:
+                return int(result[self._config.uid_attr][0])
+            except Exception as e:
+                self._logger.error(
+                    "LDAP UID number is invalid",
+                    error=str(e),
+                    ldap_search=search,
+                    user=username,
+                )
+                raise LDAPException("UID number in LDAP is invalid")
+
+        # Fell through without finding a UID.
+        self._logger.error(
+            "No UID found in LDAP", ldap_search=search, user=username
+        )
+        raise LDAPException("No UID found in LDAP")
+
+    async def get_groups(self, username: str) -> List[TokenGroup]:
+        """Get groups for a user from LDAP.
+
+        Parameters
+        ----------
+        username : `str`
+            Username of the user.
+
+        Returns
+        -------
+        groups : List[`gafaelfawr.models.token.TokenGroup`]
+            User's groups from LDAP.
+
+        Raises
+        ------
+        gafaelfawr.exceptions.LDAPException
+            One of the groups for the user in LDAP was not valid (missing
+            ``cn`` or ``gidNumber`` attributes, or ``gidNumber`` is not an
+            integer)
+        """
+        group_class = self._config.group_object_class
+        member_attr = self._config.group_member_attr
+        search = f"(&(objectClass={group_class})({member_attr}={username}))"
+        self._logger.debug(
+            "Querying LDAP for groups", ldap_search=search, user=username
+        )
+
+        try:
+            async with self._client.connect(is_async=True) as conn:
+                results = await conn.search(
+                    self._config.base_dn,
+                    bonsai.LDAPSearchScope.SUB,
+                    search,
+                    attrlist=["cn", "gidNumber"],
+                )
+        except bonsai.LDAPError as e:
+            self._logger.error(
+                "Cannot query LDAP for groups",
+                error=str(e),
+                ldap_search=search,
+                user=username,
+            )
+            raise LDAPException("Error querying LDAP for groups")
+
+        # Parse the results into the group list.
+        groups = []
+        for result in results:
+            try:
+                name = None
+                self._logger.debug(
+                    "LDAP group found", result=result, user=username
+                )
+                name = result["cn"][0]
+                gid = int(result["gidNumber"][0])
+                groups.append(TokenGroup(name=name, id=gid))
+            except Exception as e:
+                self._logger.warning(
+                    f"LDAP group {name} invalid, ignoring",
+                    error=str(e),
+                    ldap_search=search,
+                    user=username,
+                )
+        return groups

--- a/src/gafaelfawr/verify.py
+++ b/src/gafaelfawr/verify.py
@@ -279,7 +279,6 @@ class TokenVerifier:
             claims=claims,
             jti=claims.get("jti", "UNKNOWN"),
             username=claims[self._config.username_claim],
-            uid=None,
         )
 
     async def _get_key_as_pem(self, issuer_url: str, key_id: str) -> str:

--- a/src/gafaelfawr/verify.py
+++ b/src/gafaelfawr/verify.py
@@ -97,7 +97,7 @@ class TokenVerifier:
         token : `gafaelfawr.models.oidc.OIDCToken`
             JWT to verify.
         verify_uid : `bool`
-            Whether we should attempt to parse the uid in token
+            Whether we should attempt to parse the UID from the token.
 
         Returns
         -------
@@ -179,7 +179,6 @@ class TokenVerifier:
             self._logger.warning(msg, claims=claims)
             raise MissingClaimsException(msg)
 
-        # kwargs = {"uid": None}
         uid = None
         if verify_uid:
             if self._config.uid_claim not in claims:

--- a/tests/handlers/login_oidc_test.py
+++ b/tests/handlers/login_oidc_test.py
@@ -549,10 +549,6 @@ async def test_ldap(
     assert r.json() == {
         "username": token.username,
         "email": token.claims["email"],
-        "uid": token.uid,
+        "uid": 2000,
         "groups": [{"name": g.name, "id": g.id} for g in mock_ldap.groups],
     }
-    assert mock_ldap.query == (
-        f"(&(objectClass={config.ldap.group_object_class})"
-        f"({config.ldap.group_member}={token.username}))"
-    )

--- a/tests/settings/oidc-ldap.yaml.in
+++ b/tests/settings/oidc-ldap.yaml.in
@@ -22,7 +22,7 @@ issuer:
 ldap:
   url: "ldaps://ldap.example.com/"
   base_dn: "dc=example,dc=com"
-  uid_number_attr: "uidNumber"
+  uid_base_dn: "dc=example,dc=com"
 oidc:
   client_id: "some-oidc-client-id"
   client_secret_file: "{oidc_secret_file}"

--- a/tests/settings/oidc-ldap.yaml.in
+++ b/tests/settings/oidc-ldap.yaml.in
@@ -22,7 +22,7 @@ issuer:
 ldap:
   url: "ldaps://ldap.example.com/"
   base_dn: "dc=example,dc=com"
-  uid_number_attr: "user"
+  uid_number_attr: "uidNumber"
 oidc:
   client_id: "some-oidc-client-id"
   client_secret_file: "{oidc_secret_file}"

--- a/tests/support/ldap.py
+++ b/tests/support/ldap.py
@@ -56,8 +56,8 @@ class MockLDAP(Mock):
         )
         self.query = query
         if query == "(&(uid=some-user))":
-            assert attrlist == ["user"]
-            return [{"user": [str(1000)]}]
+            assert attrlist == ["uidNumber"]
+            return [{"uidNumber": [str(1000)]}]
         elif query == "(&(objectClass=posixGroup)(member=some-user))":
             assert attrlist == ["cn", "gidNumber"]
             return [

--- a/tests/support/ldap.py
+++ b/tests/support/ldap.py
@@ -25,7 +25,6 @@ class MockLDAP(Mock):
             TokenGroup(name="group-1", id=123123),
             TokenGroup(name="group-2", id=123442),
         ]
-        self.query: Optional[str] = None
 
     async def __aenter__(self) -> MockLDAP:
         return self
@@ -54,13 +53,13 @@ class MockLDAP(Mock):
             bonsai.LDAPSearchScope.SUB,
             bonsai.LDAPSearchScope.ONELEVEL,
         )
-        self.query = query
         if query == "(&(uid=some-user))":
             assert attrlist == ["uidNumber"]
-            return [{"uidNumber": [str(1000)]}]
+            return [{"uidNumber": [str(2000)]}]
         elif query == "(&(objectClass=posixGroup)(member=some-user))":
             assert attrlist == ["cn", "gidNumber"]
             return [
                 {"cn": [g.name], "gidNumber": [str(g.id)]} for g in self.groups
             ]
-        return [{"None": ["None"]}]
+        else:
+            assert False, f"Unexpected query {query}"


### PR DESCRIPTION
The OpenID Connect authentication provider has acquired several bits of LDAP code to retrieve user group information and the numeric UID. Both LDAP searches were done independently, the UID attribute had to be in the same base DN as the group information (some sites maintain group membership in a separate tree from user objects), and the integration with code to pull the same information from the upstream JWT tokens was awkward.

Refactor LDAP support into a separate LDAP storage layer, and maintain a cleaner separation between the OpenID Connect authentication provider and the token verification code. This is intended to achieve the following goals:

- Provide a generalized LDAP storage layer that could potentially be used with the GitHub provider if desired
- Reuse the same LDAP connection for both UID and group lookups
- Move all token analysis into the `TokenVerifier` class and simplify the OpenID Connect provider code
- Avoid setting optional parameters in the `OIDCVerifiedToken` model in favor of explicit `get_*` functions in the verifier
- Allow the UID and groups to be in separate base DNs
- Use the specification of a UID base DN to trigger use of LDAP for UIDs, allowing the attribute to have a default value
- More consistent configuration parameter naming for parameters specifying LDAP attribute names