### PR TITLE
[DM-34592] Add enrollment URL support for OpenID Connect

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,8 @@ The internal configuration format may change in minor releases.
   When this is enabled, UID and GID information from the upstream OpenID Connect provider or from LDAP is ignored, and instead Gafaelfawr assigns UIDs and GIDs to usernames and group names on first use.
   UIDs and GIDs for usernames and group names will be retrieved from Firestore on initial authentication if already assigned.
   Currently, OpenID Connect (via CILogon or a generic server) must be used as the authentication provider to use Google Firestore UID and GID assignment.
+- Add an optional enrollment URL configuration when CILogon or generic OpenID Connect is used with LDAP lookups of the username.
+  If this is set and the ``sub`` claim in the ID token does not resolve to a user entry in LDAP, the user will be redirected to this URL instead of an error page.
 - Group information from LDAP is now retrieved dynamically when needed instead of stored with an authentication token, so it will change dynamically if the user's groups change in LDAP.
   This does not affect the token's scopes, only the group information retrieved by a user-info API request.
 - Support authenticated simple binds to an LDAP server.

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -253,6 +253,12 @@ CILogon has some additional options under ``config.cilogon`` that you may want t
     Can be used to set parameters like ``skin`` or ``selected_idp``.
     See the `CILogon OIDC documentation <https://www.cilogon.org/oidc>`__ for more information.
 
+``config.cilogon.enrollmentUrl``
+    Used only when LDAP lookups of usernames are configured (see :ref:`ldap-username`).
+    If a username was not found for the CILogon unique identifier, redirect the user to this URL.
+    This is intended for deployments using CILogon with COmanage for identity management.
+    The enrollment URL will normally be the initial URL for a COmanage user-initiated enrollment flow.
+
 Generic OpenID Connect
 ^^^^^^^^^^^^^^^^^^^^^^
 
@@ -269,11 +275,16 @@ Generic OpenID Connect
          - "<scope-to-request>"
          - "<scope-to-request>"
 
-There is one additional option under ``config.oidc`` that you may want to set:
+There are two additional options under ``config.oidc`` that you may want to set:
 
 ``config.oidc.loginParams``
     A mapping of additional parameters to send to the login route.
     Can be used to set additional configuration options for some OpenID Connect providers.
+
+``config.oidc.enrollmentUrl``
+    Used only when LDAP lookups of usernames are configured (see :ref:`ldap-username`).
+    If a username was not found for the unique identifier in the ``sub`` claim of the OpenID Connect ID token, redirect the user to this URL.
+    This could, for example, be a form where the user can register for access to the deployment, or a page explaining how a user can get access.
 
 .. _ldap-groups:
 
@@ -308,6 +319,8 @@ You may need to set the following additional options under ``config.ldap`` depen
     Default: ``member``.
 
 The name of each group will be taken from the ``cn`` attribute and the numeric UID will be taken from the ``gidNumber`` attribute.
+
+.. _ldap-username:
 
 LDAP username
 -------------

--- a/src/gafaelfawr/config.py
+++ b/src/gafaelfawr/config.py
@@ -85,6 +85,14 @@ class OIDCSettings(BaseModel):
     token_url: AnyHttpUrl
     """URL at which to redeem the authentication code for a token."""
 
+    enrollment_url: Optional[AnyHttpUrl] = None
+    """URL to which the user should be redirected if not enrolled.
+
+    If LDAP username lookup is configured (using ``ldap.username_base_dn``)
+    and the user could not be found, redirect the user, after login, to this
+    URL so that they can register.
+    """
+
     scopes: List[str] = []
     """Scopes to request from the authentication provider.
 
@@ -408,6 +416,14 @@ class OIDCConfig:
     token_url: str
     """URL at which to redeem the authentication code for a token."""
 
+    enrollment_url: Optional[str]
+    """URL to which the user should be redirected if not enrolled.
+
+    If LDAP username lookup is configured (using ``ldap.username_base_dn``)
+    and the user could not be found, redirect the user, after login, to this
+    URL so that they can register.
+    """
+
     scopes: Tuple[str, ...]
     """Scopes to request from the authentication provider.
 
