### PR TITLE
[DM-35842] Fix editing of token scopes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ The internal configuration format may change in minor releases.
 Dependencies are updated to the latest available version during each
 release.  Those changes are not noted here explicitly.
 
+## 5.0.3 (unreleased)
+
+- When a user token was edited to change its scope, but not its expiration
+  time, its scopes were not updated in Redis.  Since Redis is canonical
+  for token scopes, this meant that the change appeared to go through but
+  had no actual effect.  Fixed by updating Redis if either the scope or
+  expiration of a user token is changed.
+
 ## 5.0.2 (2022-07-29)
 
 - Improved error handling for LDAP queries.  Hopefully Gafaelfawr should

--- a/src/gafaelfawr/services/token.py
+++ b/src/gafaelfawr/services/token.py
@@ -719,12 +719,15 @@ class TokenService:
             return None
         await self._token_change_store.add(history_entry)
 
-        # Update the expiration in Redis if needed.
-        if no_expire or expires:
+        # Token names exist only in the database and don't require updating
+        # Redis, but scopes and expirations are stored in both places and
+        # require rewriting the token data in Redis as well.
+        if scopes or no_expire or expires:
             data = await self._token_redis_store.get_data_by_key(key)
             if not data:
                 return None
-            data.expires = None if no_expire else expires
+            data.scopes = info.scopes
+            data.expires = info.expires
             await self._token_redis_store.store_data(data)
 
         # Update subtokens if needed.

--- a/src/gafaelfawr/storage/token.py
+++ b/src/gafaelfawr/storage/token.py
@@ -281,8 +281,8 @@ class TokenDatabaseStore:
 
         Returns
         -------
-        info : `gafaelfawr.models.token.TokenInfo`
-            Information for the updated token.
+        info : `gafaelfawr.models.token.TokenInfo` or `None`
+            Information for the updated token or `None` if it was not found.
 
         Raises
         ------


### PR DESCRIPTION
When a user token was edited to change its scope, but not its
expiration time, its scopes were not updated in Redis.  Since Redis
is canonical for token scopes, this meant that the change appeared
to go through but had no actual effect.  Fixed by updating Redis if
either the scope or expiration of a user token is changed.