### PR TITLE
[DM-35881] Implement user private groups and primary GID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,13 @@ release.  Those changes are not noted here explicitly.
   the user private group.  Tokens created by admins can set a GID, which
   overrides the GID from other sources.
 
+- If configured to get a primary GID for the user from LDAP, and that GID
+  does not appear in the user's group memberships, find the group name
+  corresponding to that GID in the group tree and add it to the user's
+  group memberships.  Some LDAP configurations only record explicit
+  memberships for secondary groups and represent the user's primary group
+  only via their GID.
+
 - Add a Kubernetes `CronJob` to delete entries for expired tokens, note
   their expiration in the token change history, and truncate history
   tables.  History entries older than one year are dropped.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ release.  Those changes are not noted here explicitly.
 
 ## 5.1.0 (unreleased)
 
+- Add support for synthesizing user private groups.  When GitHub is used
+  as the authentication provider, or when LDAP is used as a source of
+  group membership and `config.ldap.addUserGroup` is set to `true`,
+  synthesize an additional group with a name equal to the username and a
+  GID equal to the user's UID and add it to the user's group membership.
+  Be aware that this is not strictly safe for GitHub because the team ID
+  space (used for GIDs) and the user ID space (used for UIDs) are not
+  distinct and may collide (although this is unlikely).
+
 - Add a Kubernetes `CronJob` to delete entries for expired tokens, note
   their expiration in the token change history, and truncate history
   tables.  History entries older than one year are dropped.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,13 @@ release.  Those changes are not noted here explicitly.
   space (used for GIDs) and the user ID space (used for UIDs) are not
   distinct and may collide (although this is unlikely).
 
+- Add support for a primary GID for a user.  When GitHub is used as the
+  authentication provider, this is always set to the same as the UID.  For
+  other authentication providers, it can be retrieved from LDAP or, if
+  synthesized user private groups are enabled, will be set to the GID of
+  the user private group.  Tokens created by admins can set a GID, which
+  overrides the GID from other sources.
+
 - Add a Kubernetes `CronJob` to delete entries for expired tokens, note
   their expiration in the token change history, and truncate history
   tables.  History entries older than one year are dropped.

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -345,6 +345,12 @@ To also obtain the numeric UID from LDAP, add ``uidAttr: "uidNumber"`` to the LD
 (Replace ``uidNumber`` with some other attribute if your LDAP directory stores the numeric UID elsewhere.)
 As with the other attributes, if this attribute has multiple values, the first one will be used.
 
+To obtain the primary GID from LDAP, add ``gidAttr: "gidNumber"`` to the LDAP configuration.
+(Replace ``gidNumber`` with some other attribute if your LDAP directory stores the primary GID elsewhere.)
+As with the other attributes, if this attribute has multiple values, the first one will be used.
+If this configuration is not given but user private groups is enabled with ``addUserGroup: true``, the primary GID will be set to the same as the UID (which is the GID of the synthetic user private group).
+Otherwise, the primary GID will be left unset.
+
 You may need to set the following additional options under ``config.ldap`` depending on your LDAP schema:
 
 ``config.ldap.emailAttr``

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -321,7 +321,7 @@ You may need to set the following additional options under ``config.ldap`` depen
     In order to safely use this option, the GIDs of regular groups must be disjoint from user UIDs so that the user's UID can safely be used as the GID of this synthetic group.
     Default: ``false``.
 
-The name of each group will be taken from the ``cn`` attribute and the numeric UID will be taken from the ``gidNumber`` attribute.
+The name of each group will be taken from the ``cn`` attribute and the GID will be taken from the ``gidNumber`` attribute.
 
 .. _ldap-user:
 
@@ -348,6 +348,8 @@ As with the other attributes, if this attribute has multiple values, the first o
 To obtain the primary GID from LDAP, add ``gidAttr: "gidNumber"`` to the LDAP configuration.
 (Replace ``gidNumber`` with some other attribute if your LDAP directory stores the primary GID elsewhere.)
 As with the other attributes, if this attribute has multiple values, the first one will be used.
