### PR TITLE
[DM-35959] Add docs for Helm chart settings for CronJobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ release.  Those changes are not noted here explicitly.
 
 - The primary GID can now be obtained from the OpenID Connect ID token from either CILogon or generic OpenID Connect by setting `config.cilogon.gidClaim` or `config.oidc.gidClaim`.
 - Add a Kubernetes `CronJob` to audit Gafaelfawr data stores for inconsistencies and report them to Slack.
+- The timing of the maintenance `CronJob` added in 5.1.0 can now be configured with `config.maintenance.maintenanceSchedule` (a cron schedule expression).
 
 ## 5.1.0 (2022-08-18)
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -579,6 +579,22 @@ To enable this, set ``config.slackAlerts``:
 
 You will also have to set the ``slack-webhook`` key in the Gafaelfawr secret to the URL of the incoming webhook to use to post these alerts.
 
+Maintenance timing
+------------------
+
+Gafaelfawr uses two Kubernetes ``CronJob`` resources to perform periodic maintenance and consistency checks on its data stores.
+
+The maintenance job records history and deletes active entries for expired tokens, and truncates history tables as needed.
+By default, it is run hourly at five minutes past the hour.
+Its schedule can be set with ``config.maintenance.maintenanceSchedule`` (a `cron schedule expression`_).
+
+The audit job looks for data inconsistencies and reports them to Slack.
+:ref:`Slack alerts <slack-alerts>` must be configured.
+By default, it runs once a day at 03:00 in the time zone of the Kubernetes cluster.
+Its schedule can be set with ``config.maintenance.auditSchedule`` (a `cron schedule expression`_).
+
+.. _cron schedule expression: https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/#cron-schedule-syntax
+
 OpenID Connect server
 ---------------------
 


### PR DESCRIPTION
The schedule for the CronJobs for audit and maintenance can be
configured in Helm.  Add that to the documentation.