### PR TITLE
[DM-34613] Add command to delete all data

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -24,6 +24,8 @@ The internal configuration format may change in minor releases.
 - Rename ``config.ldap.baseDn`` to ``config.ldap.groupBaseDn`` to make it clearer that it is only used for group membership searches.
 - Add ``gafaelfawr fix-home-ownership`` command-line invocation that assigns UIDs via Firestore for all users found in a home directory tree and then recursively changes ownership of their files to their newly-allocated UIDs.
   This is intended as a one-time migration tool for environments that are switching to Firestore for UID assignment
+- Add ``gafaelfawr delete-all-data`` command-line invocation that deletes all data except Firestore UID/GID assignments.
+  This may be useful when performing destructive updates where everyone's usernames may change.
 - Use a connection pool for LDAP queries instead of opening a new connection for each query.
 - Fix verification of OpenID Connect ID tokens when the upstream issuer URL has a path component.
   Previous versions of Gafaelfawr would incorrectly look for standard metadata URLs one path level too high.

--- a/src/gafaelfawr/services/oidc.py
+++ b/src/gafaelfawr/services/oidc.py
@@ -71,6 +71,10 @@ class OIDCService:
         self._token_service = token_service
         self._logger = logger
 
+    async def delete_all_codes(self) -> None:
+        """Invalidate all issued OpenID Connect codes."""
+        await self._authorization_store.delete_all()
+
     def get_jwks(self) -> JWKS:
         """Return the key set for the OpenID Connect server."""
         key_id = self._config.key_id

--- a/src/gafaelfawr/services/token.py
+++ b/src/gafaelfawr/services/token.py
@@ -320,6 +320,15 @@ class TokenService:
             )
         return token
 
+    async def delete_all_tokens(self) -> None:
+        """Delete all stored tokens.
+
+        This only purges them from Redis, not from the database.  It is
+        normally called in combination with truncating all database tables
+        (which is much faster than deleting entries line by line).
+        """
+        await self._token_redis_store.delete_all()
+
     async def delete_token(
         self,
         key: str,

--- a/src/gafaelfawr/storage/base.py
+++ b/src/gafaelfawr/storage/base.py
@@ -55,6 +55,17 @@ class RedisStorage(Generic[S]):
         count = await self._redis.delete(key)
         return count > 0
 
+    async def delete_all(self, pattern: str) -> None:
+        """Delete all stored objects.
+
+        Parameters
+        ----------
+        pattern : `str`
+            Glob pattern matching the keys to purge, such as ``oidc:*``.
+        """
+        async for key in self._redis.scan_iter(pattern):
+            await self._redis.delete(key)
+
     async def get(self, key: str) -> Optional[S]:
         """Retrieve a stored object.
 

--- a/src/gafaelfawr/storage/oidc.py
+++ b/src/gafaelfawr/storage/oidc.py
@@ -64,6 +64,10 @@ class OIDCAuthorizationStore:
         """
         await self._storage.delete(f"oidc:{code.key}")
 
+    async def delete_all(self) -> None:
+        """Delete all stored OpenID Connect authorizations."""
+        await self._storage.delete_all("oidc:*")
+
     async def get(
         self, code: OIDCAuthorizationCode
     ) -> Optional[OIDCAuthorization]:

--- a/src/gafaelfawr/storage/token.py
+++ b/src/gafaelfawr/storage/token.py
@@ -364,6 +364,10 @@ class TokenRedisStore:
         """
         return await self._storage.delete(f"token:{key}")
 
+    async def delete_all(self) -> None:
+        """Delete all stored tokens."""
+        await self._storage.delete_all("token:*")
+
     async def get_data(self, token: Token) -> Optional[TokenData]:
         """Retrieve the data for a token from Redis.
 


### PR DESCRIPTION
Sometimes we'll do destructive upgrades where everyone's username
may change, and in that case we want to purge all Gafaelfawr data
since any remaining data will be meaningless.  Add a command-line
tool to do that.

Drop a workaround in CLI testing from when we were recreating
tables, which is no longer needed now that we're truncating tables
instead.