### PR TITLE
[DM-35881] Fix primary GID assignment with Firestore

### DIFF
--- a/src/gafaelfawr/services/userinfo.py
+++ b/src/gafaelfawr/services/userinfo.py
@@ -127,8 +127,8 @@ class UserInfoService:
                 group_names = await self._ldap.get_group_names(username, gid)
                 groups = []
                 for group_name in group_names:
-                    gid = await self._firestore.get_gid(group_name)
-                    groups.append(TokenGroup(name=group_name, id=gid))
+                    group_gid = await self._firestore.get_gid(group_name)
+                    groups.append(TokenGroup(name=group_name, id=group_gid))
             else:
                 groups = await self._ldap.get_groups(username, gid)
 

--- a/tests/handlers/login_oidc_ldap_test.py
+++ b/tests/handlers/login_oidc_ldap_test.py
@@ -8,6 +8,10 @@ import pytest
 import respx
 from httpx import AsyncClient
 
+from gafaelfawr.constants import GID_MIN, UID_USER_MIN
+from gafaelfawr.factory import Factory
+
+from ..support.firestore import MockFirestore
 from ..support.jwt import create_upstream_oidc_jwt
 from ..support.ldap import MockLDAP
 from ..support.oidc import simulate_oidc_login
@@ -74,6 +78,64 @@ async def test_ldap(
     assert r.headers["X-Auth-Request-Email"] == "ldap-user@example.com"
     assert r.headers["X-Auth-Request-Uid"] == "2000"
     assert r.headers["X-Auth-Request-Groups"] == "foo,group-1,group-2"
+
+
+@pytest.mark.asyncio
+async def test_ldap_firestore(
+    tmp_path: Path,
+    factory: Factory,
+    client: AsyncClient,
+    respx_mock: respx.Router,
+    mock_ldap: MockLDAP,
+    mock_firestore: MockFirestore,
+) -> None:
+    config = await reconfigure(tmp_path, "oidc-ldap-firestore", factory)
+    assert config.oidc
+    assert config.ldap
+    assert config.ldap.user_base_dn
+    firestore_storage = factory.create_firestore_storage()
+    await firestore_storage.initialize()
+    token = create_upstream_oidc_jwt(uid="ldap-user", groups=["admin"])
+    mock_ldap.add_entries_for_test(
+        config.ldap.user_base_dn,
+        config.ldap.user_search_attr,
+        "ldap-user",
+        [{"displayName": ["LDAP User"], "mail": ["ldap-user@example.com"]}],
+    )
+    mock_ldap.add_entries_for_test(
+        config.ldap.group_base_dn,
+        "member",
+        "ldap-user",
+        [{"cn": ["foo"]}, {"cn": ["group-1"]}, {"cn": ["group-2"]}],
+    )
+    r = await simulate_oidc_login(client, respx_mock, token)
+    assert r.status_code == 307
+
+    # Check that the data returned from the user-info API is correct.
+    r = await client.get("/auth/api/v1/user-info")
+    assert r.status_code == 200
+    assert r.json() == {
+        "username": "ldap-user",
+        "name": "LDAP User",
+        "email": "ldap-user@example.com",
+        "uid": UID_USER_MIN,
+        "gid": UID_USER_MIN,
+        "groups": [
+            {"name": "foo", "id": GID_MIN},
+            {"name": "group-1", "id": GID_MIN + 1},
+            {"name": "group-2", "id": GID_MIN + 2},
+            {"name": "ldap-user", "id": UID_USER_MIN},
+        ],
+    }
+
+    # Check that the headers returned by the auth endpoint are also correct.
+    r = await client.get("/auth", params={"scope": "read:all"})
+    assert r.status_code == 200
+    assert r.headers["X-Auth-Request-User"] == "ldap-user"
+    assert r.headers["X-Auth-Request-Email"] == "ldap-user@example.com"
+    assert r.headers["X-Auth-Request-Uid"] == str(UID_USER_MIN)
+    expected = "foo,group-1,group-2,ldap-user"
+    assert r.headers["X-Auth-Request-Groups"] == expected
 
 
 @pytest.mark.asyncio

--- a/tests/settings/oidc-ldap-firestore.yaml.in
+++ b/tests/settings/oidc-ldap-firestore.yaml.in
@@ -1,0 +1,31 @@
+realm: "example.com"
+session_secret_file: "{session_secret_file}"
+database_url: "{database_url}"
+redis_url: "redis://localhost:6379/0"
+initial_admins: ["admin"]
+after_logout_url: "https://example.com/landing"
+group_mapping:
+  "exec:admin": ["admin"]
+  "exec:test": ["test"]
+  "read:all": ["foo", "admin", "org-a-team"]
+known_scopes:
+  "admin:token": "Can create and modify tokens for any user"
+  "exec:admin": "admin description"
+  "exec:test": "test description"
+  "read:all": "can read everything"
+  "user:token": "Can create and modify user tokens"
+firestore:
+  project: "some-google-project"
+ldap:
+  url: "ldaps://ldap.example.com/"
+  group_base_dn: "dc=example,dc=com"
+  user_base_dn: "ou=people,dc=example,dc=com"
+  add_user_group: true
+oidc:
+  client_id: "some-oidc-client-id"
+  client_secret_file: "{oidc_secret_file}"
+  login_url: "https://upstream.example.com/oidc/login"
+  redirect_url: "https://upstream.example.com/login"
+  token_url: "https://upstream.example.com/token"
+  issuer: "https://upstream.example.com/"
+  audience: "https://test.example.com/"


### PR DESCRIPTION
In the Firestore case, a variable was reused incorrectly, causing
the primary GID of the user to be set to the GID of their last
group instead of the user private group.  Fix and add a test case.