+If this GID does not match the GID of any of the user's groups, the corresponding group will be looked up in LDAP by GID and added to the user's group list.
+This handles LDAP configurations where only supplemental group memberships are recorded in LDAP, and the primary group membership is recorded only via the user's GID.
 If this configuration is not given but user private groups is enabled with ``addUserGroup: true``, the primary GID will be set to the same as the UID (which is the GID of the synthetic user private group).
 Otherwise, the primary GID will be left unset.
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -315,6 +315,12 @@ You may need to set the following additional options under ``config.ldap`` depen
     The values must match the username returned in the token from the OpenID Connect authentication server.
     Default: ``member``.
 
+``config.ldap.addUserGroup``
+    If set to ``true``, add an additional group to the user's group membership with a name equal to their username and a GID equal to their UID (provided they have a UID; if not, no group is added).
+    Use this in environments with user private groups that do not appear in LDAP.
+    In order to safely use this option, the GIDs of regular groups must be disjoint from user UIDs so that the user's UID can safely be used as the GID of this synthetic group.
+    Default: ``false``.
+
 The name of each group will be taken from the ``cn`` attribute and the numeric UID will be taken from the ``gidNumber`` attribute.
 
 .. _ldap-user:

--- a/src/gafaelfawr/config.py
+++ b/src/gafaelfawr/config.py
@@ -190,6 +190,14 @@ class LDAPSettings(BaseModel):
     ``mail``.
     """
 
+    add_user_group: bool = False
+    """Whether to synthesize a user private group with GID matching UID.
+
+    If set to `True`, synthesize a group for the user whose name and GID
+    matches the username and UID, adding it to the group list without
+    requiring it to appear in LDAP.
+    """
+
 
 class FirestoreSettings(BaseModel):
     """pydantic model of Firestore configuration."""
@@ -535,6 +543,14 @@ class LDAPConfig:
     ``mail``.
     """
 
+    add_user_group: bool = False
+    """Whether to synthesize a user private group with GID matching UID.
+
+    If set to `True`, synthesize a group for the user whose name and GID
+    matches the username and UID, adding it to the group list without
+    requiring it to appear in LDAP.
+    """
+
 
 @dataclass(frozen=True)
 class FirestoreConfig:
@@ -734,6 +750,7 @@ class Config:
                 name_attr=settings.ldap.name_attr,
                 email_attr=settings.ldap.email_attr,
                 uid_attr=settings.ldap.uid_attr,
+                add_user_group=settings.ldap.add_user_group,
             )
 
         # Build Firestore configuration if needed.

--- a/src/gafaelfawr/config.py
+++ b/src/gafaelfawr/config.py
@@ -162,15 +162,6 @@ class LDAPSettings(BaseModel):
     is the LDAP convention for the attribute holding the username.
     """
 
-    uid_attr: Optional[str] = None
-    """LDAP UID attribute.
-
-    If set, the user's UID will be taken from this sttribute.  If UID lookups
-    are desired, this should usually be ``uidNumber``, as specified in
-    :rfc:`2307` and `RFC 2307bis
-    <https://datatracker.ietf.org/doc/html/draft-howard-rfc2307bis-02>`__.
-    """
-
     name_attr: Optional[str] = "displayName"
     """LDAP full name attribute.
 
@@ -188,6 +179,26 @@ class LDAPSettings(BaseModel):
     The attribute from which the user's email address should be taken, or
     `None` to not look up email addresses.  This should normally be
     ``mail``.
+    """
+
+    uid_attr: Optional[str] = None
+    """LDAP UID attribute.
+
+    If set, the user's UID will be taken from this sttribute.  If UID lookups
+    are desired, this should usually be ``uidNumber``, as specified in
+    :rfc:`2307` and `RFC 2307bis
+    <https://datatracker.ietf.org/doc/html/draft-howard-rfc2307bis-02>`__.
+    """
+
+    gid_attr: Optional[str] = None
+    """LDAP GID attirbute.
+
+    If set, the user's primary GID will be taken from this sttribute.  If GID
+    lookups are desired, this should usually be ``gidNumber``, as specified in
+    :rfc:`2307` and `RFC 2307bis
+    <https://datatracker.ietf.org/doc/html/draft-howard-rfc2307bis-02>`__.  If
+    not set, the primary GID will match the UID if ``add_user_group`` is true,
+    and otherwise will not be set.
     """
 
     add_user_group: bool = False
@@ -515,15 +526,6 @@ class LDAPConfig:
     is the LDAP convention for the attribute holding the username.
     """
 
