### PR TITLE
[DM-35088] Fix finding OpenID Connect metadata

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,8 @@ The internal configuration format may change in minor releases.
 - Add ``gafaelfawr fix-home-ownership`` command-line invocation that assigns UIDs via Firestore for all users found in a home directory tree and then recursively changes ownership of their files to their newly-allocated UIDs.
   This is intended as a one-time migration tool for environments that are switching to Firestore for UID assignment
 - Use a connection pool for LDAP queries instead of opening a new connection for each query.
+- Fix verification of OpenID Connect ID tokens when the upstream issuer URL has a path component.
+  Previous versions of Gafaelfawr would incorrectly look for standard metadata URLs one path level too high.
 - Report better errors to the user if Firestore or LDAP fail during login.
 - Add ``config.oidc.usernameClaim`` and ``config.oidc.uidClaim`` Helm configuration options to customize which claims from the upstream OpenID Connect ID token are used to get the username and UID.
 - Update dependencies.

--- a/src/gafaelfawr/providers/oidc.py
+++ b/src/gafaelfawr/providers/oidc.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from typing import Any, Dict, List, Mapping, Optional
-from urllib.parse import urlencode, urljoin
+from urllib.parse import urlencode
 
 import jwt
 from cryptography.hazmat.backends import default_backend
@@ -387,7 +387,7 @@ class OIDCTokenVerifier:
         """
         url = await self._get_jwks_uri(issuer_url)
         if not url:
-            url = urljoin(issuer_url, ".well-known/jwks.json")
+            url = issuer_url.rstrip("/") + "/.well-known/jwks.json"
 
         try:
             r = await self._http_client.get(url)
@@ -428,7 +428,7 @@ class OIDCTokenVerifier:
             If the OpenID Connect metadata doesn't contain the expected
             parameter.
         """
-        url = urljoin(issuer_url, ".well-known/openid-configuration")
+        url = issuer_url.rstrip("/") + "/.well-known/openid-configuration"
         try:
             r = await self._http_client.get(url)
             if r.status_code != 200:

--- a/tests/settings/oidc-subdomain.yaml.in
+++ b/tests/settings/oidc-subdomain.yaml.in
@@ -1,0 +1,24 @@
+realm: "example.com"
+session_secret_file: "{session_secret_file}"
+database_url: "{database_url}"
+redis_url: "redis://localhost:6379/0"
+initial_admins: ["admin"]
+after_logout_url: "https://example.com/landing"
+group_mapping:
+  "exec:admin": ["admin"]
+  "exec:test": ["test"]
+  "read:all": ["foo", "admin", "org-a-team"]
+known_scopes:
+  "admin:token": "Can create and modify tokens for any user"
+  "exec:admin": "admin description"
+  "exec:test": "test description"
+  "read:all": "can read everything"
+  "user:token": "Can create and modify user tokens"
+oidc:
+  client_id: "some-oidc-client-id"
+  client_secret_file: "{oidc_secret_file}"
+  login_url: "https://upstream.example.com/some/path/login"
+  redirect_url: "https://test.example.com/login"
+  token_url: "https://upstream.example.com/some/path/token"
+  issuer: "https://upstream.example.com/some/path"
+  audience: "https://test.example.com/"


### PR DESCRIPTION
The implementation of OpenID Connect metadata discovery, used to
verify an upstream OpenID Connect ID token, did not correctly
follow the OpenID Connect Discovery protocol.  In particular, it
removed the last path component of the issuer URL before appending
the well-known address due to the default behavior of urljoin.

Stop using urljoin and correctly implement the protocol for
forming the URL.