### PR TITLE
[DM-35238] Generate API documentation from OpenAPI spec

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -128,6 +128,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+        with:
+          # Ensure the documentation gets the right version.
+          fetch-depth: 0
 
       - name: Set up Python
         uses: actions/setup-python@v4

--- a/.gitignore
+++ b/.gitignore
@@ -69,9 +69,10 @@ instance/
 .scrapy
 
 # Sphinx documentation
-docs/_build/
-docs/api/
-docs/_static/*.png
+/docs/_build/
+/docs/arch/internals/
+/docs/_static/openapi.json
+/docs/_static/*.png
 
 # PyBuilder
 target/

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,6 +22,8 @@ The internal configuration format may change in minor releases.
   These will normally be created via the admin token API.
   User data such as UID, full name, and email address that would normally be retrieved from LDAP (depending on the configuration) will be null instead.
 - Rename ``config.ldap.baseDn`` to ``config.ldap.groupBaseDn`` to make it clearer that it is only used for group membership searches.
+- The return status of a successful ``PATCH /auth/api/v1/users/<username>/tokens/<token>`` request is now 200 instead of 201.
+  Since this modifies a resource rather than creating one, that status code seems more accurate.
 - Add ``gafaelfawr fix-home-ownership`` command-line invocation that assigns UIDs via Firestore for all users found in a home directory tree and then recursively changes ownership of their files to their newly-allocated UIDs.
   This is intended as a one-time migration tool for environments that are switching to Firestore for UID assignment
 - Add ``gafaelfawr delete-all-data`` command-line invocation that deletes all data except Firestore UID/GID assignments.

--- a/docs/arch/internals.rst
+++ b/docs/arch/internals.rst
@@ -1,6 +1,6 @@
-#############
-API reference
-#############
+################
+Python internals
+################
 
 .. automodapi:: gafaelfawr
    :include-all-objects:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -26,6 +26,7 @@ extensions = [
     "sphinx_automodapi.automodapi",
     "sphinx_automodapi.smart_resolver",
     "sphinx_click",
+    "sphinxcontrib.redoc",
     "documenteer.sphinxext",
 ]
 
@@ -178,6 +179,19 @@ html_use_index = True
 
 # API Reference ==============================================================
 
+redoc = [
+    {
+        "name": "Gafaelfawr REST API",
+        "page": "api",
+        "spec": "_static/openapi.json",
+        "embed": True,
+        "opts": {"hide-hostname": True},
+    }
+]
+redoc_uri = (
+    "https://cdn.jsdelivr.net/npm/redoc@next/bundles/redoc.standalone.js"
+)
+
 napoleon_google_docstring = False
 napoleon_numpy_docstring = True
 napoleon_include_init_with_doc = False
@@ -194,7 +208,7 @@ napoleon_use_rtype = True
 autosummary_generate = True
 
 automodapi_inheritance_diagram = True
-automodapi_toctreedirnm = "api"
+automodapi_toctreedirnm = "arch/internals"
 
 # Inheriting docstrings from parents by default creates huge amounts of noise
 # in Pydantic.  Use the :inherited-members: flag when this is needed.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -29,6 +29,14 @@ Installation
    cli
    glossary
 
+API
+===
+
+.. toctree::
+   :maxdepth: 2
+
+* `REST API <api.html>`__
+
 Changes
 =======
 
@@ -51,6 +59,7 @@ Architecture
    arch/scopes
    arch/storage
    arch/security
+   arch/internals
    arch/references
 
 Development guide
@@ -61,14 +70,6 @@ Development guide
 
    dev/development
    dev/release
-
-API
-===
-
-.. toctree::
-   :maxdepth: 2
-
-   api
 
 Indices
 =======

--- a/examples/docker/gafaelfawr.yaml
+++ b/examples/docker/gafaelfawr.yaml
@@ -15,7 +15,7 @@ realm: "localhost"
 loglevel: "DEBUG"
 session_secret_file: "/run/secrets/session-secret"
 database_url: "postgresql://gafaelfawr:INSECURE@postgresql/gafaelfawr"
-bootstrap_token: "/run/secrets/bootstrap-token"
+bootstrap_token_file: "/run/secrets/bootstrap-token"
 
 # This Redis will be started by the docker-compose.yaml file at the top
 # level of the repository.

--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -24,6 +24,7 @@ seqdiag
 sphinx-automodapi
 sphinx-click
 sphinx-prompt
+sphinxcontrib-redoc
 sqlalchemy[mypy]
 types-cachetools
 types-PyYAML

--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -32,6 +32,3 @@ types-PyYAML
 # Temporary pin to an alpha version to pick up a fix for interoperability
 # with the latest setuptools.
 funcparserlib>=1.0.0a0
-
-# Temporary pin to fix an incompatibility with seleniumwire
-selenium<4.1.0

--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -28,7 +28,3 @@ sphinxcontrib-redoc
 sqlalchemy[mypy]
 types-cachetools
 types-PyYAML
-
-# Temporary pin to an alpha version to pick up a fix for interoperability
-# with the latest setuptools.
-funcparserlib>=1.0.0a0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -288,9 +288,7 @@ filelock==3.7.1 \
 funcparserlib==1.0.0 \
     --hash=sha256:280fa30e608d547581d65f9294f9bbda7475da86d85119079da4a8402315025f \
     --hash=sha256:7dd33dd4299fc55cbdbf4b9fdfb3abc54d3b5ed0c694b83fb38e9e3e8ac38b6b
-    # via
-    #   -r requirements/dev.in
-    #   blockdiag
+    # via blockdiag
 gitdb==4.0.9 \
     --hash=sha256:8033ad4e853066ba6ca92050b9df2f89301b8fc8bf7e9324d412a63f8bf1a8fd \
     --hash=sha256:bac2fd45c0a1c9cf619e63a90d62bdc63892ef92387424b855792a6cabe789aa

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -655,7 +655,9 @@ pysocks==1.7.1 \
     --hash=sha256:08e69f092cc6dbe92a0fdd16eeb9b9ffbc13cadfe5ca4c7bd92ffb078b293299 \
     --hash=sha256:2725bd0a9925919b9b51739eea5f9e2bae91e83288108a9ad338b2e3a4435ee5 \
     --hash=sha256:3f8804571ebe159c380ac6de37643bb4685970655d3bba243530d6558b799aa0
-    # via selenium-wire
+    # via
+    #   selenium-wire
+    #   urllib3
 pytest==7.1.2 \
     --hash=sha256:13d0e3ccfc2b6e26be000cb6568c832ba67ba32e719443bfe725814d3c42433c \
     --hash=sha256:a06a0425453864a270bc45e71f783330a7428defb4230fb5e6a731fde06ecd45
@@ -733,11 +735,9 @@ rfc3986[idna2008]==1.5.0 \
     # via
     #   -c requirements/main.txt
     #   httpx
-selenium==4.0.0 \
-    --hash=sha256:c942b166a21ce9c9065ad249b54059e926d39f9000167b5ca0fa4950d2ef9a82
-    # via
-    #   -r requirements/dev.in
-    #   selenium-wire
+selenium==4.2.0 \
+    --hash=sha256:ba5b2633f43cf6fe9d308fa4a6996e00a101ab9cb1aad6fd91ae1f3dbe57f56f
+    # via selenium-wire
 selenium-wire==4.6.4 \
     --hash=sha256:c16ef72cb4e0b2b2cf527513c9eb86a469c61933762808684e89b56350fa95b2 \
     --hash=sha256:d6e2e0947040b42a314f1d85ed88a4b34b0e8844d97da2c04b2017e6be60d60b
@@ -909,7 +909,7 @@ typing-extensions==4.2.0 \
     #   -c requirements/main.txt
     #   mypy
     #   sqlalchemy2-stubs
-urllib3[secure]==1.26.9 \
+urllib3[secure,socks]==1.26.9 \
     --hash=sha256:44ece4d53fb1706f667c9bd1c648f5469a2ec925fcf3a776667042d645472c14 \
     --hash=sha256:aabaf16477806a5e1dd19aa41f8c2b7950dd3c746362d7e3223dbe6de6ac448e
     # via

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -29,12 +29,13 @@ attrs==21.4.0 \
     --hash=sha256:626ba8234211db98e869df76230a137c4c40a12d72445c45d5f5b716f076e2fd
     # via
     #   -c requirements/main.txt
+    #   jsonschema
     #   outcome
     #   pytest
     #   trio
-babel==2.10.1 \
-    --hash=sha256:3f349e85ad3154559ac4930c3918247d319f21910d5ce4b25d439ed8693b98d2 \
-    --hash=sha256:98aeaca086133efb3e1e2aad0396987490c8425929ddbcfe0550184fdc54cd13
+babel==2.10.2 \
+    --hash=sha256:7aed055f0c04c9e7f51a2f75261e41e1c804efa724cb65b60a970dd4448d469d \
+    --hash=sha256:81a3beca4d0cd40a9cfb9e2adb2cf39261c2f959b92e7a74750befe5d79afd7b
     # via sphinx
 blinker==1.4 \
     --hash=sha256:471aee25f3992bd325afa3772f1063dbdbbca947a041b8b89466dc00d606f8b6
@@ -107,9 +108,9 @@ brotli==1.0.9 \
     --hash=sha256:ec1947eabbaf8e0531e8e899fc1d9876c179fc518989461f5d24e2223395a9e3 \
     --hash=sha256:f909bbbc433048b499cb9db9e713b5d8d949e8c109a2a548502fb9aa8630f0b1
     # via selenium-wire
-certifi==2022.5.18.1 \
-    --hash=sha256:9c5705e395cd70084351dd8ad5c41e65655e08ce46f2ec9cf6c2c08390f71eb7 \
-    --hash=sha256:f1d53542ee8cbedbe2118b5686372fb33c297fcd6379b050cca0ef13a597382a
+certifi==2022.6.15 \
+    --hash=sha256:84c85a9078b11105f04f3036a9482ae10e4621616db313fe045dd24743a0820d \
+    --hash=sha256:fe86415d55e84719d75f8b69414f6438ac3547d2078ab91b67e779ef69378412
     # via
     #   -c requirements/main.txt
     #   httpcore
@@ -427,6 +428,11 @@ jinja2==3.1.2 \
     #   -c requirements/main.txt
     #   diagrams
     #   sphinx
+    #   sphinxcontrib-redoc
+jsonschema==4.6.0 \
+    --hash=sha256:1c92d2db1900b668201f1797887d66453ab1fbfea51df8e4b46236689c427baf \
+    --hash=sha256:9d6397ba4a6c0bf0300736057f649e3e12ecbc07d3e81a0dacb72de4e9801957
+    # via sphinxcontrib-redoc
 kaitaistruct==0.9 \
     --hash=sha256:3d5845817ec8a4d5504379cc11bd570b038850ee49c4580bc0998c8fb1d327ad
     # via selenium-wire
@@ -516,9 +522,9 @@ nodeenv==1.6.0 \
     --hash=sha256:3ef13ff90291ba2a4a7a4ff9a979b63ffdd00a464dbe04acf0ea6471517a4c2b \
     --hash=sha256:621e6b7076565ddcacd2db0294c0381e01fd28945ab36bcf00f41c5daf63bef7
     # via pre-commit
-outcome==1.1.0 \
-    --hash=sha256:c7dd9375cfd3c12db9801d080a3b63d4b0a261aa996c4c13152380587288d958 \
-    --hash=sha256:e862f01d4e626e63e8f92c38d1f8d5546d3f9cce989263c521b2e7990d186967
+outcome==1.2.0 \
+    --hash=sha256:6f82bd3de45da303cf1f771ecafa1633750a358436a8bb60e06a1ceb745d2672 \
+    --hash=sha256:c4ab89a56575d6d38a05aa16daeaa333109c1f96167aba8901ab18b6b5e0f7f5
     # via trio
 packaging==21.3 \
     --hash=sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb \
@@ -622,6 +628,29 @@ pyparsing==3.0.9 \
     # via
     #   packaging
     #   selenium-wire
+pyrsistent==0.18.1 \
+    --hash=sha256:0e3e1fcc45199df76053026a51cc59ab2ea3fc7c094c6627e93b7b44cdae2c8c \
+    --hash=sha256:1b34eedd6812bf4d33814fca1b66005805d3640ce53140ab8bbb1e2651b0d9bc \
+    --hash=sha256:4ed6784ceac462a7d6fcb7e9b663e93b9a6fb373b7f43594f9ff68875788e01e \
+    --hash=sha256:5d45866ececf4a5fff8742c25722da6d4c9e180daa7b405dc0a2a2790d668c26 \
+    --hash=sha256:636ce2dc235046ccd3d8c56a7ad54e99d5c1cd0ef07d9ae847306c91d11b5fec \
+    --hash=sha256:6455fc599df93d1f60e1c5c4fe471499f08d190d57eca040c0ea182301321286 \
+    --hash=sha256:6bc66318fb7ee012071b2792024564973ecc80e9522842eb4e17743604b5e045 \
+    --hash=sha256:7bfe2388663fd18bd8ce7db2c91c7400bf3e1a9e8bd7d63bf7e77d39051b85ec \
+    --hash=sha256:7ec335fc998faa4febe75cc5268a9eac0478b3f681602c1f27befaf2a1abe1d8 \
+    --hash=sha256:914474c9f1d93080338ace89cb2acee74f4f666fb0424896fcfb8d86058bf17c \
+    --hash=sha256:b568f35ad53a7b07ed9b1b2bae09eb15cdd671a5ba5d2c66caee40dbf91c68ca \
+    --hash=sha256:cdfd2c361b8a8e5d9499b9082b501c452ade8bbf42aef97ea04854f4a3f43b22 \
+    --hash=sha256:d1b96547410f76078eaf66d282ddca2e4baae8964364abb4f4dcdde855cd123a \
+    --hash=sha256:d4d61f8b993a7255ba714df3aca52700f8125289f84f704cf80916517c46eb96 \
+    --hash=sha256:d7a096646eab884bf8bed965bad63ea327e0d0c38989fc83c5ea7b8a87037bfc \
+    --hash=sha256:df46c854f490f81210870e509818b729db4488e1f30f2a1ce1698b2295a878d1 \
+    --hash=sha256:e24a828f57e0c337c8d8bb9f6b12f09dfdf0273da25fda9e314f0b684b415a07 \
+    --hash=sha256:e4f3149fd5eb9b285d6bfb54d2e5173f6a116fe19172686797c056672689daf6 \
+    --hash=sha256:e92a52c166426efbe0d1ec1332ee9119b6d32fc1f0bbfd55d5c1088070e7fc1b \
+    --hash=sha256:f87cc2863ef33c709e237d4b5f4502a62a00fab450c9e020892e8e2ede5847f5 \
+    --hash=sha256:fd8da6d0124efa2f67d86fa70c851022f87c98e205f0594e1fae044e7119a5a6
+    # via jsonschema
 pysocks==1.7.1 \
     --hash=sha256:08e69f092cc6dbe92a0fdd16eeb9b9ffbc13cadfe5ca4c7bd92ffb078b293299 \
     --hash=sha256:2725bd0a9925919b9b51739eea5f9e2bae91e83288108a9ad338b2e3a4435ee5 \
@@ -686,6 +715,7 @@ pyyaml==6.0 \
     #   documenteer
     #   pre-commit
     #   pybtex
+    #   sphinxcontrib-redoc
 requests==2.28.0 \
     --hash=sha256:bc7861137fbce630f17b03d3ad02ad0bf978c844f3536d0edda6499dafce2b6f \
     --hash=sha256:d568723a7ebd25875d8d1eaf5dfa068cd2fc8194b2e483d7b1f7c81918dbec6b
@@ -723,6 +753,7 @@ six==1.16.0 \
     #   -c requirements/main.txt
     #   latexcodec
     #   pybtex
+    #   sphinxcontrib-redoc
     #   virtualenv
 smmap==5.0.0 \
     --hash=sha256:2aba19d6a040e78d8b09de5c57e96207b09ed71d8e55ce0959eeee6c8e190d94 \
@@ -755,6 +786,7 @@ sphinx==5.0.1 \
     #   sphinx-click
     #   sphinx-prompt
     #   sphinxcontrib-bibtex
+    #   sphinxcontrib-redoc
 sphinx-automodapi==0.14.1 \
     --hash=sha256:4238e131d7abc47226449661bb3cfa2bb1b5b190184ffa69d9b924b984a22753 \
     --hash=sha256:a2f9c0f9e2901875e6db75df6c01412875eb15f25e7db1206e1b69fedf75bbc9
@@ -790,6 +822,9 @@ sphinxcontrib-qthelp==1.0.3 \
     --hash=sha256:4c33767ee058b70dba89a6fc5c1892c0d57a54be67ddd3e7875a18d14cba5a72 \
     --hash=sha256:bd9fc24bcb748a8d51fd4ecaade681350aa63009a347a8c14e637895444dfab6
     # via sphinx
+sphinxcontrib-redoc==1.6.0 \
+    --hash=sha256:e358edbe23927d36432dde748e978cf897283a331a03e93d3ef02e348dee4561
+    # via -r requirements/dev.in
 sphinxcontrib-serializinghtml==1.1.5 \
     --hash=sha256:352a9a00ae864471d3a7ead8d7d79f5fc0b57e8b3f95e9867eb9eb28999b92fd \
     --hash=sha256:aa5f6de5dfdf809ef505c4895e51ef5c9eac17d0f287933eb49ec495280b6952
@@ -834,9 +869,9 @@ sqlalchemy[asyncio,mypy]==1.4.37 \
     # via
     #   -c requirements/main.txt
     #   -r requirements/dev.in
-sqlalchemy2-stubs==0.0.2a23 \
-    --hash=sha256:6011d2219365d4e51f3e9d83ffeb5b904964ef1d143dc1298d8a70ce8641014d \
-    --hash=sha256:a13d94e23b5b0da8ee21986ef8890788a1f2eb26c2a9f39424cc933e4e7e87ff
+sqlalchemy2-stubs==0.0.2a24 \
+    --hash=sha256:e15c45302eafe196ed516f979ef017135fd619d2c62d02de9a5c5f2e59a600c4 \
+    --hash=sha256:f2399251d3d8f00a88659d711a449c855a0d4e977c7a9134e414f1459b9acc11
     # via sqlalchemy
 toml==0.10.2 \
     --hash=sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b \
@@ -859,9 +894,9 @@ trio-websocket==0.9.2 \
     --hash=sha256:5b558f6e83cc20a37c3b61202476c5295d1addf57bd65543364e0337e37ed2bc \
     --hash=sha256:a3d34de8fac26023eee701ed1e7bf4da9a8326b61a62934ec9e53b64970fd8fe
     # via selenium
-types-cachetools==5.0.1 \
-    --hash=sha256:2b9e0b1ace1a0de67bc3ced9c4aa69fff882bac8bfeb0f2aefaf0f99e4571c6b \
-    --hash=sha256:4915e40fce8df222aa9ef118cdbc3e8eef55caefe32b6ded2cd2dbe21a2e2398
+types-cachetools==5.0.2 \
+    --hash=sha256:4291c3b6ae10e7b0d7ae3c4cb7d9daa6b21d4b7deb64d193e44bcec7ca5c4095 \
+    --hash=sha256:bf22b2e9f9243983914f6510e43a1873f012afb8c3fc5e09a59b0ccbe3ab0f35
     # via -r requirements/dev.in
 types-pyyaml==6.0.8 \
     --hash=sha256:56a7b0e8109602785f942a11ebfbd16e97d5d0e79f5fbb077ec4e6a0004837ff \
@@ -947,9 +982,9 @@ zstandard==0.17.0 \
     # via selenium-wire
 
 # The following packages are considered to be unsafe in a requirements file:
-setuptools==62.3.4 \
-    --hash=sha256:1f5d3a1502812025cdb2e5609b6af2d207332e3f50febe6db10ed3a59b2f155f \
-    --hash=sha256:30b6b0fbacc459c90d27a63e6173facfc8b8c99a48fb24b5044f459ba63cd6cf
+setuptools==62.4.0 \
+    --hash=sha256:5a844ad6e190dccc67d6d7411d119c5152ce01f7c76be4d8a1eaa314501bba77 \
+    --hash=sha256:bf8a748ac98b09d32c9a64a995a6b25921c96cc5743c1efa82763ba80ff54e91
     # via
     #   -c requirements/main.txt
     #   blockdiag

--- a/requirements/main.txt
+++ b/requirements/main.txt
@@ -162,9 +162,9 @@ cachetools==5.2.0 \
     # via
     #   -r requirements/main.in
     #   google-auth
-certifi==2022.5.18.1 \
-    --hash=sha256:9c5705e395cd70084351dd8ad5c41e65655e08ce46f2ec9cf6c2c08390f71eb7 \
-    --hash=sha256:f1d53542ee8cbedbe2118b5686372fb33c297fcd6379b050cca0ef13a597382a
+certifi==2022.6.15 \
+    --hash=sha256:84c85a9078b11105f04f3036a9482ae10e4621616db313fe045dd24743a0820d \
+    --hash=sha256:fe86415d55e84719d75f8b69414f6438ac3547d2078ab91b67e779ef69378412
     # via
     #   httpcore
     #   httpx
@@ -327,15 +327,15 @@ frozenlist==1.3.0 \
     # via
     #   aiohttp
     #   aiosignal
-google-api-core[grpc]==2.8.1 \
-    --hash=sha256:958024c6aa3460b08f35741231076a4dd9a4c819a6a39d44da9627febe8b28f0 \
-    --hash=sha256:ce1daa49644b50398093d2a9ad886501aa845e2602af70c3001b9f402a9d7359
+google-api-core[grpc]==2.8.2 \
+    --hash=sha256:06f7244c640322b508b125903bb5701bebabce8832f85aba9335ec00b3d02edc \
+    --hash=sha256:93c6a91ccac79079ac6bbf8b74ee75db970cc899278b97d53bc012f35908cf50
     # via
     #   google-cloud-core
     #   google-cloud-firestore
-google-auth==2.7.0 \
-    --hash=sha256:8a954960f852d5f19e6af14dd8e75c20159609e85d8db37e4013cc8c3824a7e1 \
-    --hash=sha256:df549a1433108801b11bdcc0e312eaf0d5f0500db42f0523e4d65c78722e8475
+google-auth==2.8.0 \
+    --hash=sha256:819b70140d05501739e1387291d39f0de3b4dff3b00ae4aff8e7a05369957f89 \
+    --hash=sha256:9b1da39ab8731c3061f36fefde9f8bb902dbee9eb28e3a67e8cfa7dc1be76227
     # via
     #   google-api-core
     #   google-cloud-core
@@ -343,9 +343,9 @@ google-cloud-core==2.3.1 \
     --hash=sha256:113ba4f492467d5bd442c8d724c1a25ad7384045c3178369038840ecdd19346c \
     --hash=sha256:34334359cb04187bdc80ddcf613e462dfd7a3aabbc3fe4d118517ab4b9303d53
     # via google-cloud-firestore
-google-cloud-firestore==2.5.2 \
-    --hash=sha256:32d0ac602bafdb0a6fefb02e407e2c1a13d7e13fc2988e14d9e58c38be0a2ab7 \
-    --hash=sha256:96d1574fe714fd818faaedbc59c4ad57a6c96ab6e22066e3b072c8fbd51953cd
+google-cloud-firestore==2.5.3 \
+    --hash=sha256:2123e3a55d9f8d948c6e425ae98cc519daf0c840bc31ab8bc12ea9a2132d1686 \
+    --hash=sha256:8685d21b7cc64f3f95a6cc484b54b21cf6df0d9537c5527d1060247225fe4bed
     # via -r requirements/main.in
 googleapis-common-protos==1.56.2 \
     --hash=sha256:023eaea9d8c1cceccd9587c6af6c20f33eeeb05d4148670f2b0322dc1511700c \
@@ -647,9 +647,9 @@ multidict==6.0.2 \
     # via
     #   aiohttp
     #   yarl
-proto-plus==1.20.5 \
-    --hash=sha256:81794eb1be333c67986333948df70ebb8cdf538e039f8cfa92fd2a9d7176d405 \
-    --hash=sha256:fa29fec8a91cf178bc1d8bf9263769421d2dba7787eae42b67235676e211c158
+proto-plus==1.20.6 \
+    --hash=sha256:449b4537e83f4776bd69051c4d776db8ffe3f9d0641f1e87b06c116eb94c90e9 \
+    --hash=sha256:c6c43c3fcfc360fdab46b47e2e9e805ff56e13169f9f2e45caf88b6b593215ab
     # via google-cloud-firestore
 protobuf==3.20.1 \
     --hash=sha256:06059eb6953ff01e56a25cd02cca1a9649a75a7e65397b5b9b4e929ed71d10cf \
@@ -801,9 +801,9 @@ rsa==4.8 \
     --hash=sha256:5c6bd9dc7a543b7fe4304a631f8a8a3b674e2bbfc49c2ae96200cdbe55df6b17 \
     --hash=sha256:95c5d300c4e879ee69708c428ba566c59478fd653cc3a22243eeb8ed846950bb
     # via google-auth
-safir[db,kubernetes]==3.1.0 \
-    --hash=sha256:d32eafce4180fc245bd6e804b3e537159521dfe6d319994143012c2214a5ab10 \
-    --hash=sha256:e46e49f54360763379897b889940e734545e601657cdec9a3a4c005d3dc9587b
+safir[db,kubernetes]==3.2.0 \
+    --hash=sha256:3573c6f24043004591e5c070a7b7f2445fdf575e1114f2cecfb34164dc33e5a0 \
+    --hash=sha256:c0b51c0d0a0fd05549329122aa6ebb9affdedc56861691cea1cc98939bfd9621
     # via -r requirements/main.in
 six==1.16.0 \
     --hash=sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926 \
@@ -1038,7 +1038,7 @@ yarl==1.7.2 \
     # via aiohttp
 
 # The following packages are considered to be unsafe in a requirements file:
-setuptools==62.3.4 \
-    --hash=sha256:1f5d3a1502812025cdb2e5609b6af2d207332e3f50febe6db10ed3a59b2f155f \
-    --hash=sha256:30b6b0fbacc459c90d27a63e6173facfc8b8c99a48fb24b5044f459ba63cd6cf
+setuptools==62.4.0 \
+    --hash=sha256:5a844ad6e190dccc67d6d7411d119c5152ce01f7c76be4d8a1eaa314501bba77 \
+    --hash=sha256:bf8a748ac98b09d32c9a64a995a6b25921c96cc5743c1efa82763ba80ff54e91
     # via kubernetes-asyncio

--- a/src/gafaelfawr/cli.py
+++ b/src/gafaelfawr/cli.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import json
 import sys
-from importlib.metadata import version
 from pathlib import Path
 from typing import Optional, Union
 
@@ -223,20 +222,26 @@ async def kubernetes_controller(settings: Optional[str]) -> None:
 
 @main.command()
 @click.option(
+    "--add-back-link",
+    default=False,
+    is_flag=True,
+    help="Add back link (used when generating application documentation)",
+)
+@click.option(
     "--output",
     default=None,
     type=click.Path(path_type=Path),
     help="Output path (output to stdout if not given).",
 )
-def openapi_schema(output: Optional[Path]) -> None:
+def openapi_schema(add_back_link: bool, output: Optional[Path]) -> None:
     app = create_app(load_config=False)
+    description = app.description
+    if add_back_link:
+        description += "\n\n[Return to Gafaelfawr documentation](index.html)."
     schema = get_openapi(
-        title="Gafaelfawr",
-        description=(
-            "Gafaelfawr is a FastAPI application for the authorization and"
-            " management of tokens, including their issuance and revocation."
-        ),
-        version=version("gafaelfawr"),
+        title=app.title,
+        description=description,
+        version=app.version,
         routes=app.routes,
     )
     if output:

--- a/src/gafaelfawr/dependencies/return_url.py
+++ b/src/gafaelfawr/dependencies/return_url.py
@@ -94,7 +94,7 @@ async def return_url_with_header(
         title="URL to return to",
         description=(
             "User is sent here after successful authentication. Overrides"
-            " X-Auth-Request-Redirect if both are set."
+            " `X-Auth-Request-Redirect` if both are set."
         ),
         example="https://example.com/",
     ),

--- a/src/gafaelfawr/handlers/analyze.py
+++ b/src/gafaelfawr/handlers/analyze.py
@@ -109,7 +109,7 @@ async def get_analyze(
     description=(
         "Show a JSON dump of data about the provided token.  The output"
         " format is for backwards compatibility with Gafaelfawr 1.x."
-        " Use /auth/api/v1/token-info and /auth/api/v1/user-info instead."
+        " Use `/auth/api/v1/token-info` and `/auth/api/v1/user-info` instead."
     ),
     response_class=FormattedJSONResponse,
     responses={

--- a/src/gafaelfawr/handlers/auth.py
+++ b/src/gafaelfawr/handlers/auth.py
@@ -65,8 +65,16 @@ class AuthConfig:
 
 
 def auth_uri(
-    x_original_uri: Optional[str] = Header(None),
-    x_original_url: Optional[str] = Header(None),
+    x_original_uri: Optional[str] = Header(
+        None, description="URL for which authorization is being checked"
+    ),
+    x_original_url: Optional[str] = Header(
+        None,
+        description=(
+            "URL for which authorization is being checked. `X-Original-URI`"
+            " takes precedence if both are set."
+        ),
+    ),
 ) -> str:
     """Determine URL for which we're validating authentication.
 
@@ -82,7 +90,7 @@ def auth_config(
         ...,
         title="Required scopes",
         description=(
-            "If given more than once, meaning is determined by the satisfy"
+            "If given more than once, meaning is determined by the `satisfy`"
             " parameter"
         ),
         example="read:all",
@@ -91,21 +99,21 @@ def auth_config(
         Satisfy.ALL,
         title="Scope matching policy",
         description=(
-            "Set to all to require all listed scopes, set to any to require"
-            " any of the listed scopes"
+            "Set to `all` to require all listed scopes, set to `any` to"
+            " require any of the listed scopes"
         ),
         example="any",
     ),
     auth_type: AuthType = Query(
         AuthType.Bearer,
         title="Challenge type",
-        description="Control the type of WWW-Authenticate challenge returned",
+        description="Type of `WWW-Authenticate` challenge to return",
         example="basic",
     ),
     notebook: bool = Query(
         False,
         title="Request notebook token",
-        description="Cannot be used with delegate_to or delegate_scope.",
+        description="Cannot be used with `delegate_to` or `delegate_scope`",
         example=True,
     ),
     delegate_to: Optional[str] = Query(

--- a/src/gafaelfawr/handlers/login.py
+++ b/src/gafaelfawr/handlers/login.py
@@ -51,7 +51,17 @@ class LoginError(Enum):
         " protected site."
     ),
     responses={
-        307: {"description": "Redirect to provider or destination"},
+        307: {
+            "description": "Redirect to provider or destination",
+            "headers": {
+                "Location": {
+                    "description": (
+                        "URL of authentication provider or protected site"
+                    ),
+                    "schema": {"type": "string"},
+                }
+            },
+        },
         403: {
             "content": {"text/html": {}},
             "description": "Error authenticating the user",

--- a/src/gafaelfawr/handlers/oidc.py
+++ b/src/gafaelfawr/handlers/oidc.py
@@ -167,7 +167,7 @@ def build_return_url(
 
 @router.post(
     "/auth/openid/token",
-    description="Redeem an authorization code for a token.",
+    description="Redeem an authorization code for a token",
     response_model=OIDCTokenReply,
     responses={
         400: {"description": "Request was invalid", "model": OIDCErrorReply}
@@ -180,7 +180,7 @@ async def post_token(
     grant_type: str = Form(
         None,
         title="Request type",
-        description="authorization_code is the only supported grant type",
+        description="`authorization_code` is the only supported grant type",
         example="authorization_code",
     ),
     client_id: str = Form(
@@ -247,7 +247,7 @@ async def post_token(
 
 @router.get(
     "/auth/oidc/userinfo",
-    description="Return information about the holder of a JWT.",
+    description="Return information about the holder of a JWT",
     responses={
         200: {
             "content": {
@@ -286,7 +286,9 @@ async def get_userinfo(
     "/.well-known/jwks.json",
     description=(
         "Returns the key set used for JWT signatures in the format"
-        " specified in RFC 7517 and RFC 7518."
+        " specified in"
+        " [RFC 7517](https://datatracker.ietf.org/doc/html/rfc7517) and"
+        " [RFC 7518](https://datatracker.ietf.org/doc/html/rfc7518)"
     ),
     response_model=JWKS,
     response_model_exclude_none=True,
@@ -304,7 +306,10 @@ async def get_well_known_jwks(
     "/.well-known/openid-configuration",
     description=(
         "Returns OpenID Connect configuration information in the format"
-        " specified in the OpenID Connect Discovery 1.0 specification."
+        " specified in the"
+        " [OpenID Connect Discovery 1.0]"
+        "(https://openid.net/specs/openid-connect-discovery-1_0.html)"
+        " specification."
     ),
     response_model=OIDCConfig,
     summary="OIDC configuration",

--- a/src/gafaelfawr/models/auth.py
+++ b/src/gafaelfawr/models/auth.py
@@ -52,7 +52,7 @@ class APILoginResponse(BaseModel):
         title="CSRF token",
         description=(
             "This token must be included in any non-GET request using cookie"
-            " authentication as the value of the X-CSRF-Token header."
+            " authentication as the value of the `X-CSRF-Token` header"
         ),
         example="OmNdVTtKKuK_VuJsGFdrqg",
     )

--- a/src/gafaelfawr/models/history.py
+++ b/src/gafaelfawr/models/history.py
@@ -198,7 +198,21 @@ class TokenChangeHistoryEntry(BaseModel):
     )
 
     token_type: TokenType = Field(
-        ..., title="Type of the token", example="user"
+        ...,
+        title="Type of the token",
+        description=(
+            "Class of token, chosen from:\n\n"
+            "* `session`: An interactive user web session\n"
+            "* `user`: A user-generated token that may be used"
+            " programmatically\n"
+            "* `notebook`: The token delegated to a Jupyter notebook for"
+            " the user\n"
+            "* `internal`: A service-to-service token used for internal"
+            " sub-calls made as part of processing a user request\n"
+            "* `service`: A service-to-service token used for internal calls"
+            " initiated by services, unrelated to a user request\n"
+        ),
+        example="user",
     )
 
     token_name: Optional[str] = Field(

--- a/src/gafaelfawr/models/oidc.py
+++ b/src/gafaelfawr/models/oidc.py
@@ -211,7 +211,7 @@ class OIDCTokenReply(BaseModel):
     token_type: str = Field(
         "Bearer",
         title="Type of token",
-        description="Will always be Bearer",
+        description="Will always be `Bearer`",
         example="Bearer",
     )
 
@@ -222,7 +222,10 @@ class OIDCErrorReply(BaseModel):
     error: str = Field(
         ...,
         title="Error code",
-        description="See RFC 6750 for possible codes",
+        description=(
+            "See [RFC 6750](https://datatracker.ietf.org/doc/html/rfc6750)"
+            " for possible codes"
+        ),
         example="some_code",
     )
 
@@ -239,21 +242,21 @@ class JWK(BaseModel):
     alg: str = Field(
         ...,
         title="Algorithm",
-        description=f"Will always be {ALGORITHM}",
+        description=f"Will always be `{ALGORITHM}`",
         example=ALGORITHM,
     )
 
     kty: str = Field(
         ...,
         title="Key type",
-        description="Will always be RSA",
+        description="Will always be `RSA`",
         example="RSA",
     )
 
     use: str = Field(
         ...,
         title="Key usage",
-        description="Will always be sig (signatures)",
+        description="Will always be `sig` (signatures)",
         example="sig",
     )
 
@@ -343,41 +346,41 @@ class OIDCConfig(BaseModel):
     scopes_supported: List[str] = Field(
         ["openid"],
         title="Supported scopes",
-        description="openid is the only supported scope",
+        description="`openid` is the only supported scope",
         example=["openid"],
     )
 
     response_types_supported: List[str] = Field(
         ["code"],
         title="Supported response types",
-        description="code is the only supported response type",
+        description="`code` is the only supported response type",
         example=["code"],
     )
 
     grant_types_supported: List[str] = Field(
         ["authorization_code"],
         title="Supported grant types",
-        description="authorization_code is the only supported grant type",
+        description="`authorization_code` is the only supported grant type",
         example=["authorization_code"],
     )
 
     subject_types_supported: List[str] = Field(
         ["public"],
         title="Supported subject types",
-        description="public is the only supported subject type",
+        description="`public` is the only supported subject type",
         example=["public"],
     )
 
     id_token_signing_alg_values_supported: List[str] = Field(
         [ALGORITHM],
         title="Supported JWT signing algorithms",
-        description=f"{ALGORITHM} is the only supported signing algorithm",
+        description=f"`{ALGORITHM}` is the only supported signing algorithm",
         example=[ALGORITHM],
     )
 
     token_endpoint_auth_methods_supported: List[str] = Field(
         ["client_secret_post"],
         title="Supported client auth methods",
-        description="client_secret_post is the only supported auth method",
+        description="`client_secret_post` is the only supported auth method",
         example=["client_secret_post"],
     )

--- a/src/gafaelfawr/models/token.py
+++ b/src/gafaelfawr/models/token.py
@@ -100,6 +100,9 @@ class TokenType(Enum):
     internal
         A service-to-service token used for internal sub-calls made as part of
         processing a user request.
+    service
+        A service-to-service token used for internal calls initiated by
+        services, unrelated to a user request.
     """
 
     session = "session"
@@ -143,7 +146,23 @@ class TokenBase(BaseModel):
         max_length=64,
     )
 
-    token_type: TokenType = Field(..., title="Token type", example="session")
+    token_type: TokenType = Field(
+        ...,
+        description=(
+            "Class of token, chosen from:\n\n"
+            "* `session`: An interactive user web session\n"
+            "* `user`: A user-generated token that may be used"
+            " programmatically\n"
+            "* `notebook`: The token delegated to a Jupyter notebook for"
+            " the user\n"
+            "* `internal`: A service-to-service token used for internal"
+            " sub-calls made as part of processing a user request\n"
+            "* `service`: A service-to-service token used for internal calls"
+            " initiated by services, unrelated to a user request\n"
+        ),
+        title="Token type",
+        example="session",
+    )
 
     scopes: List[str] = Field(
         ..., title="Token scopes", example=["read:all", "user:token"]
@@ -340,7 +359,7 @@ class AdminTokenRequest(BaseModel):
         title="User for which to issue a token",
         description=(
             "The username may only contain lowercase letters, digits,"
-            " and dash (-), and may not start or end with a dash."
+            " and dash (`-`), and may not start or end with a dash"
         ),
         example="some-service",
         min_length=1,
@@ -351,14 +370,21 @@ class AdminTokenRequest(BaseModel):
     token_type: TokenType = Field(
         ...,
         title="Token type",
-        description="Must be either service or user.",
+        description=(
+            "Must be either `service` or `user`"
+            "\n\n"
+            "* `service`: A service-to-service token used for internal calls"
+            " initiated by services, unrelated to a user request\n"
+            "* `user`: A user-generated token that may be used"
+            " programmatically\n"
+        ),
         example="service",
     )
 
     token_name: Optional[str] = Field(
         None,
         title="User-given name of the token",
-        description="Only provide this field for a token type of user.",
+        description="Only provide this field for a token type of `user`",
         example="laptop token",
         min_length=1,
         max_length=64,
@@ -375,7 +401,7 @@ class AdminTokenRequest(BaseModel):
         title="Token expiration",
         description=(
             "Expiration timestamp of the token in seconds since epoch, or"
-            " omitted to never expire."
+            " omitted to never expire"
         ),
         example=1616986130,
     )
@@ -385,7 +411,7 @@ class AdminTokenRequest(BaseModel):
         title="Preferred full name",
         description=(
             "If a value is not provided, and LDAP is configured, the full"
-            " name from the LDAP entry for that username will be used."
+            " name from the LDAP entry for that username will be used"
         ),
         example="Service User",
         min_length=1,
@@ -396,7 +422,7 @@ class AdminTokenRequest(BaseModel):
         title="Email address",
         description=(
             "If a value is not provided, and LDAP is configured, the email"
-            " address from the LDAP entry for that username will be used."
+            " address from the LDAP entry for that username will be used"
         ),
         example="service@example.com",
         min_length=1,
@@ -408,7 +434,7 @@ class AdminTokenRequest(BaseModel):
         description=(
             "If a value is not provided, and Firestore or LDAP are"
             " configured, the UID from Firestore (preferred) or the LDAP"
-            " entry for that username will be used."
+            " entry for that username will be used"
         ),
         example=4131,
         ge=1,
@@ -420,7 +446,7 @@ class AdminTokenRequest(BaseModel):
         description=(
             "Groups of which the user is a member. If a value is not provided,"
             " and LDAP is configured, the group membership from LDAP will be"
-            " used."
+            " used"
         ),
     )
 

--- a/tests/handlers/api_tokens_test.py
+++ b/tests/handlers/api_tokens_test.py
@@ -124,7 +124,7 @@ async def test_create_delete_modify(
             "expires": int(new_expires.timestamp()),
         },
     )
-    assert r.status_code == 201
+    assert r.status_code == 200
     assert r.json() == {
         "token": user_token.key,
         "username": "example",
@@ -673,7 +673,7 @@ async def test_no_expires(client: AsyncClient, factory: Factory) -> None:
         headers={"X-CSRF-Token": csrf},
         json={"expires": None},
     )
-    assert r.status_code == 201
+    assert r.status_code == 200
     assert "expires" not in r.json()
 
     # Check that the expiration was also changed in Redis.

--- a/tests/pages/base.py
+++ b/tests/pages/base.py
@@ -2,25 +2,13 @@
 
 from __future__ import annotations
 
-from typing import List, Union
+from typing import List
 
-from selenium.webdriver.common.by import By
 from selenium.webdriver.remote.webelement import WebElement
 from seleniumwire import webdriver
 
 
-class BaseFinder:
-    def __init__(self, root: Union[webdriver.Chrome, WebElement]) -> None:
-        self.root = root
-
-    def find_element(self, by: By, name: str) -> WebElement:
-        return self.root.find_element(by, name)
-
-    def find_elements(self, by: By, name: str) -> List[WebElement]:
-        return self.root.find_elements(by, name)
-
-
-class BasePage(BaseFinder):
+class BasePage:
     def __init__(self, root: webdriver.Chrome) -> None:
         self.root = root
 
@@ -28,12 +16,23 @@ class BasePage(BaseFinder):
     def page_source(self) -> str:
         return self.root.page_source
 
+    def find_element(self, by: str, name: str) -> WebElement:
+        return self.root.find_element(by, name)
 
-class BaseModal(BaseFinder):
+    def find_elements(self, by: str, name: str) -> List[WebElement]:
+        return self.root.find_elements(by, name)
+
+
+class BaseElement:
     def __init__(self, root: WebElement) -> None:
         self.root = root
 
+    def find_element(self, by: str, name: str) -> WebElement:
+        return self.root.find_element(by, name)
 
-class BaseElement(BaseFinder):
-    def __init__(self, root: WebElement) -> None:
-        self.root = root
+    def find_elements(self, by: str, name: str) -> List[WebElement]:
+        return self.root.find_elements(by, name)
+
+
+class BaseModal(BaseElement):
+    pass

--- a/tox.ini
+++ b/tox.ini
@@ -56,7 +56,7 @@ whitelist_externals =
     convert
     mv
 commands =
-    gafaelfawr openapi-schema --output docs/_static/openapi.json
+    gafaelfawr openapi-schema --add-back-link --output docs/_static/openapi.json
     python docs/_static/architecture.py
     seqdiag docs/_static/flow.diag
     seqdiag docs/_static/flow-oidc.diag

--- a/tox.ini
+++ b/tox.ini
@@ -56,6 +56,7 @@ whitelist_externals =
     convert
     mv
 commands =
+    gafaelfawr openapi-schema --output docs/_static/openapi.json
     python docs/_static/architecture.py
     seqdiag docs/_static/flow.diag
     seqdiag docs/_static/flow-oidc.diag


### PR DESCRIPTION
Use sphinxcontrib-redoc to generate REST API documentation at
api.html.  Move the internals Python API documentation to
arch/internals, since only developers will need to look at it.
In support of this, add a CLI command to spit out the OpenAPI
schema so that it can be used in the tox build.
 
I experimented with sphinxcontrib-openapi, but it appears to not
be maintained and has bitrotted, and I couldn't get it to work
with the OpenAPI schema generated by FastAPI.  Redoc does,
provided that I override the version of Redoc with the current
upstream release.

There is as yet no back link from the API documentation to the
rest of the documentation.

Now that the API documentation is of the REST API, move it up in
the documentation index.

Remove now-unnecessary documentation pins and fix an incorrect
bit of local Docker configuration.