### PR TITLE
[DM-34613] Add fix-home-ownership CLI invocation

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,8 @@ The internal configuration format may change in minor releases.
   Enabling numeric UID lookups now requires setting ``config.ldap.uidAttr`` plus ``config.ldap.userBaseDn``, and ``config.ldap.uidBaseDn`` is no longer a valid configuration setting.
 - LDAP data is cached for up to five minutes to reduce latency and load on the LDAP server.
 - Rename ``config.ldap.baseDn`` to ``config.ldap.groupBaseDn`` to make it clearer that it is only used for group membership searches.
+- Add ``gafaelfawr fix-home-ownership`` command-line invocation that assigns UIDs via Firestore for all users found in a home directory tree and then recursively changes ownership of their files to their newly-allocated UIDs.
+  This is intended as a one-time migration tool for environments that are switching to Firestore for UID assignment
 - Use a connection pool for LDAP queries instead of opening a new connection for each query.
 - Report better errors to the user if Firestore or LDAP fail during login.
 - Add ``config.oidc.usernameClaim`` and ``config.oidc.uidClaim`` Helm configuration options to customize which claims from the upstream OpenID Connect ID token are used to get the username and UID.

--- a/src/gafaelfawr/factory.py
+++ b/src/gafaelfawr/factory.py
@@ -232,6 +232,22 @@ class Factory:
         admin_history_store = AdminHistoryStore(self.session)
         return AdminService(admin_store, admin_history_store, self._logger)
 
+    def create_firestore_service(self) -> FirestoreService:
+        """Create the Firestore service layer.
+
+        Returns
+        -------
+        firestore : `gafaelfawr.services.firestore.FirestoreService`
+            Newly-created Firestore service.
+        """
+        storage = self.create_firestore_storage()
+        return FirestoreService(
+            uid_cache=self._context.uid_cache,
+            gid_cache=self._context.gid_cache,
+            storage=storage,
+            logger=self._logger,
+        )
+
     def create_firestore_storage(self) -> FirestoreStorage:
         """Create the Firestore storage layer.
 
@@ -325,13 +341,7 @@ class Factory:
             raise NotConfiguredError("OpenID Connect is not configured")
         firestore = None
         if self._context.config.firestore:
-            firestore_storage = self.create_firestore_storage()
-            firestore = FirestoreService(
-                uid_cache=self._context.uid_cache,
-                gid_cache=self._context.gid_cache,
-                storage=firestore_storage,
-                logger=self._logger,
-            )
+            firestore = self.create_firestore_service()
         ldap = None
         if self._context.config.ldap and self._context.ldap_pool:
             ldap_storage = LDAPStorage(
@@ -425,13 +435,7 @@ class Factory:
         """
         firestore = None
         if self._context.config.firestore:
-            firestore_storage = self.create_firestore_storage()
-            firestore = FirestoreService(
-                uid_cache=self._context.uid_cache,
-                gid_cache=self._context.gid_cache,
-                storage=firestore_storage,
-                logger=self._logger,
-            )
+            firestore = self.create_firestore_service()
         ldap = None
         if self._context.config.ldap and self._context.ldap_pool:
             ldap_storage = LDAPStorage(

--- a/src/gafaelfawr/services/firestore.py
+++ b/src/gafaelfawr/services/firestore.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import re
+import subprocess
+from pathlib import Path
 
 from structlog.stdlib import BoundLogger
 
@@ -46,6 +48,36 @@ class FirestoreService:
         self._gid_cache = gid_cache
         self._storage = storage
         self._logger = logger
+
+    async def fix_home_ownership(self, root: Path) -> None:
+        """Fix the ownership of home directories.
+
+        This is a special-purpose method used when migrating a home directory
+        structure from pre-Firestore UIDs to Firestore UIDs.  It assigns a UID
+        to each user and recursively changes ownership of all files in that
+        user's home directory to a UID and GID matching that assigned UID.
+
+        Parameters
+        ----------
+        root : `pathlib.Path`
+            Root of home directories.  Every subdirectory is presumed to be
+            the home directory of a user whose username matches the name of
+            the directory, and should be set to be owned by the UID assigned
+            to that user.
+
+        Raises
+        ------
+        gafaelfawr.exceptions.NoAvailableUidError
+            No more UIDs are available in that range.
+        subprocess.CalledProcessError
+            If ``chown`` fails.
+        """
+        for homedir in root.iterdir():
+            if not homedir.is_dir():
+                continue
+            uid = await self.get_uid(homedir.name)
+            self._logger.info(f"Setting ownership of {homedir} to {uid}:{uid}")
+            subprocess.run(["chown", "-R", f"{uid}:{uid}", str(homedir)])
 
     async def get_gid(self, group: str) -> int:
         """Get the GID for a given user from Firestore.

--- a/tests/support/firestore.py
+++ b/tests/support/firestore.py
@@ -34,6 +34,14 @@ class MockDocumentRef(Mock):
         assert isinstance(transaction, MockTransaction)
         return MockDocument(self.document)
 
+    def get_for_testing(self) -> MockDocument:
+        """Get the document without a transaction.
+
+        Used for testing, particularly where the test is not async and can't
+        make an async call easily.
+        """
+        return MockDocument(self.document)
+
 
 class MockCollection(Mock):
     """Mock Firestore collection object."""


### PR DESCRIPTION
When converting an existing deployment to using Firestore for UID
and GID assignment, we will allocate new UIDs and will need to
change the ownership of everyone's home directories.  Add a new
command-line invocation that assumes every subdirectory of a
directory is a home directory, takes the username from the name of
the directory, allocates a UID, and sets ownership of the files
recursively with chown to that new UID.