-    uid_attr: Optional[str] = None
-    """LDAP UID attribute.
-
-    If set, the user's UID will be taken from this sttribute.  If UID lookups
-    are desired, this should usually be ``uidNumber``, as specified in
-    :rfc:`2307` and `RFC 2307bis
-    <https://datatracker.ietf.org/doc/html/draft-howard-rfc2307bis-02>`__.
-    """
-
     name_attr: Optional[str] = "displayName"
     """LDAP full name attribute.
 
@@ -541,6 +543,26 @@ class LDAPConfig:
     The attribute from which the user's email address should be taken, or
     `None` to not look up email addresses.  This should normally be
     ``mail``.
+    """
+
+    uid_attr: Optional[str] = None
+    """LDAP UID attribute.
+
+    If set, the user's UID will be taken from this sttribute.  If UID lookups
+    are desired, this should usually be ``uidNumber``, as specified in
+    :rfc:`2307` and `RFC 2307bis
+    <https://datatracker.ietf.org/doc/html/draft-howard-rfc2307bis-02>`__.
+    """
+
+    gid_attr: Optional[str] = None
+    """LDAP GID attirbute.
+
+    If set, the user's primary GID will be taken from this sttribute.  If GID
+    lookups are desired, this should usually be ``gidNumber``, as specified in
+    :rfc:`2307` and `RFC 2307bis
+    <https://datatracker.ietf.org/doc/html/draft-howard-rfc2307bis-02>`__.  If
+    not set, the primary GID will match the UID if ``add_user_group`` is true,
+    and otherwise will not be set.
     """
 
     add_user_group: bool = False
@@ -750,6 +772,7 @@ class Config:
                 name_attr=settings.ldap.name_attr,
                 email_attr=settings.ldap.email_attr,
                 uid_attr=settings.ldap.uid_attr,
+                gid_attr=settings.ldap.gid_attr,
                 add_user_group=settings.ldap.add_user_group,
             )
 

--- a/src/gafaelfawr/handlers/login.py
+++ b/src/gafaelfawr/handlers/login.py
@@ -235,6 +235,9 @@ async def handle_provider_return(
         return login_error(context, LoginError.LDAP_FAILED, str(e))
     except ProviderError as e:
         return login_error(context, LoginError.PROVIDER_FAILED, str(e))
+    except PermissionDeniedError as e:
+        await provider.logout(context.state)
+        return login_error(context, LoginError.INVALID_USERNAME, str(e))
 
     # Get the scopes for this user.
     user_info_service = context.factory.create_user_info_service()

--- a/src/gafaelfawr/models/ldap.py
+++ b/src/gafaelfawr/models/ldap.py
@@ -25,3 +25,6 @@ class LDAPUserData:
 
     uid: Optional[int]
     """UID number."""
+
+    gid: Optional[int]
+    """Primary GID."""

--- a/src/gafaelfawr/models/token.py
+++ b/src/gafaelfawr/models/token.py
@@ -281,6 +281,17 @@ class TokenUserInfo(BaseModel):
 
     uid: Optional[int] = Field(None, title="UID number", example=4123, ge=1)
 
+    gid: Optional[int] = Field(
+        None,
+        title="Primary GID",
+        description=(
+            "GID of primary group. If set, this will also be the GID of one of"
+            " the groups of which the user is a member."
+        ),
+        example=4123,
+        ge=1,
+    )
+
     groups: Optional[List[TokenGroup]] = Field(
         None,
         title="Groups",
@@ -441,6 +452,19 @@ class AdminTokenRequest(BaseModel):
             " entry for that username will be used"
         ),
         example=4131,
+        ge=1,
+    )
+
+    gid: Optional[int] = Field(
+        None,
+        title="Primary GID",
+        description=(
+            "GID of primary group. If set, should correspond to the id of a"
+            " group of which the user is a member. If a value is not provided"
+            " and LDAP is configured to add user private groups, it will be"
+            " set to the same value as the UID."
+        ),
+        example=4123,
         ge=1,
     )
 

