### PR TITLE
[DM-33698] Speed up Gafaelfawr tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -119,7 +119,7 @@ jobs:
             tox-${{ matrix.python }}-${{ hashFiles('requirements/*.txt') }}-
 
       - name: Run tox
-        run: tox -e py,coverage-report,typing
+        run: tox -e typing,py-coverage,coverage-report
 
   docs:
     runs-on: ubuntu-latest

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -15,14 +15,17 @@ API reference
 .. automodapi:: gafaelfawr.dependencies.auth
 
 .. automodapi:: gafaelfawr.dependencies.config
+   :include-all-objects:
 
 .. automodapi:: gafaelfawr.dependencies.context
 
 .. automodapi:: gafaelfawr.dependencies.redis
+   :include-all-objects:
 
 .. automodapi:: gafaelfawr.dependencies.return_url
 
 .. automodapi:: gafaelfawr.dependencies.token_cache
+   :include-all-objects:
 
 .. automodapi:: gafaelfawr.exceptions
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -188,10 +188,13 @@ autosummary_generate = True
 
 automodapi_inheritance_diagram = True
 automodapi_toctreedirnm = "api"
+
+# Inheriting docstrings from parents by default creates huge amounts of noise
+# in Pydantic.  Use the :inherited-members: flag when this is needed.
 automodsumm_inherited_members = False
 
 # Docstrings for classes and methods are inherited from parents.
-autodoc_inherit_docstrings = False
+autodoc_inherit_docstrings = True
 
 # Class documentation should only contain the class docstring and
 # ignore the __init__ docstring, account to LSST coding standards.

--- a/src/gafaelfawr/constants.py
+++ b/src/gafaelfawr/constants.py
@@ -37,4 +37,4 @@ USERNAME_REGEX = "^[a-z0-9](?:[a-z0-9]|-[a-z0-9])*$"
 """Regex matching all valid usernames."""
 
 ACTOR_REGEX = f"{USERNAME_REGEX}|^<[a-z]+>$"
-""""Regex matching all valid actors (including ``<bootstrap>``)."""
+"""Regex matching all valid actors (including ``<bootstrap>``)."""

--- a/src/gafaelfawr/providers/github.py
+++ b/src/gafaelfawr/providers/github.py
@@ -88,7 +88,7 @@ class GitHubProvider(Provider):
         Configuration for the GitHub authentication provider.
     http_client : ``httpx.AsyncClient``
         Session to use to make HTTP requests.
-    logger : ``structlog.stdlib.BoundLogger``
+    logger : `structlog.stdlib.BoundLogger`
         Logger for any log messages.
     """
 

--- a/src/gafaelfawr/providers/oidc.py
+++ b/src/gafaelfawr/providers/oidc.py
@@ -34,7 +34,7 @@ class OIDCProvider(Provider):
         Token verifier to use to verify the token returned by the provider.
     http_client : ``httpx.AsyncClient``
         Session to use to make HTTP requests.
-    logger : ``structlog.stdlib.BoundLogger``
+    logger : `structlog.stdlib.BoundLogger`
         Logger for any log messages.
     """
 

--- a/src/gafaelfawr/services/admin.py
+++ b/src/gafaelfawr/services/admin.py
@@ -25,7 +25,7 @@ class AdminService:
         The backing store for token administrators.
     admin_history_store : `gafaelfawr.storage.history.AdminHistoryStore`
         The backing store for history of changes to token administrators.
-    logger : ``structlog.stdlib.BoundLogger``
+    logger : `structlog.stdlib.BoundLogger`
         Logger to use for messages.
     """
 

--- a/src/gafaelfawr/services/kubernetes.py
+++ b/src/gafaelfawr/services/kubernetes.py
@@ -79,7 +79,7 @@ class KubernetesService:
         Storage layer for the Kubernetes cluster.
     session : `sqlalchemy.ext.asyncio.async_scoped_session`
         Database session, used for transaction management.
-    logger : ``structlog.stdlib.BoundLogger``
+    logger : `structlog.stdlib.BoundLogger`
         Logger to report issues.
     """
 

--- a/src/gafaelfawr/services/oidc.py
+++ b/src/gafaelfawr/services/oidc.py
@@ -39,7 +39,7 @@ class OIDCService:
         JWT issuer.
     token_service : `gafaelfawr.services.token.TokenService`
         Token manipulation service.
-    logger : ``structlog.stdlib.BoundLogger``
+    logger : `structlog.stdlib.BoundLogger`
         Logger for diagnostics.
 
     Notes

--- a/src/gafaelfawr/services/token.py
+++ b/src/gafaelfawr/services/token.py
@@ -55,7 +55,7 @@ class TokenService:
         The Redis backing store for tokens.
     token_change_store : `gafaelfawr.storage.history.TokenChangeHistoryStore`
         The backing store for history of changes to tokens.
