### PR TITLE
[DM-34637] Minor refactoring and cleanup

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,13 @@ Versioning follows `semver <https://semver.org/>`__.
 Versioning assumes that Gafaelfawr is installed and configured via `Phalanx <https://phalanx.lsst.io/>`__, so only changes to configuration changes exposed in the Helm values file are considered breaking changes.
 The internal configuration format may change in minor releases.
 
+4.2.0 (unreleased)
+==================
+
+- Report better errors to the user if Firestore or LDAP fail during login.
+- Add ``config.oidc.usernameClaim`` and ``config.oidc.uidClaim`` Helm configuration options to customize which claims from the upstream OpenID Connect ID token are used to get the username and UID.
+- Update dependencies.
+
 4.1.0 (2022-04-29)
 ==================
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -286,6 +286,16 @@ There are two additional options under ``config.oidc`` that you may want to set:
     If a username was not found for the unique identifier in the ``sub`` claim of the OpenID Connect ID token, redirect the user to this URL.
     This could, for example, be a form where the user can register for access to the deployment, or a page explaining how a user can get access.
 
+``config.oidc.usernameClaim``
+    The claim of the OpenID Connect ID token from which to take the username.
+    Only used if :ref:`username lookup in LDAP <ldap-username>` is not configured.
+    The default is ``sub``.
+
+``config.oidc.uidClaim``
+    The claim of the OpenID Connect ID token from which to take the numeric UID.
+    Only used if :ref:`UID lookup in LDAP <ldap-uid>` is not configured.
+    The default is ``uidNumber``.
+
 .. _ldap-groups:
 
 LDAP groups
@@ -337,6 +347,8 @@ To do this, add the following configuration:
 
 The user object will be located by searching for a ``voPersonSoRID`` attribute equal to the ``sub`` claim of the ID token returned by the OpenID Connect authentication server.
 The username will be the value of the ``uid`` attribute of the corresponding record.
+
+.. _ldap-uid:
 
 LDAP numeric UID
 ----------------

--- a/src/gafaelfawr/constants.py
+++ b/src/gafaelfawr/constants.py
@@ -50,7 +50,7 @@ GID_MAX = 2999999
 # The following constants are used for field validation.  Minimum and maximum
 # length are handled separately.
 
-BOT_USERNAME_REGEX = "^bot-.*$"
+BOT_USERNAME_REGEX = "^bot-[a-z0-9](?:[a-z0-9]|-[a-z0-9])*$"
 """Regex matching a valid username that is also a bot user."""
 
 CURSOR_REGEX = "^p?[0-9]+_[0-9]+$"

--- a/src/gafaelfawr/exceptions.py
+++ b/src/gafaelfawr/exceptions.py
@@ -331,6 +331,14 @@ class KubernetesObjectError(KubernetesError):
     """A Kubernetes object could not be parsed."""
 
 
+class LDAPError(Exception):
+    """Group information for the user in LDAP was invalid."""
+
+
+class NoUsernameMappingError(LDAPError):
+    """No mapping from identifier to username was found in LDAP."""
+
+
 class NotConfiguredError(Exception):
     """The requested operation was not configured."""
 
@@ -349,14 +357,6 @@ class GitHubError(ProviderError):
 
 class OIDCError(ProviderError):
     """The OpenID Connect provider returned an error from an API call."""
-
-
-class LDAPError(ProviderError):
-    """Group information for the user in LDAP was invalid."""
-
-
-class NoUsernameMappingError(LDAPError):
-    """No mapping from identifier to username was found in LDAP."""
 
 
 class UnauthorizedClientError(Exception):