--- a/src/gafaelfawr/providers/github.py
+++ b/src/gafaelfawr/providers/github.py
@@ -226,6 +226,7 @@ class GitHubProvider(Provider):
             name=user_info.name,
             email=user_info.email,
             uid=user_info.uid,
+            gid=user_info.uid,
             groups=sorted(groups, key=lambda g: g.name),
         )
 

--- a/src/gafaelfawr/providers/github.py
+++ b/src/gafaelfawr/providers/github.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import base64
 import hashlib
+import re
 from dataclasses import dataclass
 from typing import Any, Dict, List
 from urllib.parse import urlencode
@@ -13,7 +14,8 @@ from pydantic import ValidationError
 from structlog.stdlib import BoundLogger
 
 from ..config import GitHubConfig
-from ..exceptions import GitHubError
+from ..constants import USERNAME_REGEX
+from ..exceptions import GitHubError, PermissionDeniedError
 from ..models.link import LinkData
 from ..models.state import State
 from ..models.token import TokenGroup, TokenUserInfo
@@ -33,7 +35,7 @@ class GitHubTeam:
     """The organization (its login attribute) of which the team is a part."""
 
     gid: int
-    """The GitHub ID of the team, hopefully usable as a GID."""
+    """The GitHub ID of the team, used as a GID."""
 
     @property
     def group_name(self) -> str:
@@ -70,7 +72,7 @@ class GitHubUserInfo:
     """The GitHub login of the user."""
 
     uid: int
-    """The GitHub ID of the user, hopefully usable as a UID."""
+    """The GitHub ID of the user, used as the UID and primary GID."""
 
     email: str
     """The primary email address of the user."""
@@ -171,6 +173,8 @@ class GitHubProvider(Provider):
         ------
         gafaelfawr.exceptions.GitHubError
             GitHub responded with an error to a request.
+        gafaelfawr.exceptions.PermissionDeniedError
+            The GitHub username is not a valid username for Gafaelfawr.
         ``httpx.HTTPError``
             An HTTP client error occurred trying to talk to the authentication
             provider.
@@ -189,6 +193,7 @@ class GitHubProvider(Provider):
             ],
         )
 
+        # Map GitHub teams to groups.
         groups = []
         invalid_groups = {}
         for team in user_info.teams:
@@ -200,13 +205,28 @@ class GitHubProvider(Provider):
             self._logger.warning(
                 "Ignoring invalid groups", invalid_groups=invalid_groups
             )
+
+        # Always synthesize a user private group with the same name as the
+        # username and a GID matching the UID.  This is not truly a valid
+        # approach because GitHub team IDs may clash with GitHub user IDs, but
+        # the space of both is large enough that we take the risk.
+        username = user_info.username.lower()
+        if not re.match(USERNAME_REGEX, username):
+            raise PermissionDeniedError(f"Invalid username: {username}")
+        groups.append(TokenGroup(name=username, id=user_info.uid))
+
+        # Save the token in the session so that we can revoke it later.
         session.github = github_token
+
+        # Return the calculated user information.  For GitHub logins, we store
+        # all user information with the token rather than looking it up
+        # dynamically.
         return TokenUserInfo(
             username=user_info.username.lower(),
             name=user_info.name,
             email=user_info.email,
             uid=user_info.uid,
-            groups=groups,
+            groups=sorted(groups, key=lambda g: g.name),
         )
 
     async def logout(self, session: State) -> None:

--- a/src/gafaelfawr/services/token.py
+++ b/src/gafaelfawr/services/token.py
@@ -206,6 +206,7 @@ class TokenService:
             name=auth_data.name,
             email=auth_data.email,
             uid=auth_data.uid,
