### PR TITLE
[DM-36093] Add support for getting primary GID from OIDC token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ release.  Those changes are not noted here explicitly.
 
 ## 5.2.0 (unreleased)
 
+- The primary GID can now be obtained from the OpenID Connect ID token from either CILogon or generic OpenID Connect by setting `config.cilogon.gidClaim` or `config.oidc.gidClaim`.
 - Add a Kubernetes `CronJob` to audit Gafaelfawr data stores for inconsistencies and report them to Slack.
 
 ## 5.1.0 (2022-08-18)

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -244,6 +244,11 @@ CILogon has some additional options under ``config.cilogon`` that you may want t
     This is intended for deployments using CILogon with COmanage for identity management.
     The enrollment URL will normally be the initial URL for a COmanage user-initiated enrollment flow.
 
+``config.cilogon.gidClaim``
+    The claim of the OpenID Connect ID token from which to take the primary GID.
+    Only used if :ref:`GID lookup in LDAP <ldap-user>` is not configured.
+    The default is to not obtain a primary GID from the token.
+
 ``config.cilogon.uidClaim``
     The claim of the OpenID Connect ID token from which to take the numeric UID.
     Only used if :ref:`UID lookup in LDAP <ldap-user>` is not configured.
@@ -278,6 +283,11 @@ There are two additional options under ``config.oidc`` that you may want to set:
 ``config.oidc.enrollmentUrl``
     If a username was not found for the unique identifier in the ``sub`` claim of the OpenID Connect ID token, redirect the user to this URL.
     This could, for example, be a form where the user can register for access to the deployment, or a page explaining how a user can get access.
+
+``config.oidc.gidClaim``
+    The claim of the OpenID Connect ID token from which to take the primary GID.
+    Only used if :ref:`GID lookup in LDAP <ldap-user>` is not configured.
+    The default is to not obtain a primary GID from the token.
 
 ``config.oidc.uidClaim``
     The claim of the OpenID Connect ID token from which to take the numeric UID.
@@ -334,7 +344,7 @@ LDAP user information
 ---------------------
 
 By default, Gafaelfawr takes the user's name, email, and numeric UID from the upstream provider via the ``name``, ``mail``, and ``uidNumber`` claims in the ID token.
-If LDAP is used for group information, this data can instead be obtained from LDAP.
+If LDAP is used for group information, this data, plus the primary GID, can instead be obtained from LDAP.
 To do this, add the following configuration:
 
 .. code-block:: yaml

--- a/src/gafaelfawr/config.py
+++ b/src/gafaelfawr/config.py
@@ -112,6 +112,9 @@ class OIDCSettings(BaseModel):
     uid_claim: str = "uidNumber"
     """Name of claim to use as the UID."""
 
+    gid_claim: Optional[str] = None
+    """Name of claim to use as the primary GID."""
+
 
 class LDAPSettings(BaseModel):
     """pydantic model of LDAP configuration."""
@@ -474,6 +477,9 @@ class OIDCConfig:
     uid_claim: str
     """Token claim from which to take the UID."""
 
+    gid_claim: Optional[str]
+    """Token claim from which to take the primary GID."""
+
 
 @dataclass(frozen=True)
 class LDAPConfig:
@@ -757,6 +763,7 @@ class Config:
                 audience=settings.oidc.audience,
                 username_claim=settings.oidc.username_claim,
                 uid_claim=settings.oidc.uid_claim,
+                gid_claim=settings.oidc.gid_claim,
             )
 
         # Build LDAP configuration if needed.

--- a/src/gafaelfawr/exceptions.py
+++ b/src/gafaelfawr/exceptions.py
@@ -32,6 +32,7 @@ __all__ = [
     "KubernetesError",
     "KubernetesObjectError",
     "LDAPError",
+    "MissingGIDClaimError",
     "MissingUIDClaimError",
     "MissingUsernameClaimError",
     "NoAvailableGidError",
@@ -383,6 +384,10 @@ class FetchKeysError(VerifyTokenError):
 
 class InvalidTokenClaimsError(VerifyTokenError):
     """One of the claims in the token is of an invalid format."""
+
+
+class MissingGIDClaimError(VerifyTokenError):
+    """The token is missing the required GID claim."""
 
 
 class MissingUIDClaimError(VerifyTokenError):

--- a/tests/settings/oidc-gid.yaml.in
+++ b/tests/settings/oidc-gid.yaml.in
@@ -1,0 +1,31 @@
+realm: "example.com"
+session_secret_file: "{session_secret_file}"
+database_url: "{database_url}"
+redis_url: "redis://localhost:6379/0"
+slack_webhook_file: "{slack_webhook_file}"
+initial_admins: ["admin"]
+after_logout_url: "https://example.com/landing"
+group_mapping:
+  "exec:admin": ["admin"]
+  "exec:test": ["test"]
+  "read:all": ["foo", "admin", "org-a-team"]
+known_scopes:
+  "admin:token": "Can create and modify tokens for any user"
+  "exec:admin": "admin description"
+  "exec:test": "test description"
+  "read:all": "can read everything"
+  "user:token": "Can create and modify user tokens"
+oidc:
+  client_id: "some-oidc-client-id"
+  client_secret_file: "{oidc_secret_file}"
+  login_url: "https://upstream.example.com/oidc/login"
+  login_params:
+    skin: "test"
+  redirect_url: "https://upstream.example.com/login"
+  token_url: "https://upstream.example.com/token"
+  scopes:
+    - "email"
+    - "voPerson"
+  issuer: "https://upstream.example.com/"
+  audience: "https://test.example.com/"
+  gid_claim: "gid_number"


### PR DESCRIPTION
Add new configuration options and support for obtaining the primary
GID from the OpenID Connect ID token rather than LDAP.  Previously,
unless LDAP was used, OpenID Connect authentications got no primary
GID.