### PR TITLE
[DM-28121] Add background maintenance task

### DIFF
--- a/src/gafaelfawr/cli.py
+++ b/src/gafaelfawr/cli.py
@@ -192,7 +192,7 @@ async def maintenance(settings: Optional[str]) -> None:
         config_dependency.set_settings_path(settings)
     config = await config_dependency()
     logger = structlog.get_logger("gafaelfawr")
-    logger.debug("Starting")
+    logger.debug("Starting background maintenance")
     engine = create_database_engine(
         config.database_url, config.database_password
     )
@@ -200,6 +200,8 @@ async def maintenance(settings: Optional[str]) -> None:
         token_service = factory.create_token_service()
         async with factory.session.begin():
             await token_service.expire_tokens()
+            await token_service.truncate_history()
+    logger.debug("Completed background maintenance")
 
 
 @main.command()

--- a/src/gafaelfawr/cli.py
+++ b/src/gafaelfawr/cli.py
@@ -33,6 +33,7 @@ __all__ = [
     "init",
     "kubernetes_controller",
     "main",
+    "maintenance",
     "openapi_schema",
     "run",
     "update_service_tokens",
@@ -174,6 +175,31 @@ async def kubernetes_controller(settings: Optional[str]) -> None:
             queue = await kubernetes_service.start_watcher()
             logger.debug("Starting continuous processing")
             await kubernetes_service.update_service_tokens_from_queue(queue)
+
+
+@main.command()
+@click.option(
+    "--settings",
+    envvar="GAFAELFAWR_SETTINGS_PATH",
+    type=str,
+    default=None,
+    help="Application settings file.",
+)
+@run_with_asyncio
+async def maintenance(settings: Optional[str]) -> None:
+    """Perform background maintenance."""
+    if settings:
+        config_dependency.set_settings_path(settings)
+    config = await config_dependency()
+    logger = structlog.get_logger("gafaelfawr")
+    logger.debug("Starting")
+    engine = create_database_engine(
+        config.database_url, config.database_password
+    )
+    async with Factory.standalone(config, engine, check_db=True) as factory:
+        token_service = factory.create_token_service()
+        async with factory.session.begin():
+            await token_service.expire_tokens()
 
 
 @main.command()

--- a/src/gafaelfawr/constants.py
+++ b/src/gafaelfawr/constants.py
@@ -1,5 +1,33 @@
 """Constants for Gafaelfawr."""
 
+from datetime import timedelta
+
+__all__ = [
+    "ACTOR_REGEX",
+    "ALGORITHM",
+    "BOT_USERNAME_REGEX",
+    "CHANGE_HISTORY_RETENTION",
+    "COOKIE_NAME",
+    "CURSOR_REGEX",
+    "GID_MIN",
+    "GID_MAX",
+    "GROUPNAME_REGEX",
+    "HTTP_TIMEOUT",
+    "ID_CACHE_SIZE",
+    "LDAP_CACHE_SIZE",
+    "LDAP_CACHE_LIFETIME",
+    "LDAP_TIMEOUT",
+    "MINIMUM_LIFETIME",
+    "OIDC_AUTHORIZATION_LIFETIME",
+    "SETTINGS_PATH",
+    "SCOPE_REGEX",
+    "TOKEN_CACHE_SIZE",
+    "UID_BOT_MIN",
+    "UID_BOT_MAX",
+    "UID_USER_MIN",
+    "USERNAME_REGEX",
+]
+
 ALGORITHM = "RS256"
 """JWT algorithm to use for all tokens."""
 
@@ -11,6 +39,9 @@ HTTP_TIMEOUT = 20.0
 
 LDAP_TIMEOUT = 5.0
 """Timeout (in seconds) for LDAP queries."""
+
+CHANGE_HISTORY_RETENTION = timedelta(days=365)
+"""Retention of old token change history entries."""
 
 MINIMUM_LIFETIME = 5 * 60
 """Minimum expiration lifetime for a token in seconds."""

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -25,12 +25,15 @@ from sqlalchemy.ext.asyncio import AsyncEngine
 
 from gafaelfawr.cli import main
 from gafaelfawr.config import Config, OIDCClient
+from gafaelfawr.constants import CHANGE_HISTORY_RETENTION
 from gafaelfawr.exceptions import InvalidGrantError
 from gafaelfawr.factory import Factory
 from gafaelfawr.models.admin import Admin
+from gafaelfawr.models.history import TokenChange, TokenChangeHistoryEntry
 from gafaelfawr.models.oidc import OIDCAuthorizationCode
 from gafaelfawr.models.token import Token, TokenData, TokenType, TokenUserInfo
 from gafaelfawr.schema import Base
+from gafaelfawr.storage.history import TokenChangeHistoryStore
 from gafaelfawr.storage.token import TokenDatabaseStore
 
 from .support.logging import parse_log
@@ -155,11 +158,34 @@ def test_maintenance(
         created=now - timedelta(minutes=60),
         expires=now - timedelta(minutes=30),
     )
+    new_token_data = TokenData(
+        token=Token(),
+        username="some-user",
+        token_type=TokenType.session,
+        scopes=["read:all", "user:token"],
+        created=now - timedelta(minutes=60),
+        expires=now + timedelta(minutes=30),
+    )
+    old_history_entry = TokenChangeHistoryEntry(
+        token=Token().key,
+        username="other-user",
+        token_type=TokenType.session,
+        scopes=[],
+        expires=now - CHANGE_HISTORY_RETENTION + timedelta(days=10),
+        actor="other-user",
+        action=TokenChange.create,
+        ip_address="127.0.0.1",
+        event_time=now - CHANGE_HISTORY_RETENTION - timedelta(minutes=1),
+    )
 
     async def initialize() -> None:
         async with Factory.standalone(config, engine) as factory:
-            token_store = TokenDatabaseStore(factory.session)
-            await token_store.add(token_data)
+            async with factory.session.begin():
+                token_store = TokenDatabaseStore(factory.session)
+                await token_store.add(token_data)
+                await token_store.add(new_token_data)
+                history_store = TokenChangeHistoryStore(factory.session)
+                await history_store.add(old_history_entry)
 
     event_loop.run_until_complete(initialize())
     runner = CliRunner()
@@ -168,8 +194,13 @@ def test_maintenance(
 
     async def check_database() -> None:
         async with Factory.standalone(config, engine) as factory:
-            token_store = TokenDatabaseStore(factory.session)
-            assert await token_store.get_info(token_data.token.key) is None
+            async with factory.session.begin():
+                token_store = TokenDatabaseStore(factory.session)
+                assert await token_store.get_info(token_data.token.key) is None
+                assert await token_store.get_info(new_token_data.token.key)
+                history_store = TokenChangeHistoryStore(factory.session)
+                history = await history_store.list(username="other-user")
+                assert history.entries == []
 
     event_loop.run_until_complete(check_database())
 

--- a/tests/services/token_test.py
+++ b/tests/services/token_test.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import json
-from datetime import timedelta
+from datetime import datetime, timedelta, timezone
 
 import pytest
 from cryptography.fernet import Fernet
@@ -26,6 +26,7 @@ from gafaelfawr.models.token import (
     TokenType,
     TokenUserInfo,
 )
+from gafaelfawr.storage.token import TokenDatabaseStore
 from gafaelfawr.util import current_datetime
 
 from ..support.tokens import create_session_token
@@ -1322,4 +1323,141 @@ async def test_invalid_username(factory: Factory) -> None:
     with pytest.raises(PermissionDeniedError):
         await token_service.create_token_from_admin_request(
             request, data, ip_address="127.0.0.1"
+        )
+
+
+@pytest.mark.asyncio
+async def test_token_expires(factory: Factory) -> None:
+    """Test periodic cleanup of expired tokens."""
+    now = datetime.now(tz=timezone.utc)
+    session_token_data = TokenData(
+        token=Token(),
+        username="some-user",
+        token_type=TokenType.session,
+        scopes=["read:all", "user:token"],
+        created=now - timedelta(minutes=60),
+        expires=now - timedelta(minutes=30),
+    )
+    user_token_data = TokenData(
+        token=Token(),
+        username=session_token_data.username,
+        token_type=TokenType.user,
+        scopes=["read:all"],
+        created=now - timedelta(minutes=50),
+        expires=now - timedelta(minutes=30),
+    )
+    unexpired_user_token_data = TokenData(
+        token=Token(),
+        username=session_token_data.username,
+        token_type=TokenType.user,
+        scopes=["admin:token", "read:all"],
+        created=now - timedelta(minutes=50),
+        expires=now + timedelta(minutes=30),
+    )
+    notebook_token_data = TokenData(
+        token=Token(),
+        username=session_token_data.username,
+        token_type=TokenType.notebook,
+        scopes=["read:all"],
+        created=now - timedelta(minutes=59),
+        expires=now - timedelta(minutes=30),
+    )
+    internal_token_data = TokenData(
+        token=Token(),
+        username=session_token_data.username,
+        token_type=TokenType.internal,
+        scopes=[],
+        created=now - timedelta(minutes=58),
+        expires=now - timedelta(minutes=30),
+    )
+    notebook_internal_token_data = TokenData(
+        token=Token(),
+        username=session_token_data.username,
+        token_type=TokenType.internal,
+        scopes=["read:all"],
+        created=now - timedelta(minutes=58),
+        expires=now - timedelta(minutes=30),
+    )
+    service_token_data = TokenData(
+        token=Token(),
+        username="bot-service",
+        token_type=TokenType.service,
+        scopes=["read:all"],
+        created=now - timedelta(minutes=45),
+        expires=now - timedelta(minutes=30),
+    )
+    token_service = factory.create_token_service()
+    token_store = TokenDatabaseStore(factory.session)
+
+    # Create some tokens, most of which are expired.  These entries are
+    # created only in the database and not in Redis since expired tokens
+    # should have already expired from Redis and therefore it's normal for
+    # there to be no Redis entry.
+    async with factory.session.begin():
+        await token_store.add(session_token_data)
+        await token_store.add(user_token_data, token_name="old")
+        await token_store.add(unexpired_user_token_data, token_name="new")
+        await token_store.add(
+            notebook_token_data, parent=session_token_data.token.key
+        )
+        await token_store.add(
+            internal_token_data,
+            service="tap",
+            parent=session_token_data.token.key,
+        )
+        await token_store.add(
+            notebook_internal_token_data,
+            service="tap",
+            parent=notebook_token_data.token.key,
+        )
+        await token_store.add(service_token_data)
+
+    # Run the expiration.
+    async with factory.session.begin():
+        await token_service.expire_tokens()
+
+    # Check that all of the tokens that should be expired have been expired,
+    # that ones that shouldn't be expired are still present, and that history
+    # entries were created as appropriate for each token.
+    async with factory.session.begin():
+        for token_data in (
+            session_token_data,
+            user_token_data,
+            notebook_token_data,
+            internal_token_data,
+            notebook_internal_token_data,
+            service_token_data,
+        ):
+            assert await token_store.get_info(token_data.token.key) is None
+            history = await token_service.get_change_history(
+                unexpired_user_token_data,
+                username=token_data.username,
+                token=token_data.token.key,
+            )
+            assert history.entries == [
+                TokenChangeHistoryEntry(
+                    token=token_data.token.key,
+                    username=token_data.username,
+                    token_type=token_data.token_type,
+                    token_name=history.entries[0].token_name,
+                    parent=history.entries[0].parent,
+                    scopes=token_data.scopes,
+                    service=history.entries[0].service,
+                    expires=token_data.expires,
+                    actor="<internal>",
+                    action=TokenChange.expire,
+                )
+            ]
+
+        unexpired = await token_store.get_info(
+            unexpired_user_token_data.token.key
+        )
+        assert unexpired == TokenInfo(
+            token=unexpired_user_token_data.token.key,
+            username=unexpired_user_token_data.username,
+            token_type=unexpired_user_token_data.token_type,
+            token_name="new",
+            scopes=unexpired_user_token_data.scopes,
+            created=unexpired_user_token_data.created,
+            expires=unexpired_user_token_data.expires,
         )


### PR DESCRIPTION
Add a background maintenance task that:

- Removes database entries and adds change history entries for expired tokens
- Truncates the change history table to keep it from growing without bound