@@ -662,6 +678,9 @@ class Config:
         oidc_config = None
         if settings.oidc:
             path = settings.oidc.client_secret_file
+            enrollment_url = None
+            if settings.oidc.enrollment_url:
+                enrollment_url = str(settings.oidc.enrollment_url)
             oidc_secret = cls._load_secret(path).decode()
             oidc_config = OIDCConfig(
                 client_id=settings.oidc.client_id,
@@ -670,6 +689,7 @@ class Config:
                 login_params=settings.oidc.login_params,
                 redirect_url=str(settings.oidc.redirect_url),
                 token_url=str(settings.oidc.token_url),
+                enrollment_url=enrollment_url,
                 scopes=tuple(settings.oidc.scopes),
                 issuer=settings.oidc.issuer,
                 audience=settings.oidc.audience,

--- a/src/gafaelfawr/exceptions.py
+++ b/src/gafaelfawr/exceptions.py
@@ -33,6 +33,7 @@ __all__ = [
     "MissingClaimsException",
     "NoAvailableGidError",
     "NoAvailableUidError",
+    "NoUsernameMappingError",
     "NotConfiguredException",
     "OAuthError",
     "OAuthBearerError",
@@ -352,6 +353,10 @@ class OIDCException(ProviderException):
 
 class LDAPException(ProviderException):
     """Group information for the user in LDAP was invalid."""
+
+
+class NoUsernameMappingError(LDAPException):
+    """No mapping from identifier to username was found in LDAP."""
 
 
 class UnauthorizedClientException(Exception):

--- a/src/gafaelfawr/providers/oidc.py
+++ b/src/gafaelfawr/providers/oidc.py
@@ -120,6 +120,9 @@ class OIDCProvider(Provider):
         gafaelfawr.exceptions.LDAPException
             Gafaelfawr was configured to get user groups, username, or numeric
             UID from LDAP, but the attempt failed due to some error.
+        gafaelfawr.exceptions.NoUsernameMappingError
+            The opaque authentication identity could not be mapped to a
+            username, probably because the user is not enrolled.
         ``httpx.HTTPError``
             An HTTP client error occurred trying to talk to the authentication
             provider.

--- a/src/gafaelfawr/services/userinfo.py
+++ b/src/gafaelfawr/services/userinfo.py
@@ -313,6 +313,9 @@ class OIDCUserInfoService(UserInfoService):
         gafaelfawr.exceptions.LDAPException
             Gafaelfawr was configured to get user groups, username, or numeric
             UID from LDAP, but the attempt failed due to some error.
+        gafaelfawr.exceptions.NoUsernameMappingError
+            The opaque authentication identity could not be mapped to a
+            username, probably because the user is not enrolled.
         gafaelfawr.exceptions.VerifyTokenException
             The token is missing required claims.
         """

--- a/tests/settings/oidc-ldap.yaml.in
+++ b/tests/settings/oidc-ldap.yaml.in
@@ -27,6 +27,7 @@ oidc:
     skin: "test"
   redirect_url: "https://upstream.example.com/login"
   token_url: "https://upstream.example.com/token"
+  enrollment_url: "https://upstream.example.com/enroll"
   scopes:
     - "email"
     - "voPerson"

--- a/tests/support/ldap.py
+++ b/tests/support/ldap.py
@@ -68,4 +68,4 @@ class MockLDAP(Mock):
                 {"cn": [g.name], "gidNumber": [str(g.id)]} for g in self.groups
             ]
         else:
-            assert False, f"Unexpected query {query}"
+            return []


### PR DESCRIPTION
When using CILogon with COmanage, CILogon will pass an opaque
identifier in the sub claim that we need to look up in COmanage
LDAP to resolve to a user.  That was previously implemented, but
with a generic login error if the lookup failed.  However, a
lookup failure is expected for a new user, and rather than an
error, we want to direct that user to the self-service enrollment
flow so that they can create a pending COmanage record and be
added to the queue for approval.

Implement this via a new configuration parameter and a new
distinguished exception raised from the LDAP service layer if
all the queries succeeded but a user record was not found.