+            gid=auth_data.gid,
             groups=auth_data.groups,
         )
         history_entry = TokenChangeHistoryEntry(
@@ -288,6 +289,7 @@ class TokenService:
             name=request.name,
             email=request.email,
             uid=request.uid,
+            gid=request.gid,
             groups=request.groups,
         )
         history_entry = TokenChangeHistoryEntry(

--- a/src/gafaelfawr/services/token_cache.py
+++ b/src/gafaelfawr/services/token_cache.py
@@ -216,6 +216,7 @@ class TokenCacheService:
             name=token_data.name,
             email=token_data.email,
             uid=token_data.uid,
+            gid=token_data.gid,
             groups=token_data.groups,
         )
         history_entry = TokenChangeHistoryEntry(
@@ -288,6 +289,7 @@ class TokenCacheService:
             name=token_data.name,
             email=token_data.email,
             uid=token_data.uid,
+            gid=token_data.gid,
             groups=token_data.groups,
         )
         history_entry = TokenChangeHistoryEntry(

--- a/tests/handlers/api_tokens_test.py
+++ b/tests/handlers/api_tokens_test.py
@@ -227,6 +227,7 @@ async def test_token_info(
         name="Example Person",
         email="example@example.com",
         uid=45613,
+        gid=12345,
         groups=[TokenGroup(name="foo", id=12313)],
     )
     token_service = factory.create_token_service()
@@ -268,6 +269,7 @@ async def test_token_info(
         "name": "Example Person",
         "email": "example@example.com",
         "uid": 45613,
+        "gid": 12345,
         "groups": [
             {
                 "name": "foo",
@@ -839,6 +841,7 @@ async def test_create_admin(
             "expires": expires,
             "name": "A Service",
             "uid": 1234,
+            "gid": 4567,
             "email": "service@example.com",
             "groups": [{"name": "some-group", "id": 12381}],
         },
@@ -873,6 +876,7 @@ async def test_create_admin(
         "name": "A Service",
         "email": "service@example.com",
         "uid": 1234,
+        "gid": 4567,
         "groups": [{"name": "some-group", "id": 12381}],
     }
 

--- a/tests/handlers/auth_test.py
+++ b/tests/handlers/auth_test.py
@@ -275,6 +275,20 @@ async def test_notebook(client: AsyncClient, factory: Factory) -> None:
         "parent": token_data.token.key,
     }
 
+    r = await client.get(
+        "/auth/api/v1/user-info",
+        headers={"Authorization": f"Bearer {notebook_token}"},
+    )
+    assert r.status_code == 200
+    assert r.json() == {
+        "username": token_data.username,
+        "name": token_data.name,
+        "email": token_data.email,
+        "uid": token_data.uid,
+        "gid": token_data.gid,
+        "groups": token_data.groups,
+    }
+
     # Requesting a token with the same parameters returns the same token.
     r = await client.get(
         "/auth",
@@ -321,6 +335,20 @@ async def test_internal(client: AsyncClient, factory: Factory) -> None:
         "created": ANY,
         "expires": int(token_data.expires.timestamp()),
         "parent": token_data.token.key,
+    }
+
+    r = await client.get(
+        "/auth/api/v1/user-info",
+        headers={"Authorization": f"Bearer {internal_token}"},
+    )
+    assert r.status_code == 200
+    assert r.json() == {
+        "username": token_data.username,
+        "name": token_data.name,
+        "email": token_data.email,
+        "uid": token_data.uid,
+        "gid": token_data.gid,
+        "groups": token_data.groups,
     }
 
     # Requesting a token with the same parameters returns the same token.

--- a/tests/handlers/login_github_test.py
+++ b/tests/handlers/login_github_test.py
@@ -188,6 +188,7 @@ async def test_login(
         "name": "GitHub User",
         "email": "githubuser@example.com",
         "uid": 123456,
+        "gid": 123456,
         "groups": [
             {"name": "githubuser", "id": 123456},
             {"name": "org-a-team", "id": 1000},
@@ -497,6 +498,7 @@ async def test_unicode_name(
         "name": "名字",
         "email": "githubuser@example.com",
         "uid": 123456,
+        "gid": 123456,
         "groups": [
             {"name": "githubuser", "id": 123456},
             {"name": "org-a-team", "id": 1000},

--- a/tests/handlers/login_github_test.py
+++ b/tests/handlers/login_github_test.py
@@ -170,7 +170,14 @@ async def test_login(
     assert r.headers["X-Auth-Request-User"] == "githubuser"
     assert r.headers["X-Auth-Request-Email"] == "githubuser@example.com"
     assert r.headers["X-Auth-Request-Uid"] == "123456"
-    expected = "org-a-team,org-other-team,other-org-team-with-very--F279yg"
+    expected = ",".join(
+        [
+            "githubuser",
+            "org-a-team",
+            "org-other-team",
+            "other-org-team-with-very--F279yg",
+        ]
+    )
     assert r.headers["X-Auth-Request-Groups"] == expected
 
     # Do the same verification with the user-info endpoint.
@@ -182,6 +189,7 @@ async def test_login(
         "email": "githubuser@example.com",
         "uid": 123456,
         "groups": [
+            {"name": "githubuser", "id": 123456},
             {"name": "org-a-team", "id": 1000},
             {"name": "org-other-team", "id": 1001},
             {"name": "other-org-team-with-very--F279yg", "id": 1002},
@@ -325,6 +333,7 @@ async def test_github_uppercase(
     r = await client.get("/auth", params={"scope": "read:all"})
     assert r.status_code == 200
     assert r.headers["X-Auth-Request-User"] == "someuser"
+    assert r.headers["X-Auth-Request-Groups"] == "org-a-team,someuser"
 
 
 @pytest.mark.asyncio
@@ -396,7 +405,7 @@ async def test_invalid_groups(
     # present.
     r = await client.get("/auth", params={"scope": "read:all"})
     assert r.status_code == 200
-    assert r.headers["X-Auth-Request-Groups"] == "org-a-team"
+    assert r.headers["X-Auth-Request-Groups"] == "org-a-team,someuser"
 
 
 @pytest.mark.asyncio
@@ -430,9 +439,10 @@ async def test_paginated_teams(
     assert r.status_code == 200
     expected = ",".join(
         [
+            "foo-third-team",
+            "githubuser",
             "org-a-team",
             "org-other-team",
-            "foo-third-team",
             "other-org-team-with-very--F279yg",
         ]
     )
@@ -487,5 +497,8 @@ async def test_unicode_name(
         "name": "名字",
         "email": "githubuser@example.com",
         "uid": 123456,
-        "groups": [{"name": "org-a-team", "id": 1000}],
+        "groups": [
+            {"name": "githubuser", "id": 123456},
+            {"name": "org-a-team", "id": 1000},
+        ],
     }

--- a/tests/handlers/login_oidc_ldap_test.py
+++ b/tests/handlers/login_oidc_ldap_test.py
@@ -109,6 +109,7 @@ async def test_no_name_email(
         "username": "ldap-user",
         "email": token.claims["email"],
         "uid": 2000,
+        "gid": 2000,
         "groups": [
             {"name": "foo", "id": 1222},
             {"name": "ldap-user", "id": 2000},
@@ -122,6 +123,60 @@ async def test_no_name_email(
     assert r.headers["X-Auth-Request-Email"] == token.claims["email"]
     assert r.headers["X-Auth-Request-Uid"] == "2000"
     assert r.headers["X-Auth-Request-Groups"] == "foo,ldap-user"
+
+
+@pytest.mark.asyncio
+async def test_gid(
+    tmp_path: Path,
+    client: AsyncClient,
+    respx_mock: respx.Router,
+    mock_ldap: MockLDAP,
+) -> None:
+    config = await reconfigure(tmp_path, "oidc-ldap-gid")
+    assert config.ldap
+    assert config.ldap.user_base_dn
+    token = create_upstream_oidc_jwt(uid="ldap-user", groups=["admin"])
+    mock_ldap.add_entries_for_test(
+        config.ldap.user_base_dn,
+        config.ldap.user_search_attr,
+        "ldap-user",
+        [
+            {
+                "displayName": ["LDAP User"],
+                "mail": ["ldap-user@example.com"],
+                "uidNumber": ["2000"],
+                "gidNumber": ["1045"],
+            }
+        ],
+    )
+    mock_ldap.add_entries_for_test(
+        config.ldap.group_base_dn,
+        "member",
+        "ldap-user",
+        [
+            {"cn": ["foo"], "gidNumber": ["1045"]},
+            {"cn": ["group-1"], "gidNumber": ["123123"]},
+            {"cn": ["group-2"], "gidNumber": ["123442"]},
+        ],
+    )
+    r = await simulate_oidc_login(client, respx_mock, token)
+    assert r.status_code == 307
+
+    # Check that the data returned from the user-info API is correct.
+    r = await client.get("/auth/api/v1/user-info")
+    assert r.status_code == 200
+    assert r.json() == {
+        "username": "ldap-user",
+        "name": "LDAP User",
+        "email": "ldap-user@example.com",
+        "uid": 2000,
+        "gid": 1045,
+        "groups": [
+            {"name": "foo", "id": 1045},
+            {"name": "group-1", "id": 123123},
+            {"name": "group-2", "id": 123442},
+        ],
+    }
 
 
 @pytest.mark.asyncio

--- a/tests/handlers/login_oidc_ldap_test.py
+++ b/tests/handlers/login_oidc_ldap_test.py
@@ -109,7 +109,10 @@ async def test_no_name_email(
         "username": "ldap-user",
         "email": token.claims["email"],
         "uid": 2000,
-        "groups": [{"name": "foo", "id": 1222}],
+        "groups": [
+            {"name": "foo", "id": 1222},
+            {"name": "ldap-user", "id": 2000},
+        ],
     }
 
     # Check that the headers returned by the auth endpoint are also correct.
@@ -118,7 +121,7 @@ async def test_no_name_email(
     assert r.headers["X-Auth-Request-User"] == "ldap-user"
     assert r.headers["X-Auth-Request-Email"] == token.claims["email"]
     assert r.headers["X-Auth-Request-Uid"] == "2000"
-    assert r.headers["X-Auth-Request-Groups"] == "foo"
+    assert r.headers["X-Auth-Request-Groups"] == "foo,ldap-user"
 
 
 @pytest.mark.asyncio

--- a/tests/settings/oidc-ldap-gid.yaml.in
+++ b/tests/settings/oidc-ldap-gid.yaml.in
@@ -19,10 +19,8 @@ ldap:
   url: "ldaps://ldap.example.com/"
   group_base_dn: "dc=example,dc=com"
   user_base_dn: "ou=people,dc=example,dc=com"
-  name_attr: null
-  email_attr: null
   uid_attr: "uidNumber"
-  add_user_group: true
+  gid_attr: "gidNumber"
 oidc:
   client_id: "some-oidc-client-id"
   client_secret_file: "{oidc_secret_file}"

--- a/tests/settings/oidc-ldap-uid.yaml.in
+++ b/tests/settings/oidc-ldap-uid.yaml.in
@@ -22,6 +22,7 @@ ldap:
   uid_attr: "uidNumber"
   name_attr: null
   email_attr: null
+  add_user_group: true
 oidc:
   client_id: "some-oidc-client-id"
   client_secret_file: "{oidc_secret_file}"

--- a/tests/support/tokens.py
+++ b/tests/support/tokens.py
@@ -120,6 +120,7 @@ async def create_session_token(
         name="Some User",
         email="someuser@example.com",
         uid=1000,
+        gid=2000,
         groups=groups,
     )
     if not scopes:


### PR DESCRIPTION
- Support synthesizing user private groups, always for GitHub and optionally for LDAP setups
- Support a new GID field in the user authentication data and populate it from LDAP or the user private group
- Retrieve the group name corresponding to the primary GID from LDAP and add it to the user's group list if needed