### PR TITLE
[DM-35644] Remove obsolete isMemberOf reference

### DIFF
--- a/docs/arch/providers.rst
+++ b/docs/arch/providers.rst
@@ -51,7 +51,7 @@ Groups from GitHub
 ------------------
 
 Gafaelfawr synthesizes groups from GitHub teams.
-Each team membership that an authenticated user has on GitHub (and releases through the GitHub OAuth authentication) will be mapped to a group in the ``isMemberOf`` claim.
+Each team membership that an authenticated user has on GitHub (and releases through the GitHub OAuth authentication) will be mapped to a group.
 The default group name is ``<organization>-<team-slug>`` where ``<organization>`` is the ``login`` attribute (forced to lowercase) of the organization containing the team and ``<team-slug>`` is the ``slug`` attribute of the team.
 These values are retrieved through the ``/user/teams`` API route.
 The ``slug`` attribute is constructed by GitHub based on the name.


### PR DESCRIPTION
The GitHub group discussion talked about adding an isMemberOf claim,
which is no longer how Gafaelfawr works.  Remove that reference.