--- a/src/gafaelfawr/exceptions.py
+++ b/src/gafaelfawr/exceptions.py
@@ -8,13 +8,13 @@ from typing import ClassVar, Dict, List, Union
 from fastapi import status
 
 __all__ = [
-    "DeserializeException",
+    "DeserializeError",
     "DuplicateTokenNameError",
     "ErrorLocation",
-    "FetchKeysException",
+    "FetchKeysError",
     "FirestoreError",
     "FirestoreNotInitializedError",
-    "GitHubException",
+    "GitHubError",
     "InsufficientScopeError",
     "InvalidClientError",
     "InvalidCSRFError",
@@ -25,26 +25,26 @@ __all__ = [
     "InvalidRequestError",
     "InvalidReturnURLError",
     "InvalidScopesError",
-    "InvalidTokenClaimsException",
+    "InvalidTokenClaimsError",
     "InvalidTokenError",
     "KubernetesError",
     "KubernetesObjectError",
-    "LDAPException",
-    "MissingClaimsException",
+    "LDAPError",
+    "MissingClaimsError",
     "NoAvailableGidError",
     "NoAvailableUidError",
     "NoUsernameMappingError",
-    "NotConfiguredException",
+    "NotConfiguredError",
     "OAuthError",
     "OAuthBearerError",
-    "OIDCException",
+    "OIDCError",
     "PermissionDeniedError",
-    "ProviderException",
-    "UnauthorizedClientException",
-    "UnknownAlgorithmException",
-    "UnknownKeyIdException",
+    "ProviderError",
+    "UnauthorizedClientError",
+    "UnknownAlgorithmError",
+    "UnknownKeyIdError",
     "ValidationError",
-    "VerifyTokenException",
+    "VerifyTokenError",
 ]
 
 
@@ -298,7 +298,7 @@ class InsufficientScopeError(OAuthBearerError):
     status_code = status.HTTP_403_FORBIDDEN
 
 
-class DeserializeException(Exception):
+class DeserializeError(Exception):
     """A stored object could not be decrypted or deserialized.
 
     Used for data stored in the backing store, such as sessions or user
@@ -331,7 +331,7 @@ class KubernetesObjectError(KubernetesError):
     """A Kubernetes object could not be parsed."""
 
 
-class NotConfiguredException(Exception):
+class NotConfiguredError(Exception):
     """The requested operation was not configured."""
 
 
@@ -339,52 +339,52 @@ class PermissionDeniedError(Exception):
     """The user does not have permission to perform this operation."""
 
 
-class ProviderException(Exception):
+class ProviderError(Exception):
     """An authentication provider returned an error from an API call."""
 
 
-class GitHubException(ProviderException):
+class GitHubError(ProviderError):
     """GitHub returned an error from an API call."""
 
 
-class OIDCException(ProviderException):
+class OIDCError(ProviderError):
     """The OpenID Connect provider returned an error from an API call."""
 
 
-class LDAPException(ProviderException):
+class LDAPError(ProviderError):
     """Group information for the user in LDAP was invalid."""
 
 
-class NoUsernameMappingError(LDAPException):
+class NoUsernameMappingError(LDAPError):
     """No mapping from identifier to username was found in LDAP."""
 
 
-class UnauthorizedClientException(Exception):
+class UnauthorizedClientError(Exception):
     """The client is not authorized to request an authorization code.
 
     This corresponds to the ``unauthorized_client`` error in RFC 6749.
     """
 
 
-class VerifyTokenException(Exception):
+class VerifyTokenError(Exception):
     """Base exception class for failure in verifying a token."""
 
 
-class FetchKeysException(VerifyTokenException):
+class FetchKeysError(VerifyTokenError):
     """Cannot retrieve the keys from an issuer."""
 
 
-class InvalidTokenClaimsException(VerifyTokenException):
+class InvalidTokenClaimsError(VerifyTokenError):
     """One of the claims in the token is of an invalid format."""
 
 
-class MissingClaimsException(VerifyTokenException):
+class MissingClaimsError(VerifyTokenError):
     """The token is missing required claims."""
 
 
-class UnknownAlgorithmException(VerifyTokenException):
+class UnknownAlgorithmError(VerifyTokenError):
     """The issuer key was for an unsupported algorithm."""
 
 
-class UnknownKeyIdException(VerifyTokenException):
+class UnknownKeyIdError(VerifyTokenError):
     """The reqeusted key ID was not found for an issuer."""

--- a/src/gafaelfawr/factory.py
+++ b/src/gafaelfawr/factory.py
@@ -18,7 +18,7 @@ from .config import Config
 from .dependencies.cache import IdCache, TokenCache
 from .dependencies.config import config_dependency
 from .dependencies.redis import redis_dependency
-from .exceptions import NotConfiguredException
+from .exceptions import NotConfiguredError
 from .models.token import TokenData
 from .providers.base import Provider
 from .providers.github import GitHubProvider
@@ -164,7 +164,7 @@ class ComponentFactory:
             Newly-created Firestore storage.
         """
         if not self._config.firestore:
-            raise NotConfiguredException("Firestore is not configured")
+            raise NotConfiguredError("Firestore is not configured")
         return FirestoreStorage(self._config.firestore, self._logger)
 
     def create_influxdb_service(self) -> InfluxDBService:
@@ -176,7 +176,7 @@ class ComponentFactory:
             Newly-created InfluxDB token issuer.
         """
         if not self._config.influxdb:
-            raise NotConfiguredException("No InfluxDB issuer configuration")
+            raise NotConfiguredError("No InfluxDB issuer configuration")
         return InfluxDBService(self._config.influxdb)
 
     def create_kubernetes_service(
@@ -213,7 +213,7 @@ class ComponentFactory:
         """
         if not self._config.oidc_server:
             msg = "OpenID Connect server not configured"
-            raise NotConfiguredException(msg)
+            raise NotConfiguredError(msg)
         key = self._config.session_secret
         storage = RedisStorage(OIDCAuthorization, key, self._redis)
         authorization_store = OIDCAuthorizationStore(storage)
@@ -239,11 +239,11 @@ class ComponentFactory:
 
         Raises
         ------
-        gafaelfawr.exceptions.NotConfiguredException
+        gafaelfawr.exceptions.NotConfiguredError
             The configured authentication provider is not OpenID Connect.
         """
         if not self._config.oidc:
-            raise NotConfiguredException("OpenID Connect is not configured")
+            raise NotConfiguredError("OpenID Connect is not configured")
         firestore = None
         if self._config.firestore:
             firestore = self.create_firestore_storage()
@@ -272,7 +272,7 @@ class ComponentFactory:
         """
         if not self._config.oidc:
             msg = "OpenID Connect provider not configured"
-            raise NotConfiguredException(msg)
+            raise NotConfiguredError(msg)
         return OIDCTokenVerifier(
             config=self._config.oidc,
             http_client=self._http_client,

--- a/src/gafaelfawr/handlers/login.py
+++ b/src/gafaelfawr/handlers/login.py
@@ -16,7 +16,7 @@ from ..exceptions import (
     InvalidReturnURLError,
     NoUsernameMappingError,
     PermissionDeniedError,
-    ProviderException,
+    ProviderError,
 )
 from ..models.token import TokenGroup
 from ..templates import templates
@@ -217,7 +217,7 @@ async def handle_provider_return(
             return RedirectResponse(url)
         else:
             return login_error(context, LoginError.NOT_ENROLLED, str(e))
-    except ProviderException as e:
+    except ProviderError as e:
         return login_error(context, LoginError.PROVIDER_FAILED, str(e))
     except HTTPError as e:
         return login_error(context, LoginError.PROVIDER_NETWORK, str(e))

--- a/src/gafaelfawr/handlers/login.py
+++ b/src/gafaelfawr/handlers/login.py
@@ -13,7 +13,9 @@ from ..config import Config
 from ..dependencies.context import RequestContext, context_dependency
 from ..dependencies.return_url import return_url_with_header
 from ..exceptions import (
+    FirestoreError,
     InvalidReturnURLError,
+    LDAPError,
     NoUsernameMappingError,
     PermissionDeniedError,
     ProviderError,
@@ -32,6 +34,8 @@ class LoginError(Enum):
     GROUPS_MISSING = "User unauthorized"
     INVALID_USERNAME = "Cannot authenticate"
     NOT_ENROLLED = "User is not enrolled"
+    FIRESTORE_FAILED = "Retrieving UID/GID from Firestore failed"
+    LDAP_FAILED = "Retrieving data from LDAP failed"
     PROVIDER_FAILED = "Authentication provider failed"
     PROVIDER_NETWORK = "Cannot contact authentication provider"
     RETURN_URL_MISSING = "Invalid state: return_url not present in cookie"
@@ -217,10 +221,14 @@ async def handle_provider_return(
             return RedirectResponse(url)
         else:
             return login_error(context, LoginError.NOT_ENROLLED, str(e))
-    except ProviderError as e:
-        return login_error(context, LoginError.PROVIDER_FAILED, str(e))
+    except FirestoreError as e:
+        return login_error(context, LoginError.FIRESTORE_FAILED, str(e))
     except HTTPError as e:
         return login_error(context, LoginError.PROVIDER_NETWORK, str(e))
+    except LDAPError as e:
+        return login_error(context, LoginError.LDAP_FAILED, str(e))
+    except ProviderError as e:
+        return login_error(context, LoginError.PROVIDER_FAILED, str(e))
 
     # If we normally get group information from LDAP, the groups returned by
     # the authentication provider will be empty, but we still want to

--- a/src/gafaelfawr/handlers/logout.py
+++ b/src/gafaelfawr/handlers/logout.py
@@ -18,6 +18,7 @@ __all__ = ["get_logout"]
 
 @router.get(
     "/logout",
+    response_class=RedirectResponse,
     responses={307: {"description": "Redirect to landing page"}},
     status_code=status.HTTP_307_TEMPORARY_REDIRECT,
     summary="Log out",
@@ -26,7 +27,7 @@ __all__ = ["get_logout"]
 async def get_logout(
     return_url: Optional[str] = Depends(return_url),
     context: RequestContext = Depends(context_dependency),
-) -> RedirectResponse:
+) -> str:
     """Log out and redirect the user.
 
     The user is redirected to the URL given in the rd parameter, if any, and
@@ -45,4 +46,4 @@ async def get_logout(
 
     if not return_url:
         return_url = context.config.after_logout_url
-    return RedirectResponse(return_url)
+    return return_url

--- a/src/gafaelfawr/handlers/oidc.py
+++ b/src/gafaelfawr/handlers/oidc.py
@@ -59,6 +59,7 @@ __all__ = ["get_login", "get_userinfo", "post_token"]
         " invalid OpenID client ID are reported via a redirect back to the"
         " OpenID client application with error and error_description set."
     ),
+    response_class=RedirectResponse,
     responses={
         307: {"description": "Redirect for authentication or back to client"},
         400: {"description": "Invalid OpenID client ID", "model": ErrorModel},
@@ -95,7 +96,7 @@ async def get_login(
     ),
     token_data: TokenData = Depends(authenticate),
     context: RequestContext = Depends(context_dependency),
-) -> RedirectResponse:
+) -> str:
     oidc_service = context.factory.create_oidc_service()
 
     # Check the client_id first, since if it's not valid, we cannot continue
@@ -127,7 +128,7 @@ async def get_login(
             error=e.error,
             error_description=str(e),
         )
-        return RedirectResponse(return_url)
+        return return_url
 
     # Get an authorization code and return it.
     code = await oidc_service.issue_code(
@@ -137,7 +138,7 @@ async def get_login(
         parsed_redirect_uri, state=state, code=str(code)
     )
     context.logger.info("Returned OpenID Connect authorization code")
-    return RedirectResponse(return_url)
+    return return_url
 
 
 def build_return_url(

--- a/src/gafaelfawr/main.py
+++ b/src/gafaelfawr/main.py
@@ -19,7 +19,7 @@ from .dependencies.cache import id_cache_dependency, token_cache_dependency
 from .dependencies.config import config_dependency
 from .dependencies.redis import redis_dependency
 from .exceptions import (
-    NotConfiguredException,
+    NotConfiguredError,
     PermissionDeniedError,
     ValidationError,
 )
@@ -114,7 +114,7 @@ def create_app() -> FastAPI:
     app.on_event("shutdown")(shutdown_event)
 
     # Register exception handlers.
-    app.exception_handler(NotConfiguredException)(not_configured_handler)
+    app.exception_handler(NotConfiguredError)(not_configured_handler)
     app.exception_handler(PermissionDeniedError)(permission_handler)
     app.exception_handler(ValidationError)(validation_handler)
 
@@ -137,7 +137,7 @@ async def shutdown_event() -> None:
 
 
 async def not_configured_handler(
-    request: Request, exc: NotConfiguredException
+    request: Request, exc: NotConfiguredError
 ) -> JSONResponse:
     return JSONResponse(
         status_code=status.HTTP_404_NOT_FOUND,

--- a/src/gafaelfawr/providers/base.py
+++ b/src/gafaelfawr/providers/base.py
@@ -54,7 +54,7 @@ class Provider(metaclass=ABCMeta):
         httpx.HTTPError
             An HTTP client error occurred trying to talk to the authentication
             provider.
-        gafaelfawr.exceptions.ProviderException
+        gafaelfawr.exceptions.ProviderError
             The provider responded with an error to a request.
         """
 

--- a/src/gafaelfawr/providers/github.py
+++ b/src/gafaelfawr/providers/github.py
@@ -13,7 +13,7 @@ from pydantic import ValidationError
 from structlog.stdlib import BoundLogger
 
 from ..config import GitHubConfig
-from ..exceptions import GitHubException
+from ..exceptions import GitHubError
 from ..models.link import LinkData
 from ..models.state import State
 from ..models.token import TokenGroup, TokenUserInfo
@@ -169,7 +169,7 @@ class GitHubProvider(Provider):
 
         Raises
         ------
-        gafaelfawr.exceptions.GitHubException
+        gafaelfawr.exceptions.GitHubError
             GitHub responded with an error to a request.
         ``httpx.HTTPError``
             An HTTP client error occurred trying to talk to the authentication
@@ -259,7 +259,7 @@ class GitHubProvider(Provider):
 
         Raises
         ------
-        gafaelfawr.exceptions.GitHubException
+        gafaelfawr.exceptions.GitHubError
             GitHub responded with an error to the request for the access
             token.
         ``httpx.HTTPError``
@@ -281,7 +281,7 @@ class GitHubProvider(Provider):
         result = r.json()
         if "error" in result:
             msg = result["error"] + ": " + result["error_description"]
-            raise GitHubException(msg)
+            raise GitHubError(msg)
         return result["access_token"]
 
     async def _get_user_info(self, token: str) -> GitHubUserInfo:
@@ -299,7 +299,7 @@ class GitHubProvider(Provider):
 
         Raises
         ------
-        gafaelfawr.exceptions.GitHubException
+        gafaelfawr.exceptions.GitHubError
             User has no primary email address.
         ``httpx.HTTPError``
             An error occurred trying to talk to GitHub.
@@ -335,7 +335,7 @@ class GitHubProvider(Provider):
                 email = email_data["email"]
         if not email:
             msg = f"{user_data['login']} has no primary email address"
-            raise GitHubException(msg)
+            raise GitHubError(msg)
 
         return GitHubUserInfo(
             name=user_data["name"],
@@ -361,7 +361,7 @@ class GitHubProvider(Provider):
 
         Raises
         ------
-        gafaelfawr.exceptions.GitHubException
+        gafaelfawr.exceptions.GitHubError
             The next URL from a Link header didn't point to the teams API URL.
         ``httpx.HTTPError``
             An error occurred trying to talk to GitHub.
@@ -383,7 +383,7 @@ class GitHubProvider(Provider):
                     "Invalid next URL for team data from GitHub: "
                     + link_data.next_url
                 )
-                raise GitHubException(msg)
+                raise GitHubError(msg)
             self._logger.debug(
                 "Fetching user team data from %s", link_data.next_url
             )

--- a/src/gafaelfawr/providers/oidc.py
+++ b/src/gafaelfawr/providers/oidc.py
@@ -114,6 +114,8 @@ class OIDCProvider(Provider):
 
         Raises
         ------
+        gafaelfawr.exceptions.FirestoreError
+            Retrieving or assigning a UID from Firestore failed.
         gafaelfawr.exceptions.OIDCError
             The OpenID Connect provider responded with an error to a request
             or the group membership in the resulting token was not valid.

--- a/src/gafaelfawr/storage/ldap.py
+++ b/src/gafaelfawr/storage/ldap.py
@@ -10,7 +10,7 @@ from bonsai.utils import escape_filter_exp
 from structlog.stdlib import BoundLogger
 
 from ..config import LDAPConfig
-from ..exceptions import LDAPException, NoUsernameMappingError
+from ..exceptions import LDAPError, NoUsernameMappingError
 from ..models.token import TokenGroup
 
 __all__ = ["LDAPStorage", "LDAPStorageConnection"]
@@ -98,7 +98,7 @@ class LDAPStorageConnection:
 
         Raises
         ------
-        gafaelfawr.exceptions.LDAPException
+        gafaelfawr.exceptions.LDAPError
             The lookup by ``username_search_attr`` in the LDAP server was not
             valid (connection to the LDAP server failed, attribute not found
             in LDAP, result value not an integer).
@@ -129,7 +129,7 @@ class LDAPStorageConnection:
                 ldap_search=search,
                 sub=sub,
             )
-            raise LDAPException("Error querying LDAP for username")
+            raise LDAPError("Error querying LDAP for username")
 
         for result in results:
             try:
@@ -141,7 +141,7 @@ class LDAPStorageConnection:
                     ldap_search=search,
                     sub=sub,
                 )
-                raise LDAPException("Username in LDAP is invalid")
+                raise LDAPError("Username in LDAP is invalid")
 
         # Fell through without finding a UID.
         self._logger.info(
@@ -166,7 +166,7 @@ class LDAPStorageConnection:
 
         Raises
         ------
-        gafaelfawr.exceptions.LDAPException
+        gafaelfawr.exceptions.LDAPError
             The lookup of ``uid_attr`` in the LDAP server was not valid
             (connection to the LDAP server failed, attribute not found in
             LDAP, result value not an integer).
@@ -193,7 +193,7 @@ class LDAPStorageConnection:
                 ldap_search=search,
                 user=username,
             )
-            raise LDAPException("Error querying LDAP for UID number")
+            raise LDAPError("Error querying LDAP for UID number")
 
         for result in results:
             try:
@@ -205,13 +205,13 @@ class LDAPStorageConnection:
                     ldap_search=search,
                     user=username,
                 )
-                raise LDAPException("UID number in LDAP is invalid")
+                raise LDAPError("UID number in LDAP is invalid")
 
         # Fell through without finding a UID.
         self._logger.error(
             "No UID found in LDAP", ldap_search=search, user=username
         )
-        raise LDAPException("No UID found in LDAP")
+        raise LDAPError("No UID found in LDAP")
 
     async def get_groups(
         self, username: str, *, add_gids: bool
@@ -232,7 +232,7 @@ class LDAPStorageConnection:
 
         Raises
         ------
-        gafaelfawr.exceptions.LDAPException
+        gafaelfawr.exceptions.LDAPError
             One of the groups for the user in LDAP was not valid (missing
             ``cn`` or, if ``add_gids`` was `True`, ``gidNumber`` attributes,
             or ``gidNumber`` is not an integer)
@@ -258,7 +258,7 @@ class LDAPStorageConnection:
                 ldap_search=search,
                 user=username,
             )
-            raise LDAPException("Error querying LDAP for groups")
+            raise LDAPError("Error querying LDAP for groups")
 
         # Parse the results into the group list.
         groups = []

--- a/src/gafaelfawr/storage/oidc.py
+++ b/src/gafaelfawr/storage/oidc.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Optional
 
 from ..constants import OIDC_AUTHORIZATION_LIFETIME
-from ..exceptions import DeserializeException
+from ..exceptions import DeserializeError
 from ..models.oidc import OIDCAuthorization, OIDCAuthorizationCode
 from ..models.token import Token
 from .base import RedisStorage
@@ -82,7 +82,7 @@ class OIDCAuthorizationStore:
 
         Raises
         ------
-        gafaelfawr.exceptions.DeserializeException
+        gafaelfawr.exceptions.DeserializeError
             If the authorization exists but cannot be deserialized.
         """
         authorization = await self._storage.get(f"oidc:{code.key}")
@@ -90,5 +90,5 @@ class OIDCAuthorizationStore:
             return None
         if authorization.code != code:
             msg = "Secret does not match stored authorization"
-            raise DeserializeException(msg)
+            raise DeserializeError(msg)
         return authorization

--- a/src/gafaelfawr/storage/token.py
+++ b/src/gafaelfawr/storage/token.py
@@ -12,7 +12,7 @@ from sqlalchemy.ext.asyncio import async_scoped_session
 from sqlalchemy.future import select
 from structlog.stdlib import BoundLogger
 
-from ..exceptions import DeserializeException, DuplicateTokenNameError
+from ..exceptions import DeserializeError, DuplicateTokenNameError
 from ..models.token import Token, TokenData, TokenInfo, TokenType
 from ..schema.subtoken import Subtoken
 from ..schema.token import Token as SQLToken
@@ -411,7 +411,7 @@ class TokenRedisStore:
         """
         try:
             data = await self._storage.get(f"token:{key}")
-        except DeserializeException as e:
+        except DeserializeError as e:
             self._logger.error("Cannot retrieve token", error=str(e))
             return None
         return data

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,7 +36,7 @@ from .support.constants import TEST_DATABASE_URL, TEST_HOSTNAME
 from .support.firestore import MockFirestore, patch_firestore
 from .support.ldap import MockLDAP
 from .support.selenium import SeleniumConfig, run_app, selenium_driver
-from .support.settings import build_settings
+from .support.settings import build_settings, configure
 
 
 @pytest_asyncio.fixture
@@ -72,9 +72,7 @@ def config(tmp_path: Path) -> Config:
     which must not be async because the Click support starts its own asyncio
     loop.
     """
-    settings_path = build_settings(tmp_path, "github")
-    config_dependency.set_settings_path(str(settings_path))
-    return config_dependency.config()
+    return configure(tmp_path, "github")
 
 
 @pytest.fixture(scope="session")
@@ -196,7 +194,7 @@ def mock_kubernetes() -> Iterator[MockKubernetesApi]:
 
 
 @pytest_asyncio.fixture
-async def mock_ldap(tmp_path: Path) -> AsyncIterator[MockLDAP]:
+async def mock_ldap() -> AsyncIterator[MockLDAP]:
     """Replace the bonsai LDAP API with a mock class.
 
     Returns
@@ -204,11 +202,7 @@ async def mock_ldap(tmp_path: Path) -> AsyncIterator[MockLDAP]:
     mock_ldap : `tests.support.ldap.MockLDAP`
         The mock LDAP API object.
     """
-    settings_path = build_settings(tmp_path, "oidc-ldap")
-    config_dependency.set_settings_path(str(settings_path))
-    config = await config_dependency()
-    assert config.ldap
-    ldap = MockLDAP(config.ldap)
+    ldap = MockLDAP()
     with patch.object(bonsai, "LDAPClient") as mock:
         mock.return_value = ldap
         yield ldap

--- a/tests/handlers/influxdb_test.py
+++ b/tests/handlers/influxdb_test.py
@@ -82,7 +82,7 @@ async def test_no_auth(client: AsyncClient, config: Config) -> None:
 async def test_not_configured(
     tmp_path: Path, client: AsyncClient, factory: ComponentFactory
 ) -> None:
-    config = await configure(tmp_path, "oidc")
+    config = configure(tmp_path, "oidc")
     factory.reconfigure(config)
     token_data = await create_session_token(factory)
 
@@ -102,7 +102,7 @@ async def test_influxdb_force_username(
     factory: ComponentFactory,
     caplog: LogCaptureFixture,
 ) -> None:
-    config = await configure(tmp_path, "influxdb-username")
+    config = configure(tmp_path, "influxdb-username")
     factory.reconfigure(config)
     token_data = await create_session_token(factory)
     assert token_data.expires

--- a/tests/handlers/login_oidc_test.py
+++ b/tests/handlers/login_oidc_test.py
@@ -111,7 +111,7 @@ async def test_login(
     respx_mock: respx.Router,
     caplog: LogCaptureFixture,
 ) -> None:
-    config = await configure(tmp_path, "oidc")
+    config = configure(tmp_path, "oidc")
     assert config.oidc
     token = create_upstream_oidc_jwt(
         groups=["admin"], name="Some Person", email="person@example.com"
@@ -187,7 +187,7 @@ async def test_login_redirect_header(
     tmp_path: Path, client: AsyncClient, respx_mock: respx.Router
 ) -> None:
     """Test receiving the redirect header via X-Auth-Request-Redirect."""
-    await configure(tmp_path, "oidc")
+    configure(tmp_path, "oidc")
     token = create_upstream_oidc_jwt(groups=["admin"])
     return_url = "https://example.com/foo?a=bar&b=baz"
 
@@ -206,7 +206,7 @@ async def test_oauth2_callback(
     tmp_path: Path, client: AsyncClient, respx_mock: respx.Router
 ) -> None:
     """Test the compatibility /oauth2/callback route."""
-    config = await configure(tmp_path, "oidc")
+    config = configure(tmp_path, "oidc")
     token = create_upstream_oidc_jwt(groups=["admin"])
     assert config.oidc
 
@@ -221,7 +221,7 @@ async def test_claim_names(
     tmp_path: Path, client: AsyncClient, respx_mock: respx.Router
 ) -> None:
     """Uses an alternate settings environment with non-default claims."""
-    config = await configure(tmp_path, "oidc-claims")
+    config = configure(tmp_path, "oidc-claims")
     assert config.oidc
     claims = {
         config.oidc.username_claim: "alt-username",
@@ -251,7 +251,7 @@ async def test_callback_error(
     caplog: LogCaptureFixture,
 ) -> None:
     """Test an error return from the OIDC token endpoint."""
-    config = await configure(tmp_path, "oidc")
+    config = configure(tmp_path, "oidc")
     assert config.oidc
     return_url = "https://example.com/foo"
 
@@ -351,7 +351,7 @@ async def test_callback_error(
 async def test_connection_error(
     tmp_path: Path, client: AsyncClient, respx_mock: respx.Router
 ) -> None:
-    config = await configure(tmp_path, "oidc")
+    config = configure(tmp_path, "oidc")
     assert config.oidc
     return_url = "https://example.com/foo"
 
@@ -375,7 +375,7 @@ async def test_connection_error(
 async def test_verify_error(
     tmp_path: Path, client: AsyncClient, respx_mock: respx.Router
 ) -> None:
-    config = await configure(tmp_path, "oidc")
+    config = configure(tmp_path, "oidc")
     token = create_upstream_oidc_jwt(groups=["admin"])
     assert config.oidc
     issuer = config.oidc.issuer
@@ -405,7 +405,7 @@ async def test_verify_error(
 async def test_invalid_username(
     tmp_path: Path, client: AsyncClient, respx_mock: respx.Router
 ) -> None:
-    await configure(tmp_path, "oidc")
+    configure(tmp_path, "oidc")
     token = create_upstream_oidc_jwt(
         groups=["admin"], sub="invalid@user", uid="invalid@user"
     )
@@ -419,7 +419,7 @@ async def test_invalid_username(
 async def test_invalid_group_syntax(
     tmp_path: Path, client: AsyncClient, respx_mock: respx.Router
 ) -> None:
-    await configure(tmp_path, "oidc")
+    configure(tmp_path, "oidc")
     token = create_upstream_oidc_jwt(isMemberOf=47)
 
     r = await simulate_oidc_login(client, respx_mock, token)
@@ -431,7 +431,7 @@ async def test_invalid_group_syntax(
 async def test_invalid_groups(
     tmp_path: Path, client: AsyncClient, respx_mock: respx.Router
 ) -> None:
-    await configure(tmp_path, "oidc")
+    configure(tmp_path, "oidc")
     token = create_upstream_oidc_jwt(
         isMemberOf=[
             {"name": "foo"},
@@ -457,7 +457,7 @@ async def test_invalid_groups(
 async def test_no_valid_groups(
     tmp_path: Path, client: AsyncClient, respx_mock: respx.Router
 ) -> None:
-    config = await configure(tmp_path, "oidc")
+    config = configure(tmp_path, "oidc")
     assert config.oidc
     token = create_upstream_oidc_jwt(groups=[])
 
@@ -478,7 +478,7 @@ async def test_no_valid_groups(
 async def test_unicode_name(
     tmp_path: Path, client: AsyncClient, respx_mock: respx.Router
 ) -> None:
-    config = await configure(tmp_path, "oidc")
+    config = configure(tmp_path, "oidc")
     assert config.oidc
     token = create_upstream_oidc_jwt(name="名字", groups=["admin"])
 
@@ -499,9 +499,12 @@ async def test_unicode_name(
 
 @pytest.mark.asyncio
 async def test_ldap(
-    client: AsyncClient, respx_mock: respx.Router, mock_ldap: MockLDAP
+    tmp_path: Path,
+    client: AsyncClient,
+    respx_mock: respx.Router,
+    mock_ldap: MockLDAP,
 ) -> None:
-    config = await config_dependency()
+    config = configure(tmp_path, "oidc-ldap")
     assert config.ldap
     token = create_upstream_oidc_jwt(sub=mock_ldap.source_id, groups=["admin"])
 
@@ -531,9 +534,12 @@ async def test_ldap(
 
 @pytest.mark.asyncio
 async def test_enrollment_url(
-    client: AsyncClient, respx_mock: respx.Router, mock_ldap: MockLDAP
+    tmp_path: Path,
+    client: AsyncClient,
+    respx_mock: respx.Router,
+    mock_ldap: MockLDAP,
 ) -> None:
-    config = await config_dependency()
+    config = configure(tmp_path, "oidc-ldap")
     assert config.oidc
     assert config.ldap
     token = create_upstream_oidc_jwt(sub="unknown-sub", groups=["admin"])
@@ -554,7 +560,7 @@ async def test_firestore(
     respx_mock: respx.Router,
     mock_firestore: MockFirestore,
 ) -> None:
-    config = await configure(tmp_path, "oidc-firestore")
+    config = configure(tmp_path, "oidc-firestore")
     assert config.oidc
     factory.reconfigure(config)
     firestore_storage = factory.create_firestore_storage()

--- a/tests/handlers/login_oidc_test.py
+++ b/tests/handlers/login_oidc_test.py
@@ -9,11 +9,12 @@ from urllib.parse import parse_qs, urljoin, urlparse
 import pytest
 import respx
 from _pytest.logging import LogCaptureFixture
-from httpx import AsyncClient, ConnectError
+from httpx import AsyncClient, ConnectError, Response
 
 from gafaelfawr.constants import GID_MIN, UID_BOT_MIN, UID_USER_MIN
 from gafaelfawr.dependencies.config import config_dependency
 from gafaelfawr.factory import ComponentFactory
+from gafaelfawr.models.oidc import OIDCVerifiedToken
 
 from ..support.firestore import MockFirestore
 from ..support.jwt import create_upstream_oidc_jwt
@@ -23,24 +24,57 @@ from ..support.oidc import mock_oidc_provider_config, mock_oidc_provider_token
 from ..support.settings import configure
 
 
-@pytest.mark.asyncio
-async def test_login(
-    tmp_path: Path,
+async def simulate_oidc_login(
     client: AsyncClient,
     respx_mock: respx.Router,
-    caplog: LogCaptureFixture,
-) -> None:
-    config = await configure(tmp_path, "oidc")
-    token = create_upstream_oidc_jwt(
-        groups=["admin"], name="Some Person", email="person@example.com"
-    )
+    token: OIDCVerifiedToken,
+    *,
+    return_url: str = "https://example.com/foo",
+    use_redirect_header: bool = False,
+    callback_route: str = "/login",
+    expect_enrollment: bool = False,
+) -> Response:
+    """Simulate an OpenID Connect login and return the final response.
+
+    Parameters
+    ----------
+    client : `httpx.AsyncClient`
+        Client to use to make calls to the application.
+    respx_mock : `respx.Router`
+        Mock for httpx calls.
+    token : `gafaelfawr.models.oidc.OIDCVerifiedToken`
+        Authentication token the upstream OpenID Connect provider should
+        return.
+    return_url : `str`, optional
+        The return URL to pass to the login process.  If not provided, a
+        simple one will be used.
+    use_redirect_header : `bool`, optional
+        If set to `True`, pass the return URL in a header instead of as a
+        parameter to the ``/login`` route.
+    callback_route : `str`, optional
+        Override the callback route to which the upstream OpenID Connect
+        provider is expected to send the redirect.
+    expect_enrollment : `bool`, optional
+        If set to `True`, expect a redirect to the enrollment URL after login
+        rather than to the return URL.
+
+    Returns
+    -------
+    response : ``httpx.Response``
+        The response from the return to the ``/login`` handler.
+    """
+    config = await config_dependency()
+    assert config.oidc
     await mock_oidc_provider_config(respx_mock, "orig-kid")
     await mock_oidc_provider_token(respx_mock, "some-code", token)
-    assert config.oidc
-    return_url = "https://example.com:4444/foo?a=bar&b=baz"
 
-    caplog.clear()
-    r = await client.get("/login", params={"rd": return_url})
+    # Simulate the redirect to the OpenID Connect provider.
+    if use_redirect_header:
+        r = await client.get(
+            "/login", headers={"X-Auth-Request-Redirect": return_url}
+        )
+    else:
+        r = await client.get("/login", params={"rd": return_url})
     assert r.status_code == 307
     assert r.headers["Location"].startswith(config.oidc.login_url)
     url = urlparse(r.headers["Location"])
@@ -56,8 +90,48 @@ async def test_login(
         **login_params,
     }
 
+    # Simulate the return from the OpenID Connect provider.
+    r = await client.get(
+        callback_route,
+        params={"code": "some-code", "state": query["state"][0]},
+    )
+    if r.status_code == 307:
+        if expect_enrollment:
+            assert r.headers["Location"] == config.oidc.enrollment_url
+        else:
+            assert r.headers["Location"] == return_url
+
+    return r
+
+
+@pytest.mark.asyncio
+async def test_login(
+    tmp_path: Path,
+    client: AsyncClient,
+    respx_mock: respx.Router,
+    caplog: LogCaptureFixture,
+) -> None:
+    config = await configure(tmp_path, "oidc")
+    assert config.oidc
+    token = create_upstream_oidc_jwt(
+        groups=["admin"], name="Some Person", email="person@example.com"
+    )
+    return_url = "https://example.com:4444/foo?a=bar&b=baz"
+
+    # Perform a successful login.
+    caplog.clear()
+    r = await simulate_oidc_login(
+        client, respx_mock, token, return_url=return_url
+    )
+    assert r.status_code == 307
+
     # Verify the logging.
     login_url = config.oidc.login_url
+    expected_scopes = set(config.group_mapping["admin"])
+    expected_scopes.add("user:token")
+    username = token.claims[config.oidc.username_claim]
+    uid = token.claims[config.oidc.uid_claim]
+    event = f"Successfully authenticated user {username} ({uid})"
     assert parse_log(caplog) == [
         {
             "event": f"Redirecting user to {login_url} for authentication",
@@ -68,24 +142,7 @@ async def test_login(
             },
             "return_url": return_url,
             "severity": "info",
-        }
-    ]
-
-    # Simulate the return from the provider.
-    caplog.clear()
-    r = await client.get(
-        "/login", params={"code": "some-code", "state": query["state"][0]}
-    )
-    assert r.status_code == 307
-    assert r.headers["Location"] == return_url
-
-    # Verify the logging.
-    expected_scopes = set(config.group_mapping["admin"])
-    expected_scopes.add("user:token")
-    username = token.claims[config.oidc.username_claim]
-    uid = token.claims[config.oidc.uid_claim]
-    event = f"Successfully authenticated user {username} ({uid})"
-    assert parse_log(caplog) == [
+        },
         {
             "event": f"Retrieving ID token from {config.oidc.token_url}",
             "httpRequest": {
@@ -132,23 +189,16 @@ async def test_login_redirect_header(
     """Test receiving the redirect header via X-Auth-Request-Redirect."""
     await configure(tmp_path, "oidc")
     token = create_upstream_oidc_jwt(groups=["admin"])
-    await mock_oidc_provider_config(respx_mock, "orig-kid")
-    await mock_oidc_provider_token(respx_mock, "some-code", token)
     return_url = "https://example.com/foo?a=bar&b=baz"
 
-    r = await client.get(
-        "/login", headers={"X-Auth-Request-Redirect": return_url}
+    r = await simulate_oidc_login(
+        client,
+        respx_mock,
+        token,
+        return_url=return_url,
+        use_redirect_header=True,
     )
     assert r.status_code == 307
-    url = urlparse(r.headers["Location"])
-    query = parse_qs(url.query)
-
-    # Simulate the return from the OpenID Connect provider.
-    r = await client.get(
-        "/login", params={"code": "some-code", "state": query["state"][0]}
-    )
-    assert r.status_code == 307
-    assert r.headers["Location"] == return_url
 
 
 @pytest.mark.asyncio
@@ -158,24 +208,12 @@ async def test_oauth2_callback(
     """Test the compatibility /oauth2/callback route."""
     config = await configure(tmp_path, "oidc")
     token = create_upstream_oidc_jwt(groups=["admin"])
-    await mock_oidc_provider_config(respx_mock, "orig-kid")
-    await mock_oidc_provider_token(respx_mock, "some-code", token)
     assert config.oidc
-    return_url = "https://example.com/foo"
 
-    r = await client.get("/login", params={"rd": return_url})
-    assert r.status_code == 307
-    url = urlparse(r.headers["Location"])
-    query = parse_qs(url.query)
-    assert query["redirect_uri"][0] == config.oidc.redirect_url
-
-    # Simulate the return from the OpenID Connect provider.
-    r = await client.get(
-        "/oauth2/callback",
-        params={"code": "some-code", "state": query["state"][0]},
+    r = await simulate_oidc_login(
+        client, respx_mock, token, callback_route="/oauth2/callback"
     )
     assert r.status_code == 307
-    assert r.headers["Location"] == return_url
 
 
 @pytest.mark.asyncio
@@ -192,22 +230,9 @@ async def test_claim_names(
     token = create_upstream_oidc_jwt(
         kid="orig-kid", groups=["admin"], **claims
     )
-    await mock_oidc_provider_config(respx_mock, "orig-kid")
-    await mock_oidc_provider_token(respx_mock, "some-code", token)
-    return_url = "https://example.com/foo"
 
-    r = await client.get("/login", params={"rd": return_url})
+    r = await simulate_oidc_login(client, respx_mock, token)
     assert r.status_code == 307
-    url = urlparse(r.headers["Location"])
-    query = parse_qs(url.query)
-    assert query["redirect_uri"][0] == config.oidc.redirect_url
-
-    # Simulate the return from the OpenID Connect provider.
-    r = await client.get(
-        "/login", params={"code": "some-code", "state": query["state"][0]}
-    )
-    assert r.status_code == 307
-    assert r.headers["Location"] == return_url
 
     # Check that the /auth route works and sets the headers correctly.  uid
     # will be set to some-user and uidNumber will be set to 1000, so we'll
@@ -288,8 +313,7 @@ async def test_callback_error(
     assert r.status_code == 403
     assert "Cannot contact authentication provider" in r.text
 
-    # Now try a reply that returns 200 but doesn't have the field we
-    # need.
+    # Now try a reply that returns 200 but doesn't have the field we need.
     respx_mock.post(config.oidc.token_url).respond(json={"foo": "bar"})
     r = await client.get("/login", params={"rd": return_url})
     query = parse_qs(urlparse(r.headers["Location"]).query)
@@ -385,19 +409,8 @@ async def test_invalid_username(
     token = create_upstream_oidc_jwt(
         groups=["admin"], sub="invalid@user", uid="invalid@user"
     )
-    await mock_oidc_provider_config(respx_mock, "orig-kid")
-    await mock_oidc_provider_token(respx_mock, "some-code", token)
-    return_url = "https://example.com/foo"
 
-    r = await client.get("/login", params={"rd": return_url})
-    assert r.status_code == 307
-    url = urlparse(r.headers["Location"])
-    query = parse_qs(url.query)
-
-    # Simulate the return from the OpenID Connect provider.
-    r = await client.get(
-        "/login", params={"code": "some-code", "state": query["state"][0]}
-    )
+    r = await simulate_oidc_login(client, respx_mock, token)
     assert r.status_code == 403
     assert "Invalid username: invalid@user" in r.text
 
@@ -408,19 +421,8 @@ async def test_invalid_group_syntax(
 ) -> None:
     await configure(tmp_path, "oidc")
     token = create_upstream_oidc_jwt(isMemberOf=47)
-    await mock_oidc_provider_config(respx_mock, "orig-kid")
-    await mock_oidc_provider_token(respx_mock, "some-code", token)
-    return_url = "https://example.com/foo"
 
-    r = await client.get("/login", params={"rd": return_url})
-    assert r.status_code == 307
-    url = urlparse(r.headers["Location"])
-    query = parse_qs(url.query)
-
-    # Simulate the return from the OpenID Connect provider.
-    r = await client.get(
-        "/login", params={"code": "some-code", "state": query["state"][0]}
-    )
+    r = await simulate_oidc_login(client, respx_mock, token)
     assert r.status_code == 403
     assert "isMemberOf claim has invalid format" in r.text
 
@@ -442,21 +444,9 @@ async def test_invalid_groups(
             {"name": "foo", "id": ["bar"]},
         ]
     )
-    await mock_oidc_provider_config(respx_mock, "orig-kid")
-    await mock_oidc_provider_token(respx_mock, "some-code", token)
-    return_url = "https://example.com/foo"
 
-    r = await client.get("/login", params={"rd": return_url})
+    r = await simulate_oidc_login(client, respx_mock, token)
     assert r.status_code == 307
-    url = urlparse(r.headers["Location"])
-    query = parse_qs(url.query)
-
-    # Simulate the return from the OpenID Connect provider.
-    r = await client.get(
-        "/login", params={"code": "some-code", "state": query["state"][0]}
-    )
-    assert r.status_code == 307
-    assert r.headers["Location"] == return_url
 
     r = await client.get("/auth", params={"scope": "exec:admin"})
     assert r.status_code == 200
@@ -470,19 +460,8 @@ async def test_no_valid_groups(
     config = await configure(tmp_path, "oidc")
     assert config.oidc
     token = create_upstream_oidc_jwt(groups=[])
-    await mock_oidc_provider_config(respx_mock, "orig-kid")
-    await mock_oidc_provider_token(respx_mock, "some-code", token)
-    return_url = "https://example.com/foo?a=bar&b=baz"
 
-    r = await client.get("/login", params={"rd": return_url})
-    assert r.status_code == 307
-    url = urlparse(r.headers["Location"])
-    query = parse_qs(url.query)
-
-    # Simulate the return from the OpenID Connect provider.
-    r = await client.get(
-        "/login", params={"code": "some-code", "state": query["state"][0]}
-    )
+    r = await simulate_oidc_login(client, respx_mock, token)
     assert r.status_code == 403
     assert r.headers["Cache-Control"] == "no-cache, must-revalidate"
     username = token.claims[config.oidc.username_claim]
@@ -502,21 +481,9 @@ async def test_unicode_name(
     config = await configure(tmp_path, "oidc")
     assert config.oidc
     token = create_upstream_oidc_jwt(name="名字", groups=["admin"])
-    await mock_oidc_provider_config(respx_mock, "orig-kid")
-    await mock_oidc_provider_token(respx_mock, "some-code", token)
-    return_url = "https://example.com/foo"
 
-    r = await client.get("/login", params={"rd": return_url})
+    r = await simulate_oidc_login(client, respx_mock, token)
     assert r.status_code == 307
-    url = urlparse(r.headers["Location"])
-    query = parse_qs(url.query)
-
-    # Simulate the return from the OpenID Connect provider.
-    r = await client.get(
-        "/login", params={"code": "some-code", "state": query["state"][0]}
-    )
-    assert r.status_code == 307
-    assert r.headers["Location"] == return_url
 
     # Check that the name as returned from the user-info API is correct.
     r = await client.get("/auth/api/v1/user-info")
@@ -537,21 +504,9 @@ async def test_ldap(
     config = await config_dependency()
     assert config.ldap
     token = create_upstream_oidc_jwt(sub=mock_ldap.source_id, groups=["admin"])
-    await mock_oidc_provider_config(respx_mock, "orig-kid")
-    await mock_oidc_provider_token(respx_mock, "some-code", token)
-    return_url = "https://example.com/foo"
 
-    r = await client.get("/login", params={"rd": return_url})
+    r = await simulate_oidc_login(client, respx_mock, token)
     assert r.status_code == 307
-    url = urlparse(r.headers["Location"])
-    query = parse_qs(url.query)
-
-    # Simulate the return from the OpenID Connect provider.
-    r = await client.get(
-        "/login", params={"code": "some-code", "state": query["state"][0]}
-    )
-    assert r.status_code == 307
-    assert r.headers["Location"] == return_url
 
     # Check that the data returned from the user-info API is correct.
     r = await client.get("/auth/api/v1/user-info")
@@ -585,16 +540,10 @@ async def test_enrollment_url(
     await mock_oidc_provider_config(respx_mock, "orig-kid")
     await mock_oidc_provider_token(respx_mock, "some-code", token)
 
-    r = await client.get("/login", params={"rd": "https://example.com/"})
-    assert r.status_code == 307
-    url = urlparse(r.headers["Location"])
-    query = parse_qs(url.query)
-
-    r = await client.get(
-        "/login", params={"code": "some-code", "state": query["state"][0]}
+    r = await simulate_oidc_login(
+        client, respx_mock, token, expect_enrollment=True
     )
     assert r.status_code == 307
-    assert r.headers["Location"] == config.oidc.enrollment_url
 
 
 @pytest.mark.asyncio
@@ -611,21 +560,9 @@ async def test_firestore(
     firestore_storage = factory.create_firestore_storage()
     await firestore_storage.initialize()
     token = create_upstream_oidc_jwt(groups=["admin", "foo"])
-    await mock_oidc_provider_config(respx_mock, "orig-kid")
-    await mock_oidc_provider_token(respx_mock, "some-code", token)
-    return_url = "https://example.com/foo"
 
-    r = await client.get("/login", params={"rd": return_url})
+    r = await simulate_oidc_login(client, respx_mock, token)
     assert r.status_code == 307
-    url = urlparse(r.headers["Location"])
-    query = parse_qs(url.query)
-
-    # Simulate the return from the OpenID Connect provider.
-    r = await client.get(
-        "/login", params={"code": "some-code", "state": query["state"][0]}
-    )
-    assert r.status_code == 307
-    assert r.headers["Location"] == return_url
 
     # Check the allocated UID and GIDs.
     username = token.claims[config.oidc.username_claim]
@@ -646,15 +583,7 @@ async def test_firestore(
     # Firestore API; it only works with our mock implementation.
     transaction = mock_firestore.transaction()
     transaction.delete(mock_firestore.collection("users").document(username))
-    await mock_oidc_provider_config(respx_mock, "orig-kid")
-    await mock_oidc_provider_token(respx_mock, "some-code", token)
-    r = await client.get("/login", params={"rd": return_url})
-    assert r.status_code == 307
-    url = urlparse(r.headers["Location"])
-    query = parse_qs(url.query)
-    r = await client.get(
-        "/login", params={"code": "some-code", "state": query["state"][0]}
-    )
+    r = await simulate_oidc_login(client, respx_mock, token)
     assert r.status_code == 307
     r = await client.get("/auth/api/v1/user-info")
     assert r.status_code == 200
@@ -671,15 +600,7 @@ async def test_firestore(
     # Authenticate as a different user.
     claims = {config.oidc.username_claim: "other-user", "sub": "other-user"}
     token = create_upstream_oidc_jwt(groups=["foo", "group-1"], **claims)
-    await mock_oidc_provider_config(respx_mock, "orig-kid")
-    await mock_oidc_provider_token(respx_mock, "some-code", token)
-    r = await client.get("/login", params={"rd": return_url})
-    assert r.status_code == 307
-    url = urlparse(r.headers["Location"])
-    query = parse_qs(url.query)
-    r = await client.get(
-        "/login", params={"code": "some-code", "state": query["state"][0]}
-    )
+    r = await simulate_oidc_login(client, respx_mock, token)
     assert r.status_code == 307
     r = await client.get("/auth/api/v1/user-info")
     assert r.status_code == 200
@@ -696,15 +617,7 @@ async def test_firestore(
     # Authenticate as a bot user, which should use a different UID space.
     claims = {config.oidc.username_claim: "bot-foo", "sub": "bot-foo"}
     token = create_upstream_oidc_jwt(groups=["foo", "group-2"], **claims)
-    await mock_oidc_provider_config(respx_mock, "orig-kid")
-    await mock_oidc_provider_token(respx_mock, "some-code", token)
-    r = await client.get("/login", params={"rd": return_url})
-    assert r.status_code == 307
-    url = urlparse(r.headers["Location"])
-    query = parse_qs(url.query)
-    r = await client.get(
-        "/login", params={"code": "some-code", "state": query["state"][0]}
-    )
+    r = await simulate_oidc_login(client, respx_mock, token)
     assert r.status_code == 307
     r = await client.get("/auth/api/v1/user-info")
     assert r.status_code == 200

--- a/tests/handlers/oidc_test.py
+++ b/tests/handlers/oidc_test.py
@@ -41,9 +41,7 @@ async def test_login(
     caplog: LogCaptureFixture,
 ) -> None:
     clients = [OIDCClient(client_id="some-id", client_secret="some-secret")]
-    config = await configure(
-        tmp_path, "github-oidc-server", oidc_clients=clients
-    )
+    config = configure(tmp_path, "github-oidc-server", oidc_clients=clients)
     assert config.oidc_server
     factory.reconfigure(config)
     token_data = await create_session_token(factory)
@@ -169,7 +167,7 @@ async def test_unauthenticated(
     tmp_path: Path, client: AsyncClient, caplog: LogCaptureFixture
 ) -> None:
     clients = [OIDCClient(client_id="some-id", client_secret="some-secret")]
-    await configure(tmp_path, "github-oidc-server", oidc_clients=clients)
+    configure(tmp_path, "github-oidc-server", oidc_clients=clients)
     return_url = f"https://{TEST_HOSTNAME}:4444/foo?a=bar&b=baz"
     login_params = {
         "response_type": "code",
@@ -213,9 +211,7 @@ async def test_login_errors(
     caplog: LogCaptureFixture,
 ) -> None:
     clients = [OIDCClient(client_id="some-id", client_secret="some-secret")]
-    config = await configure(
-        tmp_path, "github-oidc-server", oidc_clients=clients
-    )
+    config = configure(tmp_path, "github-oidc-server", oidc_clients=clients)
     factory.reconfigure(config)
     token_data = await create_session_token(factory)
     await set_session_cookie(client, token_data.token)
@@ -339,9 +335,7 @@ async def test_token_errors(
         OIDCClient(client_id="some-id", client_secret="some-secret"),
         OIDCClient(client_id="other-id", client_secret="other-secret"),
     ]
-    config = await configure(
-        tmp_path, "github-oidc-server", oidc_clients=clients
-    )
+    config = configure(tmp_path, "github-oidc-server", oidc_clients=clients)
     factory.reconfigure(config)
     token_data = await create_session_token(factory)
     token = token_data.token
@@ -523,9 +517,7 @@ async def test_invalid(
     caplog: LogCaptureFixture,
 ) -> None:
     clients = [OIDCClient(client_id="some-id", client_secret="some-secret")]
-    config = await configure(
-        tmp_path, "github-oidc-server", oidc_clients=clients
-    )
+    config = configure(tmp_path, "github-oidc-server", oidc_clients=clients)
     factory.reconfigure(config)
     token_data = await create_session_token(factory)
     oidc_service = factory.create_oidc_service()
@@ -605,9 +597,7 @@ async def test_well_known_jwks(
     tmp_path: Path, client: AsyncClient, config: Config
 ) -> None:
     clients = [OIDCClient(client_id="some-id", client_secret="some-secret")]
-    config = await configure(
-        tmp_path, "github-oidc-server", oidc_clients=clients
-    )
+    config = configure(tmp_path, "github-oidc-server", oidc_clients=clients)
     assert config.oidc_server
     r = await client.get("/.well-known/jwks.json")
     assert r.status_code == 200
@@ -638,9 +628,7 @@ async def test_well_known_oidc(
     tmp_path: Path, client: AsyncClient, config: Config
 ) -> None:
     clients = [OIDCClient(client_id="some-id", client_secret="some-secret")]
-    config = await configure(
-        tmp_path, "github-oidc-server", oidc_clients=clients
-    )
+    config = configure(tmp_path, "github-oidc-server", oidc_clients=clients)
     assert config.oidc_server
     r = await client.get("/.well-known/openid-configuration")
     assert r.status_code == 200

--- a/tests/providers/oidc_verifier_test.py
+++ b/tests/providers/oidc_verifier_test.py
@@ -49,7 +49,7 @@ def encode_token(
 async def test_verify_token(
     tmp_path: Path, respx_mock: respx.Router, factory: ComponentFactory
 ) -> None:
-    config = await configure(tmp_path, "oidc")
+    config = configure(tmp_path, "oidc")
     assert config.oidc
     factory.reconfigure(config)
     verifier = factory.create_oidc_token_verifier()
@@ -87,7 +87,7 @@ async def test_verify_token(
 async def test_verify_oidc_no_kids(
     tmp_path: Path, respx_mock: respx.Router, factory: ComponentFactory
 ) -> None:
-    config = await configure(tmp_path, "oidc-no-kids")
+    config = configure(tmp_path, "oidc-no-kids")
     assert config.oidc
     factory.reconfigure(config)
     verifier = factory.create_oidc_token_verifier()
@@ -112,7 +112,7 @@ async def test_verify_oidc_no_kids(
 async def test_key_retrieval(
     tmp_path: Path, respx_mock: respx.Router, factory: ComponentFactory
 ) -> None:
-    config = await configure(tmp_path, "oidc-no-kids")
+    config = configure(tmp_path, "oidc-no-kids")
     factory.reconfigure(config)
     assert config.oidc
     verifier = factory.create_oidc_token_verifier()

--- a/tests/services/oidc_test.py
+++ b/tests/services/oidc_test.py
@@ -27,9 +27,7 @@ from ..support.tokens import create_session_token
 @pytest.mark.asyncio
 async def test_issue_code(tmp_path: Path, factory: ComponentFactory) -> None:
     clients = [OIDCClient(client_id="some-id", client_secret="some-secret")]
-    config = await configure(
-        tmp_path, "github-oidc-server", oidc_clients=clients
-    )
+    config = configure(tmp_path, "github-oidc-server", oidc_clients=clients)
     factory.reconfigure(config)
     oidc_service = factory.create_oidc_service()
     token_data = await create_session_token(factory)
@@ -71,9 +69,7 @@ async def test_redeem_code(tmp_path: Path, factory: ComponentFactory) -> None:
         OIDCClient(client_id="client-1", client_secret="client-1-secret"),
         OIDCClient(client_id="client-2", client_secret="client-2-secret"),
     ]
-    config = await configure(
-        tmp_path, "github-oidc-server", oidc_clients=clients
-    )
+    config = configure(tmp_path, "github-oidc-server", oidc_clients=clients)
     assert config.oidc_server
     factory.reconfigure(config)
     oidc_service = factory.create_oidc_service()
@@ -110,9 +106,7 @@ async def test_redeem_code_errors(
         OIDCClient(client_id="client-1", client_secret="client-1-secret"),
         OIDCClient(client_id="client-2", client_secret="client-2-secret"),
     ]
-    config = await configure(
-        tmp_path, "github-oidc-server", oidc_clients=clients
-    )
+    config = configure(tmp_path, "github-oidc-server", oidc_clients=clients)
     factory.reconfigure(config)
     oidc_service = factory.create_oidc_service()
     token_data = await create_session_token(factory)
@@ -148,9 +142,7 @@ async def test_redeem_code_errors(
 @pytest.mark.asyncio
 async def test_issue_token(tmp_path: Path, factory: ComponentFactory) -> None:
     clients = [OIDCClient(client_id="some-id", client_secret="some-secret")]
-    config = await configure(
-        tmp_path, "github-oidc-server", oidc_clients=clients
-    )
+    config = configure(tmp_path, "github-oidc-server", oidc_clients=clients)
     assert config.oidc_server
     factory.reconfigure(config)
     oidc_service = factory.create_oidc_service()

--- a/tests/services/oidc_test.py
+++ b/tests/services/oidc_test.py
@@ -15,7 +15,7 @@ from gafaelfawr.dependencies.redis import redis_dependency
 from gafaelfawr.exceptions import (
     InvalidClientError,
     InvalidGrantError,
-    UnauthorizedClientException,
+    UnauthorizedClientError,
 )
 from gafaelfawr.factory import ComponentFactory
 from gafaelfawr.models.oidc import OIDCAuthorizationCode
@@ -37,7 +37,7 @@ async def test_issue_code(tmp_path: Path, factory: ComponentFactory) -> None:
     assert config.oidc_server
     assert list(config.oidc_server.clients) == clients
 
-    with pytest.raises(UnauthorizedClientException):
+    with pytest.raises(UnauthorizedClientError):
         await oidc_service.issue_code("unknown-client", redirect_uri, token)
 
     code = await oidc_service.issue_code("some-id", redirect_uri, token)

--- a/tests/services/userinfo_test.py
+++ b/tests/services/userinfo_test.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 import pytest
 
-from gafaelfawr.exceptions import MissingClaimsException
+from gafaelfawr.exceptions import MissingClaimsError
 from gafaelfawr.factory import ComponentFactory
 from gafaelfawr.models.oidc import OIDCVerifiedToken
 from tests.support.settings import configure
@@ -34,14 +34,14 @@ async def test_missing_token_data(
     )
 
     # Missing username claim.
-    with pytest.raises(MissingClaimsException) as excinfo:
+    with pytest.raises(MissingClaimsError) as excinfo:
         await user_info.get_user_info_from_oidc_token(token)
     expected = f"No {config.oidc.username_claim} claim in token"
     assert str(excinfo.value) == expected
 
     # Missing UID claim.
     token.claims[config.oidc.username_claim] = "some-user"
-    with pytest.raises(MissingClaimsException) as excinfo:
+    with pytest.raises(MissingClaimsError) as excinfo:
         await user_info.get_user_info_from_oidc_token(token)
     expected = f"No {config.oidc.uid_claim} claim in token"
     assert str(excinfo.value) == expected

--- a/tests/services/userinfo_test.py
+++ b/tests/services/userinfo_test.py
@@ -17,7 +17,7 @@ from tests.support.settings import configure
 async def test_missing_token_data(
     tmp_path: Path, factory: ComponentFactory
 ) -> None:
-    config = await configure(tmp_path, "oidc")
+    config = configure(tmp_path, "oidc")
     assert config.oidc
     factory.reconfigure(config)
     user_info = factory.create_oidc_user_info_service()

--- a/tests/support/ldap.py
+++ b/tests/support/ldap.py
@@ -9,7 +9,7 @@ from unittest.mock import Mock
 import bonsai
 from bonsai.utils import escape_filter_exp
 
-from gafaelfawr.config import LDAPConfig
+from gafaelfawr.dependencies.config import config_dependency
 from gafaelfawr.models.token import TokenGroup
 
 __all__ = ["MockLDAP"]
@@ -18,9 +18,8 @@ __all__ = ["MockLDAP"]
 class MockLDAP(Mock):
     """Mock bonsai LDAP api for testing."""
 
-    def __init__(self, config: LDAPConfig) -> None:
+    def __init__(self) -> None:
         super().__init__(spec=bonsai.LDAPClient)
-        self.config = config
         self.groups = [
             TokenGroup(name="foo", id=1222),
             TokenGroup(name="group-1", id=123123),
@@ -50,7 +49,9 @@ class MockLDAP(Mock):
         query: str,
         attrlist: List[str],
     ) -> List[Dict[str, List[str]]]:
-        assert base_dn == self.config.base_dn
+        config = config_dependency.config()
+        assert config.ldap
+        assert base_dn == config.ldap.base_dn
         assert scope in (
             bonsai.LDAPSearchScope.SUB,
             bonsai.LDAPSearchScope.ONELEVEL,

--- a/tests/support/settings.py
+++ b/tests/support/settings.py
@@ -139,7 +139,7 @@ def build_settings(
     return settings_path
 
 
-async def configure(
+def configure(
     tmp_path: Path,
     template: str,
     *,
@@ -150,6 +150,10 @@ async def configure(
 
     This cannot be used to change the database URL because sessions will not
     be recreated or the database reinitialized.
+
+    Notes
+    -----
+    This is used for tests that cannot be async, so itself must not be async.
 
     Parameters
     ----------
@@ -175,4 +179,4 @@ async def configure(
         **settings,
     )
     config_dependency.set_settings_path(str(settings_path))
-    return await config_dependency()
+    return config_dependency.config()


### PR DESCRIPTION
- Tighten the regex for recognizing bot users
- Prefer `response_class` for redirects instead of constructing `RedirectResponse`
- Refactor common OIDC test code into a helper function
- Refactor how Gafaelfawr is configured in tests to use common functions
- Document `usernameClaim` and `uidClaim` configuration settings
- Use `Error` uniformly as a class name suffix for exceptions
- Better error reporting for LDAP or Firestore failures during login