-    logger : ``structlog.stdlib.BoundLogger``
+    logger : `structlog.stdlib.BoundLogger`
         Logger to use.
     """
 

--- a/src/gafaelfawr/services/token_cache.py
+++ b/src/gafaelfawr/services/token_cache.py
@@ -39,7 +39,7 @@ class TokenCacheService:
         The Redis backing store for tokens.
     token_change_store : `gafaelfawr.storage.history.TokenChangeHistoryStore`
         The backing store for history of changes to tokens.
-    logger : ``structlog.stdlib.BoundLogger``
+    logger : `structlog.stdlib.BoundLogger`
         Logger to use.
 
     Notes

--- a/src/gafaelfawr/storage/kubernetes.py
+++ b/src/gafaelfawr/storage/kubernetes.py
@@ -478,7 +478,7 @@ class KubernetesWatcher:
         The Kubernetes client.
     queue : `asyncio.Queue`
         The queue into which to put the events.
-    logger : ``structlog.stdlib.BoundLogger``
+    logger : `structlog.stdlib.BoundLogger`
         Logger to use for messages.
     """
 

--- a/src/gafaelfawr/storage/token.py
+++ b/src/gafaelfawr/storage/token.py
@@ -333,7 +333,7 @@ class TokenRedisStore:
     ----------
     storage : `gafaelfawr.storage.base.RedisStorage`
         The underlying storage.
-    logger : `structlog.BoundLogger`
+    logger : `structlog.stdlib.BoundLogger`
         Logger for diagnostics.
     """
 

--- a/src/gafaelfawr/verify.py
+++ b/src/gafaelfawr/verify.py
@@ -43,7 +43,7 @@ class TokenVerifier:
         The JWT Authorizer configuration.
     http_client : ``httpx.AsyncClient``
         The client to use for making requests.
-    logger : ``structlog.stdlib.BoundLogger``
+    logger : `structlog.stdlib.BoundLogger`
         Logger to use to report status information.
     """
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,6 +16,7 @@ from asgi_lifespan import LifespanManager
 from fastapi import FastAPI
 from httpx import AsyncClient
 from safir.database import create_database_engine, initialize_database
+from safir.dependencies.db_session import db_session_dependency
 from safir.testing.kubernetes import MockKubernetesApi, patch_kubernetes
 from seleniumwire import webdriver
 from sqlalchemy.ext.asyncio import AsyncEngine
@@ -37,12 +38,15 @@ from .support.settings import build_settings
 
 
 @pytest_asyncio.fixture
-async def app(empty_database: None) -> AsyncIterator[FastAPI]:
+async def app(
+    engine: AsyncEngine, empty_database: None
+) -> AsyncIterator[FastAPI]:
     """Return a configured test application.
 
     Wraps the application in a lifespan manager so that startup and shutdown
     events are sent during test execution.
     """
+    db_session_dependency.override_engine(engine)
     async with LifespanManager(main.app):
         yield main.app
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,6 +19,7 @@ from safir.database import create_database_engine, initialize_database
 from safir.dependencies.db_session import db_session_dependency
 from safir.testing.kubernetes import MockKubernetesApi, patch_kubernetes
 from seleniumwire import webdriver
+from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncEngine
 
 from gafaelfawr import main
@@ -92,12 +93,13 @@ def driver() -> Iterator[webdriver.Chrome]:
 
 
 @pytest_asyncio.fixture
-async def empty_database(engine: AsyncEngine, config: Config) -> None:
-    """Initialize the database for a new test.
+async def empty_database(
+    initialize_empty_database: None, engine: AsyncEngine, config: Config
+) -> None:
+    """Empty the database before a test.
 
-    This exists as a fixture so that multiple other fixtures can depend on it
-    and avoid any duplication of work if, say, we need both a configured
-    FastAPI app and a standalone factory.
+    The tables are reset with ``TRUNCATE`` rather than dropping and recreating
+    them in the hope that this will make database initialization faster.
 
     Notes
     -----
