### PR TITLE
[DM-34613] Disallow all-numeric usernames

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -29,6 +29,7 @@ The internal configuration format may change in minor releases.
 - Use a connection pool for LDAP queries instead of opening a new connection for each query.
 - Fix verification of OpenID Connect ID tokens when the upstream issuer URL has a path component.
   Previous versions of Gafaelfawr would incorrectly look for standard metadata URLs one path level too high.
+- Disallow usernames containing only digits, bringing the username policy in sync with `DMTN-255 <https://dmtn-255.lsst.io/>`__.
 - Report better errors to the user if Firestore or LDAP fail during login.
 - Add ``config.oidc.usernameClaim`` and ``config.oidc.uidClaim`` Helm configuration options to customize which claims from the upstream OpenID Connect ID token are used to get the username and UID.
 - Update dependencies.

--- a/src/gafaelfawr/constants.py
+++ b/src/gafaelfawr/constants.py
@@ -68,7 +68,9 @@ GROUPNAME_REGEX = "^[a-zA-Z][a-zA-Z0-9._-]*$"
 SCOPE_REGEX = "^[a-zA-Z0-9:._-]+$"
 """Regex matching a valid scope."""
 
-USERNAME_REGEX = "^[a-z0-9](?:[a-z0-9]|-[a-z0-9])*$"
+USERNAME_REGEX = (
+    "^[a-z0-9](?:[a-z0-9]|-[a-z0-9])*[a-z](?:[a-z0-9]|-[a-z0-9])*$"
+)
 """Regex matching all valid usernames."""
 
 ACTOR_REGEX = f"{USERNAME_REGEX}|^<[a-z]+>$"

--- a/tests/services/token_test.py
+++ b/tests/services/token_test.py
@@ -1273,7 +1273,7 @@ async def test_invalid_username(factory: Factory) -> None:
     data = await token_service.get_data(session_token)
     assert data
 
-    # Cannot create any type of token with an invalid name.
+    # Cannot create any type of token with an invalid username.
     for user in (
         "<bootstrap>",
         "<internal>",
@@ -1285,6 +1285,7 @@ async def test_invalid_username(factory: Factory) -> None:
         "-invalid",
         "invalid-",
         "in--valid",
+        "1234567",
     ):
         user_info.username = user
         with pytest.raises(PermissionDeniedError):


### PR DESCRIPTION
Bring the valid username regex in sync with DMTN-255.