### PR TITLE
[DM-34726] Use connection pool and cache for LDAP

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -59,9 +59,13 @@ API reference
 
 .. automodapi:: gafaelfawr.services.admin
 
+.. automodapi:: gafaelfawr.services.firestore
+
 .. automodapi:: gafaelfawr.services.influxdb
 
 .. automodapi:: gafaelfawr.services.kubernetes
+
+.. automodapi:: gafaelfawr.services.ldap
 
 .. automodapi:: gafaelfawr.services.oidc
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -7,6 +7,8 @@ API reference
 
 .. automodapi:: gafaelfawr.auth
 
+.. automodapi:: gafaelfawr.cache
+
 .. automodapi:: gafaelfawr.config
 
 .. automodapi:: gafaelfawr.constants

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -22,6 +22,9 @@ API reference
 
 .. automodapi:: gafaelfawr.dependencies.context
 
+.. automodapi:: gafaelfawr.dependencies.ldap
+   :include-all-objects:
+
 .. automodapi:: gafaelfawr.dependencies.redis
    :include-all-objects:
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -102,9 +102,10 @@ nitpick_ignore = [
     ("py:class", "gafaelfawr.models.history.ConstrainedStrValue"),
     ("py:class", "gafaelfawr.models.token.ConstrainedIntValue"),
     ("py:class", "gafaelfawr.models.token.ConstrainedStrValue"),
-    # asyncio.Queue is documented, and that's what all the code references,
-    # but the combination of Sphinx extensions we're using confuse themselves
-    # and there doesn't seem to be any way to fix this.
+    # asyncio.Lock and asyncio.Queue are documented, and that's what all the
+    # code references, but the combination of Sphinx extensions we're using
+    # confuse themselves and there doesn't seem to be any way to fix this.
+    ("py:class", "asyncio.locks.Lock"),
     ("py:class", "asyncio.queues.Queue"),
     # TypeVar references that shouldn't be documented.
     ("py:class", "gafaelfawr.dependencies.cache.S"),

--- a/src/gafaelfawr/cache.py
+++ b/src/gafaelfawr/cache.py
@@ -1,0 +1,369 @@
+"""Shared caches.
+
+These caches are process-global, managed by
+`~gafaelfawr.dependencies.cache.CacheDependency` and its instantiations.
+The common theme is some storage wrapped in an `asyncio.Lock`, possibly with
+some complex structure to allow per-user locking.  These services sit below
+the main service layer and are only intended for use via their service layer
+(`~gafaelfawr.services.token_cache.TokenCacheService`,
+`~gafaelfawr.services.ldap.LDAPService`, and
+`~gafaelfawr.services.firestore.FirestoreService`).
+"""
+
+import asyncio
+from abc import ABCMeta, abstractmethod
+from types import TracebackType
+from typing import Dict, List, Literal, Optional, Tuple, Type
+
+from cachetools import LRUCache
+
+from .constants import ID_CACHE_SIZE, TOKEN_CACHE_SIZE
+from .models.token import Token, TokenData
+
+LRUTokenCache = LRUCache[Tuple[str, ...], Token]
+"""Type for the underlying token cache."""
+
+__all__ = [
+    "BaseCache",
+    "IdCache",
+    "InternalTokenCache",
+    "NotebookTokenCache",
+    "TokenCache",
+    "TokenLockManager",
+]
+
+
+class BaseCache(metaclass=ABCMeta):
+    """Base class for caches managed by a cache dependency."""
+
+    @abstractmethod
+    async def clear(self) -> None:
+        """Invalidate the cache.
+
+        Used primarily for testing.
+        """
+
+
+class IdCache(BaseCache):
+    """A cache of UIDs or GIDs.
+
+    This contains only the data structure for the ID cache and some simple
+    accessor functions.  All of the logic is handled by
+    `~gafaelfawr.services.firestore.FirestoreService`.  Two instances of this
+    class will be created, one for UIDs and one for GIDs.
+
+    UIDs and GIDs, once cached, are immutable, so the caller can first call
+    `get` without a lock and safely use the result if it is not `None`.  If
+    `get` returns `None`, the caller should take the lock, call `get` again,
+    and then allocate and `store` a token if `get` still returns `None`.
+
+    Notes
+    -----
+    When there's a cache miss for a UID or GID, the goal is to block the
+    expensive Firestore API call until the first requester either finds a
+    token in the database or creates a new one, either way adding it to the
+    cache.  Hopefully then subsequent requests that were blocked on the lock
+    can be answered from the cache.
+    """
+
+    def __init__(self) -> None:
+        self._cache: LRUCache[str, int] = LRUCache(ID_CACHE_SIZE)
+        self._lock = asyncio.Lock()
+
+    async def clear(self) -> None:
+        """Invalidate the cache.
+
+        Used primarily for testing.
+        """
+        async with self._lock:
+            self._cache = LRUCache(ID_CACHE_SIZE)
+
+    def get(self, name: str) -> Optional[int]:
+        """Retrieve the UID or GID for a name, if available.
+
+        Parameters
+        ----------
+        name : `str`
+            Username or group name.
+
+        Returns
+        -------
+        id : `int` or `None`
+            UID or GID if the name is in the cache, else `None`.
+        """
+        return self._cache.get(name)
+
+    def lock(self) -> asyncio.Lock:
+        """Return the cache lock for use in a context manager.
+
+        See `store` for how to use this method.
+
+        Returns
+        -------
+        lock : `asyncio.Lock`
+            The lock for the cache.
+        """
+        return self._lock
+
+    def store(self, name: str, id: int) -> None:
+        """Store the UID or GID for a user or group in the cache.
+
+        Examples
+        --------
+        .. code-block:: python
+
+            async with id_cache.lock():
+                uid = id_cache.get(username)
+                if not uid:
+                    # do something to allocate a UID
+                    id_cache.store(username, uid)
+
+        Parameters
+        ----------
+        name : `str`
+            Name of the user or group.
+        id : `int`
+            UID or GID to store.
+        """
+        self._cache[name] = id
+
+
+class TokenLockManager:
+    """Helper class for managing per-user locks.
+
+    This should only be created by `TokenCache`.  It is returned by the
+    `TokenCache.lock` method and implements the async context manager
+    protocol.
+
+    Parameters
+    ----------
+    general_lock : `asyncio.Lock`
+        Lock protecting the per-user locks.
+    user_lock : `asyncio.Lock`
+        Per-user lock for a given user.
+    """
+
+    def __init__(
+        self, general_lock: asyncio.Lock, user_lock: asyncio.Lock
+    ) -> None:
+        self._general_lock = general_lock
+        self._user_lock = user_lock
+
+    async def __aenter__(self) -> asyncio.Lock:
+        async with self._general_lock:
+            await self._user_lock.acquire()
+            return self._user_lock
+
+    async def __aexit__(
+        self,
+        exc_type: Optional[Type[Exception]],
+        exc: Optional[Exception],
+        tb: Optional[TracebackType],
+    ) -> Literal[False]:
+        self._user_lock.release()
+        return False
+
+
+class TokenCache(BaseCache):
+    """Base class for a cache of internal or notebook tokens.
+
+    Notes
+    -----
+    There is a moderately complex locking structure at play here.  When
+    there's a cache miss for an internal or notebook token for a specific
+    user, the goal is to block the expensive database lookups or token
+    creation for that user until the first requester either finds a token in
+    the database or creates a new one, either way adding it to the cache.
+    Hopefully then subsequent requests that were blocked on the lock can be
+    answered from the cache.
+
+    There is therefore a dictionary of per-user locks, but since we don't know
+    the list of users in advance, we have to populate those locks on the fly.
+    It shouldn't be necessary to protect the dict of per-user locks with
+    another lock because we only need to worry about asyncio concurrency, but
+    since FastAPI does use a thread pool, err on the side of caution and use
+    the same locking strategy that would be used for multithreaded code.
+
+    Note that the per-user lock must be acquired before the general lock is
+    released, so the `lock` method cannot simply return the per-user lock.  To
+    see why, imagine that one code path retrieves the per-user lock in
+    preparation for acquiring it, and then another code path calls `clear`.
+    `clear` acquires the global lock and then deletes the per-user lock, but
+    the first caller still has a copy of the per-user lock and thinks it's
+    valid.  It may then take that per-user lock, but a third code path could
+    also try to lock the same user and get a new per-user lock from the
+    post-clearing cache.  Both the first and third code paths will think they
+    have a lock and may conflict.  `TokenLockManager` is used to handle this.
+    """
+
+    def __init__(self) -> None:
+        self._cache: LRUTokenCache = LRUCache(TOKEN_CACHE_SIZE)
+        self._lock = asyncio.Lock()
+        self._user_locks: Dict[str, asyncio.Lock] = {}
+
+    async def clear(self) -> None:
+        """Invalidate the cache.
+
+        Used primarily for testing.
+        """
+        async with self._lock:
+            for user, lock in list(self._user_locks.items()):
+                async with lock:
+                    del self._user_locks[user]
+            self._cache = LRUCache(TOKEN_CACHE_SIZE)
+
+    async def lock(self, username: str) -> TokenLockManager:
+        """Return the per-user lock for locking.
+
+        The return value should be used with ``async with`` to hold a lock
+        around checking for a cached token and, if one is not found, creating
+        and storing a new token.
+
+        Parameters
+        ----------
+        username : `str`
+            Per-user lock to hold.
+
+        Returns
+        -------
+        lock : `TokenLockManager`
+            Async context manager that will take the user lock.
+        """
+        async with self._lock:
+            if username not in self._user_locks:
+                lock = asyncio.Lock()
+                self._user_locks[username] = lock
+            return TokenLockManager(self._lock, self._user_locks[username])
+
+
+class InternalTokenCache(TokenCache):
+    """Cache for internal tokens."""
+
+    def get(
+        self, token_data: TokenData, service: str, scopes: List[str]
+    ) -> Optional[Token]:
+        """Retrieve an internal token from the cache.
+
+        Should only be called while holding the lock.
+
+        Parameters
+        ----------
+        token_data : `gafaelfawr.models.token.TokenData`
+            The authentication data for the parent token.
+        service : `str`
+            The service of the internal token.
+        scopes : List[`str`]
+            The scopes the internal token should have.
+
+        Returns
+        -------
+        token : `gafaelfawr.models.token.Token` or `None`
+            The cached token or `None` if there is no matching token in the
+            cache.
+
+        Notes
+        -----
+        The token is not checked for validity or expiration.  This must be
+        done by the caller, while holding the lock, and the token replaced in
+        the cache if it is not valid.
+        """
+        key = self._build_key(token_data, service, scopes)
+        return self._cache.get(key)
+
+    def store(
+        self,
+        token_data: TokenData,
+        service: str,
+        scopes: List[str],
+        token: Token,
+    ) -> None:
+        """Store an internal token in the cache.
+
+        Should only be called while holding the lock.
+
+        Parameters
+        ----------
+        token_data : `gafaelfawr.models.token.TokenData`
+            The authentication data for the parent token.
+        service : `str`
+            The service of the internal token.
+        scopes : List[`str`]
+            The scopes the internal token should have.
+        token : `gafaelfawr.models.token.Token`
+            The token to cache.
+        """
+        key = self._build_key(token_data, service, scopes)
+        self._cache[key] = token
+
+    def _build_key(
+        self, token_data: TokenData, service: str, scopes: List[str]
+    ) -> Tuple[str, ...]:
+        """Build the cache key for an internal token.
+
+        Parameters
+        ----------
+        token_data : `gafaelfawr.models.token.TokenData`
+            The authentication data for the parent token.
+        service : `str`
+            The service of the internal token.
+        scopes : List[`str`]
+            The scopes the internal token should have.
+        """
+        expires = str(token_data.expires) if token_data.expires else "None"
+        scope = ",".join(sorted(scopes))
+        return (token_data.token.key, expires, service, scope)
+
+
+class NotebookTokenCache(TokenCache):
+    """Cache for notebook tokens."""
+
+    def get(self, token_data: TokenData) -> Optional[Token]:
+        """Retrieve a notebook token from the cache.
+
+        Should only be called while holding the lock.
+
+        Parameters
+        ----------
+        token_data : `gafaelfawr.models.token.TokenData`
+            The authentication data for the parent token.
+
+        Returns
+        -------
+        token : `gafaelfawr.models.token.Token` or `None`
+            The cached token or `None` if there is no matching token in the
+            cache.
+
+        Notes
+        -----
+        The token is not checked for validity or expiration.  This must be
+        done by the caller, while holding the lock, and the token replaced in
+        the cache if it is not valid.
+        """
+        key = self._build_key(token_data)
+        return self._cache.get(key)
+
+    def store(self, token_data: TokenData, token: Token) -> None:
+        """Store a notebook token in the cache.
+
+        Should only be called while holding the lock.
+
+        Parameters
+        ----------
+        token_data : `gafaelfawr.models.token.TokenData`
+            The authentication data for the parent token.
+        token : `gafaelfawr.models.token.Token`
+            The token to cache.
+        """
+        key = self._build_key(token_data)
+        self._cache[key] = token
+
+    def _build_key(self, token_data: TokenData) -> Tuple[str, ...]:
+        """Build the cache key for a notebook token.
+
+        Parameters
+        ----------
+        token_data : `gafaelfawr.models.token.TokenData`
+            The authentication data for the parent token.
+        """
+        expires = str(token_data.expires) if token_data.expires else "None"
+        return (token_data.token.key, expires)

--- a/src/gafaelfawr/constants.py
+++ b/src/gafaelfawr/constants.py
@@ -9,6 +9,9 @@ COOKIE_NAME = "gafaelfawr"
 HTTP_TIMEOUT = 20.0
 """Timeout (in seconds) for outbound HTTP requests to auth providers."""
 
+LDAP_TIMEOUT = 5.0
+"""Timeout (in seconds) for LDAP queries."""
+
 MINIMUM_LIFETIME = 5 * 60
 """Minimum expiration lifetime for a token in seconds."""
 

--- a/src/gafaelfawr/constants.py
+++ b/src/gafaelfawr/constants.py
@@ -23,14 +23,11 @@ SETTINGS_PATH = "/etc/gafaelfawr/gafaelfawr.yaml"
 
 # The following constants define per-process cache sizes.
 
-GID_CACHE_SIZE = 10000
-"""How many GID values to cache in memory."""
+ID_CACHE_SIZE = 10000
+"""How many UID or GID values to cache in memory."""
 
-UID_CACHE_SIZE = 10000
-"""How many UID values to cache in memory."""
-
-TOKEN_CACHE_SIZE = 10000
-"""How many internal and notebook tokens to cache in memory."""
+TOKEN_CACHE_SIZE = 5000
+"""How many internal or notebook tokens to cache in memory."""
 
 # The following constants define the limits of UID and GID ranges when
 # Gafaelfawr is doing UID and GID assignment.

--- a/src/gafaelfawr/dependencies/cache.py
+++ b/src/gafaelfawr/dependencies/cache.py
@@ -1,194 +1,18 @@
-"""Shared cache of internal and notebook tokens.
+"""FastAPI dependencies to manage process-global caches."""
 
-This is intended to be process-global, but needs to be created after the app
-has been created so that the asyncio locks are associated with the correct
-event loop.  The `TokenCache` object should only be used via
-`~gafaelfawr.services.token_cache.TokenCacheService`.
-"""
+from typing import Generic, Optional, Type, TypeVar
 
-import asyncio
-from abc import ABCMeta, abstractmethod
-from dataclasses import dataclass, field
-from typing import Dict, Generic, Optional, Tuple, Type, TypeVar
-
-from cachetools import LRUCache
-
-from ..constants import GID_CACHE_SIZE, TOKEN_CACHE_SIZE, UID_CACHE_SIZE
-from ..models.token import Token
-
-LRUIdCache = LRUCache[str, int]
-"""Type for the underlying cache."""
-
-LRUTokenCache = LRUCache[Tuple[str, ...], Token]
-"""Type for the underlying token cache."""
+from ..cache import BaseCache, IdCache, InternalTokenCache, NotebookTokenCache
 
 S = TypeVar("S", bound="BaseCache")
 
 __all__ = [
-    "BaseCache",
     "CacheDependency",
-    "IdCache",
-    "TokenCache",
-    "id_cache_dependency",
-    "token_cache_dependency",
+    "gid_cache_dependency",
+    "internal_token_cache_dependency",
+    "notebook_token_cache_dependency",
+    "uid_cache_dependency",
 ]
-
-
-class BaseCache(metaclass=ABCMeta):
-    """Base class for caches returned by a cache dependency."""
-
-    @abstractmethod
-    async def clear(self) -> None:
-        """Invalidate the cache.
-
-        Used primarily for testing.
-        """
-
-
-@dataclass
-class IdCache(BaseCache):
-    """A cache of UIDs and GIDs.
-
-    This contains only the data structure for the ID cache and some simple
-    accessor functions.  All of the logic is handled by
-    `~gafaelfawr.services.userinfo.UserInfoService`.
-
-    Notes
-    -----
-    When there's a cache miss for a UID or GID, the goal is to block the
-    expensive Firestore API call until the first requester either finds a
-    token in the database or creates a new one, either way adding it to the
-    cache.  Hopefully then subsequent requests that were blocked on the lock
-    can be answered from the cache.
-    """
-
-    gid_cache: LRUIdCache = field(
-        default_factory=lambda: LRUCache(GID_CACHE_SIZE)
-    )
-    """Shared cache storage for the GIDs."""
-
-    gid_lock: asyncio.Lock = field(default_factory=asyncio.Lock)
-    """Lock protecting the GID cache."""
-
-    uid_cache: LRUIdCache = field(
-        default_factory=lambda: LRUCache(UID_CACHE_SIZE)
-    )
-    """Shared cache storage for the UIDs."""
-
-    uid_lock: asyncio.Lock = field(default_factory=asyncio.Lock)
-    """Lock protecting the UID cache."""
-
-    async def clear(self) -> None:
-        """Invalidate the cache.
-
-        Used primarily for testing.
-        """
-        async with self.gid_lock:
-            self.gid_cache = LRUCache(GID_CACHE_SIZE)
-        async with self.uid_lock:
-            self.uid_cache = LRUCache(UID_CACHE_SIZE)
-
-    def get_gid(self, group: str) -> Optional[int]:
-        """Retrieve the GID for a group if available.
-
-        Parameters
-        ----------
-        group : `str`
-            Name of the group.
-
-        Returns
-        -------
-        gid : `int` or `None`
-            GID if the group is in the cache, otherwise `None`.
-        """
-        return self.gid_cache.get(group)
-
-    def get_uid(self, username: str) -> Optional[int]:
-        """Retrieve the UID for a username if available.
-
-        Parameters
-        ----------
-        username : `str`
-            Username of the user.
-
-        Returns
-        -------
-        uid : `int` or `None`
-            UID if the username is in the cache, otherwise `None`.
-        """
-        return self.uid_cache.get(username)
-
-    def store_gid(self, group: str, gid: int) -> None:
-        """Store the GID for a group in the cache.
-
-        Parameters
-        ----------
-        group : `str`
-            Name of the group.
-        gid : `int`
-            GID of the group.
-        """
-        self.gid_cache[group] = gid
-
-    def store_uid(self, username: str, uid: int) -> None:
-        """Store the UID for a user in the cache.
-
-        Parameters
-        ----------
-        username : `str`
-            Username of the user.
-        uid : `int`
-            UID of the user.
-        """
-        self.uid_cache[username] = uid
-
-
-@dataclass
-class TokenCache(BaseCache):
-    """A cache of internal and notebook tokens.
-
-    This contains only the data structure for a token cache.  All of the logic
-    is handled by `~gafaelfawr.services.token_cache.TokenCacheService`.
-
-    Notes
-    -----
-    There is a moderately complex locking structure at play here.  When
-    there's a cache miss for an internal or notebook token for a specific
-    user, the goal is to block the expensive database lookups or token
-    creation for that user until the first requester either finds a token in
-    the database or creates a new one, either way adding it to the cache.
-    Hopefully then subsequent requests that were blocked on the lock can be
-    answered from the cache.
-
-    There is therefore a dictionary of per-user locks, but since we don't know
-    the list of users in advance, we have to populate those locks on the fly.
-    It shouldn't be necessary to protect the dict of per-user locks with
-    another lock because we only need to worry about asyncio concurrency, but
-    since FastAPI does use a thread pool, err on the side of caution and use
-    the same locking strategy that would be used for multithreaded code.
-    """
-
-    cache: LRUTokenCache = field(
-        default_factory=lambda: LRUCache(TOKEN_CACHE_SIZE)
-    )
-    """Shared cache storage for the tokens."""
-
-    lock: asyncio.Lock = field(default_factory=asyncio.Lock)
-    """Lock protecting the dict of per-user locks."""
-
-    user_lock: Dict[str, asyncio.Lock] = field(default_factory=dict)
-    """Dict of per-user locks."""
-
-    async def clear(self) -> None:
-        """Invalidate the cache.
-
-        Used primarily for testing.
-        """
-        async with self.lock:
-            self.cache = LRUCache(TOKEN_CACHE_SIZE)
-            for user, lock in list(self.user_lock.items()):
-                async with lock:
-                    del self.user_lock[user]
 
 
 class CacheDependency(Generic[S]):
@@ -221,8 +45,14 @@ class CacheDependency(Generic[S]):
             self._cache = None
 
 
-id_cache_dependency = CacheDependency(IdCache)
-"""The dependency that will return the ID cache."""
+uid_cache_dependency = CacheDependency(IdCache)
+"""The dependency that will return the UID cache."""
 
-token_cache_dependency = CacheDependency(TokenCache)
-"""The dependency that will return the token cache."""
+gid_cache_dependency = CacheDependency(IdCache)
+"""The dependency that will return the UID cache."""
+
+internal_token_cache_dependency = CacheDependency(InternalTokenCache)
+"""The dependency that will return the internal token cache."""
+
+notebook_token_cache_dependency = CacheDependency(NotebookTokenCache)
+"""The dependency that will return the notebook token cache."""

--- a/src/gafaelfawr/dependencies/cache.py
+++ b/src/gafaelfawr/dependencies/cache.py
@@ -16,12 +16,12 @@ __all__ = [
 
 
 class CacheDependency(Generic[S]):
-    """Manage a single global token cache.
+    """Manage a global cache.
 
-    We have to defer creation of the token cache until application startup,
-    since the asyncio locks must be created in the same event loop as the rest
-    of the application.  This dependency creates the token cache lazily on
-    first request and then maintains it as a singleton.
+    We have to defer creation of the cache until application startup, since
+    the asyncio locks must be created in the same event loop as the rest of
+    the application.  This dependency creates the cache lazily on first
+    request and then maintains it as a singleton.
     """
 
     def __init__(self, cache_type: Type[S]) -> None:

--- a/src/gafaelfawr/dependencies/ldap.py
+++ b/src/gafaelfawr/dependencies/ldap.py
@@ -1,0 +1,57 @@
+"""LDAP connection pool dependency for FastSPI."""
+
+from typing import Optional
+
+from bonsai import LDAPClient
+from bonsai.asyncio import AIOConnectionPool
+from fastapi import Depends
+
+from ..config import Config
+from .config import config_dependency
+
+__all__ = ["LDAPPoolDependency", "ldap_pool_dependency"]
+
+
+class LDAPPoolDependency:
+    """Provides a bonsai LDAP connection pool as a dependency.
+
+    Notes
+    -----
+    Creation of the Redis pool has to be deferred until the configuration has
+    been loaded, which in turn is deferred for the first request.  This is
+    done on the first request instead of from the startup hook since, when
+    testing, the startup hook runs before Gafaelfawr has been reconfigured by
+    the test to use an LDAP configuration.
+    """
+
+    def __init__(self) -> None:
+        self._pool: Optional[AIOConnectionPool] = None
+
+    async def __call__(
+        self, config: Config = Depends(config_dependency)
+    ) -> Optional[AIOConnectionPool]:
+        """Creates the LDAP connection pool if necessary and returns it."""
+        if not self._pool and config.ldap:
+            client = LDAPClient(config.ldap.url)
+            if config.ldap.user_dn and config.ldap.password:
+                client.set_credentials(
+                    "SIMPLE",
+                    user=config.ldap.user_dn,
+                    password=config.ldap.password,
+                )
+            self._pool = AIOConnectionPool(client)
+        return self._pool
+
+    async def aclose(self) -> None:
+        """Close the LDAP connection pool.
+
+        Should be called from a shutdown hook to ensure that the connection
+        pool is cleanly shut down.
+        """
+        if self._pool:
+            await self._pool.close()
+            self._pool = None
+
+
+ldap_pool_dependency = LDAPPoolDependency()
+"""The dependency that will return the LDAP connection pool."""

--- a/src/gafaelfawr/dependencies/ldap.py
+++ b/src/gafaelfawr/dependencies/ldap.py
@@ -1,4 +1,4 @@
-"""LDAP connection pool dependency for FastSPI."""
+"""LDAP connection pool dependency for FastAPI."""
 
 from typing import Optional
 

--- a/src/gafaelfawr/factory.py
+++ b/src/gafaelfawr/factory.py
@@ -267,7 +267,7 @@ class ComponentFactory:
             )
             ldap = LDAPService(ldap_storage, self._logger)
         return OIDCUserInfoService(
-            config=self._config.oidc,
+            config=self._config,
             ldap=ldap,
             firestore=firestore,
             logger=self._logger,
@@ -356,6 +356,7 @@ class ComponentFactory:
             )
             ldap = LDAPService(ldap_storage, self._logger)
         return UserInfoService(
+            config=self._config,
             ldap=ldap,
             firestore=firestore,
             logger=self._logger,

--- a/src/gafaelfawr/handlers/login.py
+++ b/src/gafaelfawr/handlers/login.py
@@ -3,13 +3,12 @@
 import base64
 import os
 from enum import Enum
-from typing import List, Optional
+from typing import Optional
 
 from fastapi import APIRouter, Depends, Query, status
 from fastapi.responses import RedirectResponse, Response
 from httpx import HTTPError
 
-from ..config import Config
 from ..dependencies.context import RequestContext, context_dependency
 from ..dependencies.return_url import return_url_with_header
 from ..exceptions import (
@@ -229,22 +228,9 @@ async def handle_provider_return(
     except ProviderError as e:
         return login_error(context, LoginError.PROVIDER_FAILED, str(e))
 
-    # If we normally get group information from LDAP, the groups returned by
-    # the authentication provider will be empty, but we still want to
-    # determine the user's scopes.
-    if context.config.ldap:
-        user_info_service = context.factory.create_user_info_service()
-        username = user_info.username
-        groups = await user_info_service.get_groups_from_ldap(username)
-    elif user_info.groups:
-        groups = [g.name for g in user_info.groups]
-    else:
-        groups = []
-
-    # Get the user's scopes.  If this returns None, the user isn't in any
-    # recognized groups, which means that we should abort the login and
-    # display an error message.
-    scopes = get_scopes_from_groups(context.config, groups)
+    # Get the scopes for this user.
+    user_info_service = context.factory.create_user_info_service()
+    scopes = await user_info_service.get_scopes(user_info)
     if scopes is None:
         await auth_provider.logout(context.state)
         msg = f"{user_info.username} is not a member of any authorized groups"
@@ -278,41 +264,6 @@ async def handle_provider_return(
         scopes=sorted(scopes),
     )
     return RedirectResponse(return_url)
-
-
-def get_scopes_from_groups(
-    config: Config, groups: List[str]
-) -> Optional[List[str]]:
-    """Get scopes from a list of group names.
-
-    Used to determine the scope claim of a token issued based on an OpenID
-    Connect authentication.
-
-    Parameters
-    ----------
-    config : `gafaelfawr.config.Config`
-        Gafaelfawr configuration.
-    groups : List[`str`]
-        The groups of a token.
-
-    Returns
-    -------
-    scopes : List[`str`] or `None`
-        The scopes generated from the group membership based on the
-        ``group_mapping`` configuration parameter, or `None` if the user was
-        not a member of any known group.
-    """
-    if not groups:
-        return None
-
-    scopes = set(["user:token"])
-    found = False
-    for group in groups:
-        if group in config.group_mapping:
-            found = True
-            scopes.update(config.group_mapping[group])
-
-    return sorted(scopes) if found else None
 
 
 def login_error(

--- a/src/gafaelfawr/main.py
+++ b/src/gafaelfawr/main.py
@@ -15,7 +15,12 @@ from safir.middleware.x_forwarded import XForwardedMiddleware
 from safir.models import ErrorModel
 
 from .constants import COOKIE_NAME
-from .dependencies.cache import id_cache_dependency, token_cache_dependency
+from .dependencies.cache import (
+    gid_cache_dependency,
+    internal_token_cache_dependency,
+    notebook_token_cache_dependency,
+    uid_cache_dependency,
+)
 from .dependencies.config import config_dependency
 from .dependencies.ldap import ldap_pool_dependency
 from .dependencies.redis import redis_dependency
@@ -134,8 +139,11 @@ async def shutdown_event() -> None:
     await db_session_dependency.aclose()
     await ldap_pool_dependency.aclose()
     await redis_dependency.aclose()
-    await id_cache_dependency.aclose()
-    await token_cache_dependency.aclose()
+
+    await uid_cache_dependency.aclose()
+    await gid_cache_dependency.aclose()
+    await internal_token_cache_dependency.aclose()
+    await notebook_token_cache_dependency.aclose()
 
 
 async def not_configured_handler(

--- a/src/gafaelfawr/main.py
+++ b/src/gafaelfawr/main.py
@@ -17,6 +17,7 @@ from safir.models import ErrorModel
 from .constants import COOKIE_NAME
 from .dependencies.cache import id_cache_dependency, token_cache_dependency
 from .dependencies.config import config_dependency
+from .dependencies.ldap import ldap_pool_dependency
 from .dependencies.redis import redis_dependency
 from .exceptions import (
     NotConfiguredError,
@@ -131,6 +132,7 @@ async def startup_event() -> None:
 async def shutdown_event() -> None:
     await http_client_dependency.aclose()
     await db_session_dependency.aclose()
+    await ldap_pool_dependency.aclose()
     await redis_dependency.aclose()
     await id_cache_dependency.aclose()
     await token_cache_dependency.aclose()

--- a/src/gafaelfawr/models/token.py
+++ b/src/gafaelfawr/models/token.py
@@ -124,9 +124,7 @@ class TokenGroup(BaseModel):
         regex=GROUPNAME_REGEX,
     )
 
-    id: Optional[int] = Field(
-        None, title="The numeric GID of the group", example=123181
-    )
+    id: int = Field(..., title="The numeric GID of the group", example=123181)
 
 
 class TokenBase(BaseModel):

--- a/src/gafaelfawr/services/firestore.py
+++ b/src/gafaelfawr/services/firestore.py
@@ -1,0 +1,106 @@
+"""UID/GID assignment using Firestore."""
+
+from __future__ import annotations
+
+import re
+
+from structlog.stdlib import BoundLogger
+
+from ..constants import BOT_USERNAME_REGEX
+from ..dependencies.cache import IdCache
+from ..storage.firestore import FirestoreStorage
+
+__all__ = ["FirestoreService"]
+
+
+class FirestoreService:
+    """Manage UID and GID assignments using Firestore.
+
+    This is a thin layer over `~gafaelfawr.storage.firestore.FirestoreStorage`
+    and the UID/GID cache that integrates cache management with the underlying
+    storage.  It is primarily intended to be used by the user information
+    service rather than called directly.
+
+    Parameters
+    ----------
+    cache : `gafaelfawr.dependencies.cache.IdCache`
+        The underlying UID and GID cache and locks.
+    firestore : `gafaelfawr.storage.firestore.FirestoreStorage`, optional
+        The underlying Firestore storage for UID and GID assignment, if
+        Firestore was configured.
+    logger : `structlog.stdlib.BoundLogger`
+        Logger to use.
+    """
+
+    def __init__(
+        self, cache: IdCache, firestore: FirestoreStorage, logger: BoundLogger
+    ) -> None:
+        self._cache = cache
+        self._firestore = firestore
+        self._logger = logger
+
+    async def clear_cache(self) -> None:
+        """Invalidate the UID/GID cache.
+
+        Used primarily for testing.
+        """
+        await self._cache.clear()
+
+    async def get_gid(self, group: str) -> int:
+        """Get the GID for a given user from Firestore.
+
+        Parameters
+        ----------
+        group : `str`
+            Group of the user.
+
+        Returns
+        -------
+        gid : `int`
+            GID of the user.
+
+        Raises
+        ------
+        gafaelfawr.exceptions.NoAvailableGidError
+            No more GIDs are available in that range.
+        """
+        gid = self._cache.get_gid(group)
+        if gid:
+            return gid
+        async with self._cache.gid_lock:
+            gid = self._cache.get_gid(group)
+            if gid:
+                return gid
+            gid = await self._firestore.get_gid(group)
+            self._cache.store_gid(group, gid)
+            return gid
+
+    async def get_uid(self, username: str) -> int:
+        """Get the UID for a given user.
+
+        Parameters
+        ----------
+        username : `str`
+            Username of the user.
+
+        Returns
+        -------
+        uid : `int`
+            UID of the user.
+
+        Raises
+        ------
+        gafaelfawr.exceptions.NoAvailableUidError
+            No more UIDs are available in that range.
+        """
+        uid = self._cache.get_uid(username)
+        if uid:
+            return uid
+        async with self._cache.uid_lock:
+            uid = self._cache.get_uid(username)
+            if uid:
+                return uid
+            bot = re.search(BOT_USERNAME_REGEX, username) is not None
+            uid = await self._firestore.get_uid(username, bot=bot)
+            self._cache.store_uid(username, uid)
+            return uid

--- a/src/gafaelfawr/services/ldap.py
+++ b/src/gafaelfawr/services/ldap.py
@@ -43,8 +43,7 @@ class LDAPService:
         groups : List[`str`]
             The names of the user's groups according to LDAP.
         """
-        async with self._ldap.connect() as conn:
-            return await conn.get_group_names(username)
+        return await self._ldap.get_group_names(username)
 
     async def get_groups(self, username: str) -> List[TokenGroup]:
         """Get user group membership and GIDs from LDAP.
@@ -64,8 +63,7 @@ class LDAPService:
         gafaelfawr.exceptions.LDAPError
             An error occurred when retrieving user information from LDAP.
         """
-        async with self._ldap.connect() as conn:
-            return await conn.get_groups(username)
+        return await self._ldap.get_groups(username)
 
     async def get_uid(self, username: str) -> Optional[int]:
         """Determine a user's numeric UID from LDAP.
@@ -81,8 +79,7 @@ class LDAPService:
             Corresponding numeric UID from LDAP, or `None` if LDAP was not
             configured to get UIDs.
         """
-        async with self._ldap.connect() as conn:
-            return await conn.get_uid(username)
+        return await self._ldap.get_uid(username)
 
     async def get_username(self, sub: str) -> Optional[str]:
         """Determine a user's username from LDAP.
@@ -98,5 +95,4 @@ class LDAPService:
             Corresponding username from LDAP, or `None` if LDAP was not
             configured to get usernames.
         """
-        async with self._ldap.connect() as conn:
-            return await conn.get_username(sub)
+        return await self._ldap.get_username(sub)

--- a/src/gafaelfawr/services/ldap.py
+++ b/src/gafaelfawr/services/ldap.py
@@ -1,0 +1,102 @@
+"""LDAP lookups for user information."""
+
+from __future__ import annotations
+
+from typing import List, Optional
+
+from structlog.stdlib import BoundLogger
+
+from ..models.token import TokenGroup
+from ..storage.ldap import LDAPStorage
+
+__all__ = ["LDAPService"]
+
+
+class LDAPService:
+    """Perform LDAP lookups for user information.
+
+    This collects all of the LDAP search logic.  It is primarily intended to
+    be used by the user information service rather than called directly.
+
+    Parameters
+    ----------
+    ldap : `gafaelfawr.storage.ldap.LDAPStorage`
+        The underlying LDAP query layer.
+    logger : `structlog.stdlib.BoundLogger`
+        Logger to use.
+    """
+
+    def __init__(self, ldap: LDAPStorage, logger: BoundLogger) -> None:
+        self._ldap = ldap
+        self._logger = logger
+
+    async def get_group_names(self, username: str) -> List[str]:
+        """Get the names of user groups from LDAP.
+
+        Parameters
+        ----------
+        username : `str`
+            Username of the user.
+
+        Returns
+        -------
+        groups : List[`str`]
+            The names of the user's groups according to LDAP.
+        """
+        async with self._ldap.connect() as conn:
+            return await conn.get_group_names(username)
+
+    async def get_groups(self, username: str) -> List[TokenGroup]:
+        """Get user group membership and GIDs from LDAP.
+
+        Parameters
+        ----------
+        username : `str`
+            Username for which to get information.
+
+        Returns
+        -------
+        groups : List[`gafaelfawr.models.token.TokenGroup`]
+            Groups of the user.
+
+        Raises
+        ------
+        gafaelfawr.exceptions.LDAPError
+            An error occurred when retrieving user information from LDAP.
+        """
+        async with self._ldap.connect() as conn:
+            return await conn.get_groups(username)
+
+    async def get_uid(self, username: str) -> Optional[int]:
+        """Determine a user's numeric UID from LDAP.
+
+        Parameters
+        ----------
+        username : `str`
+            Username of the user.
+
+        Returns
+        -------
+        username : `str` or `None`
+            Corresponding numeric UID from LDAP, or `None` if LDAP was not
+            configured to get UIDs.
+        """
+        async with self._ldap.connect() as conn:
+            return await conn.get_uid(username)
+
+    async def get_username(self, sub: str) -> Optional[str]:
+        """Determine a user's username from LDAP.
+
+        Parameters
+        ----------
+        sub : `str`
+            ``sub`` claim from the OpenID Connect ID token.
+
+        Returns
+        -------
+        username : `str` or `None`
+            Corresponding username from LDAP, or `None` if LDAP was not
+            configured to get usernames.
+        """
+        async with self._ldap.connect() as conn:
+            return await conn.get_username(sub)

--- a/src/gafaelfawr/services/userinfo.py
+++ b/src/gafaelfawr/services/userinfo.py
@@ -64,14 +64,6 @@ class UserInfoService:
         self._firestore = firestore
         self._logger = logger
 
-    async def clear(self) -> None:
-        """Invalidate all of the caches.
-
-        Used primarily for testing.
-        """
-        if self._firestore:
-            await self._firestore.clear_cache()
-
     async def get_user_info_from_token(
         self, token_data: TokenData
     ) -> TokenUserInfo:

--- a/src/gafaelfawr/storage/ldap.py
+++ b/src/gafaelfawr/storage/ldap.py
@@ -2,20 +2,23 @@
 
 from __future__ import annotations
 
+import asyncio
 import re
-from contextlib import asynccontextmanager
-from typing import AsyncIterator, List, Optional
+from typing import Dict, List, Optional
 
 import bonsai
+from bonsai import LDAPSearchScope
+from bonsai.asyncio import AIOConnectionPool
+from bonsai.asyncio.aiopool import AIOPoolContextManager
 from bonsai.utils import escape_filter_exp
 from structlog.stdlib import BoundLogger
 
 from ..config import LDAPConfig
-from ..constants import GROUPNAME_REGEX
+from ..constants import GROUPNAME_REGEX, LDAP_TIMEOUT
 from ..exceptions import LDAPError, NoUsernameMappingError
 from ..models.token import TokenGroup
 
-__all__ = ["LDAPStorage", "LDAPStorageConnection"]
+__all__ = ["LDAPStorage"]
 
 
 class LDAPStorage:
@@ -25,63 +28,153 @@ class LDAPStorage:
     ----------
     config : `gafaelfawr.config.LDAPConfig`
         Configuration for LDAP searches.
+    pool : `bonsai.asyncio.AIOConnectionPool`
+        Connection pool for LDAP searches.
     logger : `structlog.stdlib.BoundLogger`
         Logger for debug messages and errors.
     """
 
-    def __init__(self, config: LDAPConfig, logger: BoundLogger) -> None:
-        self._config = config
-        self._client = bonsai.LDAPClient(config.url)
-        if self._config.user_dn and self._config.password:
-            self._client.set_credentials(
-                "SIMPLE",
-                user=self._config.user_dn,
-                password=self._config.password,
-            )
-        self._logger = logger.bind(
-            ldap_url=self._config.url,
-            ldap_base=self._config.uid_base_dn,
-        )
-
-    @asynccontextmanager
-    async def connect(self) -> AsyncIterator[LDAPStorageConnection]:
-        """Open a connection to the LDAP server.
-
-        Call this in an ``async with`` block to open a connection to the LDAP
-        server and perform some searches via methods on the resulting
-        `LDAPStorageConnection` class.
-        """
-        async with self._client.connect(is_async=True) as conn:
-            yield LDAPStorageConnection(conn, self._config, self._logger)
-
-
-class LDAPStorageConnection:
-    """Wrapper around a single LDAP connection.
-
-    This is returned by the `gafaelfawr.storage.ldap.LDAPStorage.connect`
-    method and provides functions to do the LDAP lookups Gafaelfawr needs.
-    Clients should never instantiate this class directly.
-
-    Examples
-    --------
-    Use this in an ``async with`` block such as:
-
-    .. code-block:: python
-
-       async with ldap_storage.connect() as conn:
-           uid = await conn.get_uid(username)
-           groups = await conn.get_groups(username)
-    """
-
     def __init__(
-        self,
-        conn: bonsai.LDAPConnection,
-        config: LDAPConfig,
-        logger: BoundLogger,
+        self, config: LDAPConfig, pool: AIOConnectionPool, logger: BoundLogger
     ) -> None:
-        self._conn = conn
         self._config = config
-        self._logger = logger
+        self._pool = pool
+        self._logger = logger.bind(ldap_url=self._config.url)
+
+    async def get_group_names(self, username: str) -> List[str]:
+        """Get names of groups for a user from LDAP.
+
+        Parameters
+        ----------
+        username : `str`
+            Username of the user.
+
+        Returns
+        -------
+        groups : List[`str`]
+            User's group names from LDAP.
+
+        Raises
+        ------
+        gafaelfawr.exceptions.LDAPError
+            Some error occurred while doing the LDAP search.
+        """
+        group_class = self._config.group_object_class
+        member_attr = self._config.group_member_attr
+        search = f"(&(objectClass={group_class})({member_attr}={username}))"
+        logger = self._logger.bind(ldap_search=search, user=username)
+        results = await self._query(
+            self._config.base_dn, bonsai.LDAPSearchScope.SUB, search, ["cn"]
+        )
+        logger.debug("LDAP groups found", ldap_results=results)
+
+        # Parse the results into the group list.
+        groups = []
+        valid_group_regex = re.compile(GROUPNAME_REGEX)
+        for result in results:
+            try:
+                name = result["cn"][0]
+            except Exception as e:
+                logger.warning(
+                    "Invalid LDAP group result, ignoring",
+                    error=str(e),
+                    ldap_result=result,
+                )
+            if valid_group_regex.match(name):
+                groups.append(name)
+            else:
+                logger.warning(f"LDAP group {name} invalid, ignoring")
+        return groups
+
+    async def get_groups(self, username: str) -> List[TokenGroup]:
+        """Get groups for a user from LDAP.
+
+        Parameters
+        ----------
+        username : `str`
+            Username of the user.
+
+        Returns
+        -------
+        groups : List[`gafaelfawr.models.token.TokenGroup`]
+            User's groups from LDAP.
+
+        Raises
+        ------
+        gafaelfawr.exceptions.LDAPError
+            Some error occurred when searching LDAP.
+        """
+        group_class = self._config.group_object_class
+        member_attr = self._config.group_member_attr
+        search = f"(&(objectClass={group_class})({member_attr}={username}))"
+        logger = self._logger.bind(ldap_search=search, user=username)
+        results = await self._query(
+            self._config.base_dn,
+            bonsai.LDAPSearchScope.SUB,
+            search,
+            ["cn", "gidNumber"],
+        )
+        logger.debug("LDAP groups found", ldap_results=results)
+
+        # Parse the results into the group list.
+        groups = []
+        for result in results:
+            name = None
+            try:
+                name = result["cn"][0]
+                gid = int(result["gidNumber"][0])
+                groups.append(TokenGroup(name=name, id=gid))
+            except Exception as e:
+                logger.warning(
+                    f"LDAP group {name} invalid, ignoring", error=str(e)
+                )
+        return groups
+
+    async def get_uid(self, username: str) -> Optional[int]:
+        """Get the numeric UID of a user.
+
+        Parameters
+        ----------
+        username : `str`
+            Username of the user.
+
+        Returns
+        -------
+        uid : `int` or `None`
+            The numeric UID of the user from LDAP, or `None` if Gafaelfawr was
+            not configured to get the UID from LDAP (in which case the caller
+            should fall back to other sources of the UID).
+
+        Raises
+        ------
+        gafaelfawr.exceptions.LDAPError
+            The lookup of ``uid_attr`` in the LDAP server was not valid
+            (connection to the LDAP server failed, attribute not found in
+            LDAP, result value not an integer).
+        """
+        if not self._config.uid_base_dn:
+            return None
+
+        search = f"(uid={username})"
+        logger = self._logger.bind(ldap_search=search, user=username)
+        results = await self._query(
+            self._config.uid_base_dn,
+            bonsai.LDAPSearchScope.ONE,
+            search,
+            [self._config.uid_attr],
+        )
+        logger.debug("LDAP entries for UID", ldap_results=results)
+
+        for result in results:
+            try:
+                return int(result[self._config.uid_attr][0])
+            except Exception as e:
+                logger.error("LDAP UID number is invalid", error=str(e))
+                raise LDAPError("UID number in LDAP is invalid")
+
+        # Fell through without finding a UID.
+        logger.error("No UID found in LDAP")
+        raise LDAPError("No UID found in LDAP")
 
     async def get_username(self, sub: str) -> Optional[str]:
         """Get the username of a user.
@@ -112,233 +205,99 @@ class LDAPStorageConnection:
             return None
 
         sub_escaped = escape_filter_exp(sub)
-        search = f"(&({self._config.username_search_attr}={sub_escaped}))"
-        self._logger.debug(
-            "Querying LDAP for username", ldap_search=search, sub=sub
+        search = f"({self._config.username_search_attr}={sub_escaped})"
+        logger = self._logger.bind(ldap_search=search, sub=sub)
+        results = await self._query(
+            self._config.username_base_dn,
+            bonsai.LDAPSearchScope.ONE,
+            search,
+            ["uid"],
         )
-
-        try:
-            results = await self._conn.search(
-                self._config.username_base_dn,
-                bonsai.LDAPSearchScope.ONE,
-                search,
-                attrlist=["uid"],
-            )
-        except bonsai.LDAPError as e:
-            self._logger.error(
-                "Cannot query LDAP for username",
-                error=str(e),
-                ldap_search=search,
-                sub=sub,
-            )
-            raise LDAPError("Error querying LDAP for username")
+        logger.debug("LDAP entries for username", ldap_results=results)
 
         for result in results:
             try:
                 return result["uid"][0]
             except Exception as e:
-                self._logger.error(
-                    "LDAP username is invalid",
-                    error=str(e),
-                    ldap_search=search,
-                    sub=sub,
-                )
+                self._logger.error("LDAP username is invalid", error=str(e))
                 raise LDAPError("Username in LDAP is invalid")
 
         # Fell through without finding a UID.
-        self._logger.info(
-            "No username found in LDAP", ldap_search=search, sub=sub
-        )
+        self._logger.info("No username found in LDAP")
         raise NoUsernameMappingError("No username found in LDAP")
 
-    async def get_uid(self, username: str) -> Optional[int]:
-        """Get the numeric UID of a user.
+    async def _query(
+        self,
+        base: str,
+        scope: LDAPSearchScope,
+        filter_exp: str,
+        attrlist: List[str],
+    ) -> List[Dict[str, List[str]]]:
+        """Perform an LDAP query using the connection pool.
+
+        Notes
+        -----
+        The current bonsai connection pool does not keep track of failed
+        connections and will keep returning the same connection even if the
+        LDAP server has stopped responding (due to a firewall timeout, for
+        example).  Working around this requires setting a timeout, catching
+        the timeout exception, and explicitly closing and reopening the
+        connection.  A search is attempted at most twice.
+
+        As of bonsai 1.4.0, be aware that bonsai appears to go into an
+        infinite CPU loop when waiting for results when run in an asyncio loop
+        without other active coroutines.  It's not clear whether that's true
+        if there are other active coroutines.
 
         Parameters
         ----------
-        username : `str`
-            Username of the user.
+        base : `str`
+            Base DN of the search.
+        scope : `bonsai.LDAPSearchScope`
+            Scope of the search.
+        filter_exp : `str`
+            Search filter.
+        attrlist : List[`str`]
+            List of attributes to retrieve.
 
         Returns
         -------
-        uid : `int` or `None`
-            The numeric UID of the user from LDAP, or `None` if Gafaelfawr was
-            not configured to get the UID from LDAP (in which case the caller
-            should fall back to other sources of the UID).
+        results : List[Dict[`str`, List[`str`]]]
+            List of result entries, each of which is a dictionary of the
+            requested attributes (plus possibly other attributes) to a list
+            of their values.
 
         Raises
         ------
         gafaelfawr.exceptions.LDAPError
-            The lookup of ``uid_attr`` in the LDAP server was not valid
-            (connection to the LDAP server failed, attribute not found in
-            LDAP, result value not an integer).
+            Failed to run the search.
         """
-        if not self._config.uid_base_dn:
-            return None
-
-        search = f"(&(uid={username}))"
-        self._logger.debug(
-            "Querying LDAP for UID number", ldap_search=search, user=username
+        logger = self._logger.bind(
+            ldap_attrs=attrlist, ldap_base=base, ldap_search=filter_exp
         )
 
-        try:
-            results = await self._conn.search(
-                self._config.uid_base_dn,
-                bonsai.LDAPSearchScope.ONE,
-                search,
-                attrlist=[self._config.uid_attr],
-            )
-        except bonsai.LDAPError as e:
-            self._logger.error(
-                "Cannot query LDAP for UID number",
-                error=str(e),
-                ldap_search=search,
-                user=username,
-            )
-            raise LDAPError("Error querying LDAP for UID number")
-
-        for result in results:
+        attempts = 0
+        while attempts < 2:
+            attempts += 1
             try:
-                return int(result[self._config.uid_attr][0])
-            except Exception as e:
-                self._logger.error(
-                    "LDAP UID number is invalid",
-                    error=str(e),
-                    ldap_search=search,
-                    user=username,
-                )
-                raise LDAPError("UID number in LDAP is invalid")
+                async with AIOPoolContextManager(self._pool) as conn:
+                    logger.debug("Querying LDAP")
+                    return await conn.search(
+                        base=base,
+                        scope=scope,
+                        filter_exp=filter_exp,
+                        attrlist=attrlist,
+                        timeout=LDAP_TIMEOUT,
+                    )
+            except asyncio.TimeoutError:
+                logger.debug("Reopening LDAP connection after timeout")
+                conn.close()
+                await conn.open(timeout=LDAP_TIMEOUT)
+            except bonsai.LDAPError as e:
+                logger.error("Cannot query LDAP", error=str(e))
+                raise LDAPError("Error querying LDAP")
 
-        # Fell through without finding a UID.
-        self._logger.error(
-            "No UID found in LDAP", ldap_search=search, user=username
-        )
-        raise LDAPError("No UID found in LDAP")
-
-    async def get_groups(self, username: str) -> List[TokenGroup]:
-        """Get groups for a user from LDAP.
-
-        Parameters
-        ----------
-        username : `str`
-            Username of the user.
-
-        Returns
-        -------
-        groups : List[`gafaelfawr.models.token.TokenGroup`]
-            User's groups from LDAP.
-
-        Raises
-        ------
-        gafaelfawr.exceptions.LDAPError
-            Some error occurred when searching LDAP.
-        """
-        group_class = self._config.group_object_class
-        member_attr = self._config.group_member_attr
-        search = f"(&(objectClass={group_class})({member_attr}={username}))"
-        self._logger.debug(
-            "Querying LDAP for groups", ldap_search=search, user=username
-        )
-
-        try:
-            results = await self._conn.search(
-                self._config.base_dn,
-                bonsai.LDAPSearchScope.SUB,
-                search,
-                attrlist=["cn", "gidNumber"],
-            )
-        except bonsai.LDAPError as e:
-            self._logger.error(
-                "Cannot query LDAP for groups",
-                error=str(e),
-                ldap_search=search,
-                user=username,
-            )
-            raise LDAPError("Error querying LDAP for groups")
-
-        # Parse the results into the group list.
-        groups = []
-        for result in results:
-            try:
-                name = None
-                self._logger.debug(
-                    "LDAP group found", result=result, user=username
-                )
-                name = result["cn"][0]
-                gid = int(result["gidNumber"][0])
-                groups.append(TokenGroup(name=name, id=gid))
-            except Exception as e:
-                self._logger.warning(
-                    f"LDAP group {name} invalid, ignoring",
-                    error=str(e),
-                    ldap_search=search,
-                    user=username,
-                )
-        return groups
-
-    async def get_group_names(self, username: str) -> List[str]:
-        """Get names of groups for a user from LDAP.
-
-        Parameters
-        ----------
-        username : `str`
-            Username of the user.
-
-        Returns
-        -------
-        groups : List[`str`]
-            User's group names from LDAP.
-
-        Raises
-        ------
-        gafaelfawr.exceptions.LDAPError
-            Some error occurred while doing the LDAP search.
-        """
-        group_class = self._config.group_object_class
-        member_attr = self._config.group_member_attr
-        search = f"(&(objectClass={group_class})({member_attr}={username}))"
-        self._logger.debug(
-            "Querying LDAP for group names", ldap_search=search, user=username
-        )
-
-        try:
-            results = await self._conn.search(
-                self._config.base_dn,
-                bonsai.LDAPSearchScope.SUB,
-                search,
-                attrlist=["cn"],
-            )
-        except bonsai.LDAPError as e:
-            self._logger.error(
-                "Cannot query LDAP for groups",
-                error=str(e),
-                ldap_search=search,
-                user=username,
-            )
-            raise LDAPError("Error querying LDAP for groups")
-
-        # Parse the results into the group list.
-        groups = []
-        valid_group_regex = re.compile(GROUPNAME_REGEX)
-        for result in results:
-            self._logger.debug(
-                "LDAP group found", result=result, user=username
-            )
-            try:
-                name = result["cn"][0]
-            except Exception as e:
-                self._logger.warning(
-                    "Invalid LDAP group result, ignoring",
-                    error=str(e),
-                    ldap_search=search,
-                    user=username,
-                )
-            if valid_group_regex.match(name):
-                groups.append(name)
-            else:
-                self._logger.warning(
-                    f"LDAP group {name} invalid, ignoring",
-                    ldap_search=search,
-                    user=username,
-                )
-        return groups
+        # Failed twice with a timeout.
+        msg = f"LDAP query timed out after {LDAP_TIMEOUT}s"
+        logger.error("Cannot query LDAP", error=msg)
+        raise LDAPError(msg)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,10 +5,8 @@ from __future__ import annotations
 import asyncio
 from pathlib import Path
 from typing import AsyncIterator, Iterator
-from unittest.mock import patch
 from urllib.parse import urljoin
 
-import bonsai
 import pytest
 import pytest_asyncio
 import structlog
@@ -34,7 +32,7 @@ from gafaelfawr.schema import Base
 from .pages.tokens import TokensPage
 from .support.constants import TEST_DATABASE_URL, TEST_HOSTNAME
 from .support.firestore import MockFirestore, patch_firestore
-from .support.ldap import MockLDAP
+from .support.ldap import MockLDAP, patch_ldap
 from .support.selenium import SeleniumConfig, run_app, selenium_driver
 from .support.settings import build_settings, configure
 
@@ -177,8 +175,7 @@ def mock_firestore(tmp_path: Path) -> Iterator[MockFirestore]:
     mock_firestore : `tests.support.firestore.MockFirestore`
         The mocked Firestore API.
     """
-    with patch_firestore() as firestore:
-        yield firestore
+    yield from patch_firestore()
 
 
 @pytest.fixture
@@ -193,8 +190,8 @@ def mock_kubernetes() -> Iterator[MockKubernetesApi]:
     yield from patch_kubernetes()
 
 
-@pytest_asyncio.fixture
-async def mock_ldap() -> AsyncIterator[MockLDAP]:
+@pytest.fixture
+def mock_ldap() -> Iterator[MockLDAP]:
     """Replace the bonsai LDAP API with a mock class.
 
     Returns
@@ -202,10 +199,7 @@ async def mock_ldap() -> AsyncIterator[MockLDAP]:
     mock_ldap : `tests.support.ldap.MockLDAP`
         The mock LDAP API object.
     """
-    ldap = MockLDAP()
-    with patch.object(bonsai, "LDAPClient") as mock:
-        mock.return_value = ldap
-        yield ldap
+    yield from patch_ldap()
 
 
 @pytest_asyncio.fixture

--- a/tests/services/token_cache_test.py
+++ b/tests/services/token_cache_test.py
@@ -80,10 +80,10 @@ async def test_invalid(factory: ComponentFactory) -> None:
     internal_token = Token()
     notebook_token = Token()
 
-    token_cache.store_internal_token(
-        internal_token, token_data, "some-service", ["read:all"]
+    token_cache._internal_cache.store(
+        token_data, "some-service", ["read:all"], internal_token
     )
-    token_cache.store_notebook_token(notebook_token, token_data)
+    token_cache._notebook_cache.store(token_data, notebook_token)
 
     async with factory.session.begin():
         assert internal_token != await token_cache.get_internal_token(
@@ -120,8 +120,8 @@ async def test_expiration(config: Config, factory: ComponentFactory) -> None:
         expires=expires,
     )
     await token_store.store_data(internal_token_data)
-    token_cache.store_internal_token(
-        internal_token_data.token, token_data, "some-service", ["read:all"]
+    token_cache._internal_cache.store(
+        token_data, "some-service", ["read:all"], internal_token_data.token
     )
 
     # The cache should return this token.
@@ -152,7 +152,7 @@ async def test_expiration(config: Config, factory: ComponentFactory) -> None:
         expires=expires,
     )
     await token_store.store_data(notebook_token_data)
-    token_cache.store_notebook_token(notebook_token_data.token, token_data)
+    token_cache._notebook_cache.store(token_data, notebook_token_data.token)
     assert notebook_token_data.token == await token_cache.get_notebook_token(
         token_data, "127.0.0.1"
     )

--- a/tests/settings/oidc-ldap.yaml.in
+++ b/tests/settings/oidc-ldap.yaml.in
@@ -1,4 +1,5 @@
 realm: "example.com"
+loglevel: "DEBUG"
 session_secret_file: "{session_secret_file}"
 database_url: "{database_url}"
 redis_url: "redis://localhost:6379/0"

--- a/tests/support/firestore.py
+++ b/tests/support/firestore.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from collections import defaultdict
-from contextlib import contextmanager
 from typing import Any, Dict, Iterator, Optional
 from unittest.mock import MagicMock, Mock, patch
 
@@ -93,7 +92,6 @@ class MockFirestore(Mock):
         return MockTransaction()
 
 
-@contextmanager
 def patch_firestore() -> Iterator[MockFirestore]:
     """Mock the Firestore API for testing.
 

--- a/tests/support/ldap.py
+++ b/tests/support/ldap.py
@@ -64,9 +64,14 @@ class MockLDAP(Mock):
             assert attrlist == ["uidNumber"]
             return [{"uidNumber": [str(2000)]}]
         elif query == "(&(objectClass=posixGroup)(member=ldap-user))":
-            assert attrlist == ["cn", "gidNumber"]
-            return [
-                {"cn": [g.name], "gidNumber": [str(g.id)]} for g in self.groups
-            ]
+            if attrlist == ["cn", "gidNumber"]:
+                return [
+                    {"cn": [g.name], "gidNumber": [str(g.id)]}
+                    for g in self.groups
+                ]
+            elif attrlist == ["cn"]:
+                return [{"cn": [g.name]} for g in self.groups]
+            else:
+                assert False, f"Invalid attribute list {attrlist}"
         else:
             return []


### PR DESCRIPTION
The previous LDAP support in Gafaelfawr opened at least one new LDAP connection for each request that required an LDAP lookup, sometimes two. None of the data retrieved from LDAP was cached. It therefore leaned heavily on LDAP queries and LDAP connection setup being fast.

This PR hopefully provides more scaling by using an LDAP connection pool. This is unfortunately a bit awkward using the bonsai connection library, since bonsai does not handle connections that have timed out due to a firewall rule on the remote side and instead continues to return them from the pool. It also apparently busy-waits for replies from LDAP. Work around both (partially) by setting a timeout and by explicitly closing and reopening the connection when a timeout occurs.

The LDAP service is currently a pure passthrough to the underlying storage, but it will be used in the future when caching is added for LDAP lookups.

Refactor the caching layer to implement a cleaner API model, in which each cache stores one and only one type of data and we have multiple separate caches instead of complex objects managing shared caches. Move the locking strategy and the lookup calls into methods on the cache object for a better separation of concerns.

Move scope determination into the user information service where it belongs and where it's a more natural fit given the tighter LDAP integration, and take advantage of the less-ambiguous API to make GIDs mandatory in the model of groups again.