@@ -108,11 +110,12 @@ async def empty_database(engine: AsyncEngine, config: Config) -> None:
     on it if control over the configuration prior to database initialization
     is required.
     """
-    logger = structlog.get_logger(config.safir.logger_name)
-    await initialize_database(engine, logger, schema=Base.metadata, reset=True)
+    tables = (t.name for t in Base.metadata.sorted_tables)
     async with ComponentFactory.standalone(engine) as factory:
         admin_service = factory.create_admin_service()
         async with factory.session.begin():
+            stmt = text(f'TRUNCATE TABLE {", ".join(tables)}')
+            await factory.session.execute(stmt)
             await admin_service.add_initial_admins(config.initial_admins)
 
 
@@ -153,6 +156,17 @@ def event_loop() -> Iterator[asyncio.AbstractEventLoop]:
     loop = asyncio.new_event_loop()
     yield loop
     loop.close()
+
+
+@pytest_asyncio.fixture(scope="session")
+async def initialize_empty_database(engine: AsyncEngine) -> None:
+    """Initialize the database for testing.
+
+    This sets up the database schema for the tests.  The database is then
+    reset between tests with the `empty_database` fixture.
+    """
+    logger = structlog.get_logger(__name__)
+    await initialize_database(engine, logger, schema=Base.metadata, reset=True)
 
 
 @pytest.fixture

--- a/tests/handlers/api_history_test.py
+++ b/tests/handlers/api_history_test.py
@@ -40,9 +40,9 @@ async def build_history(
     build enough history that we can make interesting paginated queries of it.
     """
     token_service = factory.create_token_service()
-
-    user_info_one = TokenUserInfo(username="one")
     async with factory.session.begin():
+
+        user_info_one = TokenUserInfo(username="one")
         token_one = await token_service.create_session_token(
             user_info_one,
             scopes=["exec:test", "read:all", "user:token"],
@@ -83,8 +83,7 @@ async def build_history(
             ip_address="10.10.10.20",
         )
 
-    user_info_two = TokenUserInfo(username="two")
-    async with factory.session.begin():
+        user_info_two = TokenUserInfo(username="two")
         token_two = await token_service.create_session_token(
             user_info_two,
             scopes=["read:some", "user:token"],
@@ -115,7 +114,6 @@ async def build_history(
             token_name="happy token",
         )
 
-    async with factory.session.begin():
         request = AdminTokenRequest(
             username="service",
             token_type=TokenType.service,
@@ -149,10 +147,9 @@ async def build_history(
             ip_address="2001:db8:034a:ea78:4278:4562:6578:9876",
         )
 
-    # Spread out the timestamps so that we can test date range queries.  Every
-    # other entry has the same timestamp as the previous entry to test that
-    # queries handle entries with the same timestamp.
-    async with factory.session.begin():
+        # Spread out the timestamps so that we can test date range queries.
+        # Every other entry has the same timestamp as the previous entry to
+        # test that queries handle entries with the same timestamp.
         stmt = select(TokenChangeHistory).order_by(TokenChangeHistory.id)
         result = await factory.session.execute(stmt)
         entries = [e[0] for e in result.all()]
@@ -162,8 +159,8 @@ async def build_history(
             if i % 2 != 0:
                 event_time += timedelta(seconds=5)
 
-    async with factory.session.begin():
         history = await token_service.get_change_history(service_token_data)
+
     assert history.count == 20
     assert len(history.entries) == 20
     return history.entries

--- a/tests/support/settings.py
+++ b/tests/support/settings.py
@@ -14,6 +14,14 @@ from gafaelfawr.keypair import RSAKeyPair
 
 from .constants import TEST_DATABASE_URL
 
+_ISSUER_KEY = RSAKeyPair.generate()
+"""RSA key pair for JWT issuance and verification.
+
+Generating this takes a surprisingly long time when summed across every test,
+so generate one statically at import time for each test run and use it for
+every settings file.
+"""
+
 __all__ = [
     "build_settings",
     "configure",
@@ -92,7 +100,7 @@ def build_settings(
     """
     session_secret = Fernet.generate_key()
     session_secret_file = store_secret(tmp_path, "session", session_secret)
-    issuer_key = RSAKeyPair.generate().private_key_as_pem()
+    issuer_key = _ISSUER_KEY.private_key_as_pem()
     issuer_key_file = store_secret(tmp_path, "issuer", issuer_key)
     influxdb_secret_file = store_secret(tmp_path, "influxdb", b"influx-secret")
     github_secret_file = store_secret(tmp_path, "github", b"github-secret")

--- a/tox.ini
+++ b/tox.ini
@@ -73,7 +73,17 @@ deps =
 commands = pre-commit run --all-files
 
 [testenv:py]
-description = Run pytest with PostgreSQL and Redis via Docker.
+description = Run pytest with Docker prerequisites.
+docker =
+    postgres
+    redis
+commands =
+    pytest -vv {posargs}
+setenv =
+    GAFAELFAWR_UI_PATH = {toxinidir}/ui/public
+
+[testenv:py-coverage]
+description = Run pytest with Docker prerequisites and coverage analysis.
 docker =
     postgres
     redis


### PR DESCRIPTION
Try to make the tests run faster. The critical changes are to truncate tables instead of dropping them, and disable coverage by default, but the other changes seem to improve things minorly so keep them.

Also tweak the documentation generation a bit to match the changes in Safir.