### PR TITLE
[DM-35879] Log uvicorn messages in JSON

### DIFF
--- a/src/gafaelfawr/logging.py
+++ b/src/gafaelfawr/logging.py
@@ -63,7 +63,7 @@ def process_uvicorn_access_log(
 def setup_uvicorn_logging(loglevel: str = "INFO") -> None:
     """Set up logging.
 
-    This configures the uvicorn to use structlog for output formatting.  It is
+    This configures uvicorn to use structlog for output formatting.  It is
     used by the main FastAPI application.
 
     Parameters

--- a/src/gafaelfawr/logging.py
+++ b/src/gafaelfawr/logging.py
@@ -2,13 +2,62 @@
 
 from __future__ import annotations
 
+import logging
 import logging.config
+import re
 
 import structlog
 import uvicorn
 from safir.logging import add_log_severity
+from structlog.types import EventDict
+
+ACCESS_LOG_REGEX = re.compile(r'^([0-9.]+):([0-9]+) - "([^"]+)" ([0-9]+)$')
 
 __all__ = ["setup_uvicorn_logging"]
+
+
+def process_uvicorn_access_log(
+    logger: logging.Logger, method_name: str, event_dict: EventDict
+) -> EventDict:
+    """Parse a uvicorn access log entry into key/value pairs.
+
+    Intended for use as a structlog processor.
+
+    This checks whether the log message is a uvicorn access log entry and, if
+    so, parses the message into key/value pairs for JSON logging so that the
+    details can be programmatically extracted.  ``remoteIp`` is intentionally
+    omitted since it isn't aware of ``X-Forwarded-For`` and will therefore
+    always point to an uninteresting in-cluster IP.
+
+    Parameters
+    ----------
+    logger : `logging.Logger`
+        The wrapped logger object.
+    method_name : `str`
+        The name of the wrapped method (``warning`` or ``error``, for
+        example).
+    event_dict : `structlog.types.EventDict`
+        Current context and current event. This parameter is also modified in
+        place, matching the normal behavior of structlog processors.
+
+    Returns
+    -------
+    event_dict : `structlog.types.EventDict`
+        The modified `~structlog.types.EventDict` with the added key.
+    """
+    match = ACCESS_LOG_REGEX.match(event_dict["event"])
+    if not match:
+        return event_dict
+    request = match.group(3)
+    method, rest = request.split(" ", 1)
+    url, protocol = rest.rsplit(" ", 1)
+    if "httpRequest" not in event_dict:
+        event_dict["httpRequest"] = {}
+    event_dict["httpRequest"]["protocol"] = protocol
+    event_dict["httpRequest"]["requestMethod"] = method
+    event_dict["httpRequest"]["requestUrl"] = url
+    event_dict["httpRequest"]["status"] = match.group(4)
+    return event_dict
 
 
 def setup_uvicorn_logging(loglevel: str = "INFO") -> None:
@@ -31,17 +80,27 @@ def setup_uvicorn_logging(loglevel: str = "INFO") -> None:
             "version": 1,
             "disable_existing_loggers": False,
             "formatters": {
-                "json": {
+                "json-access": {
                     "()": structlog.stdlib.ProcessorFormatter,
                     "processors": processors,
                     "foreign_pre_chain": [
                         add_log_severity,
-                        structlog.processors.TimeStamper(fmt="iso"),
+                        process_uvicorn_access_log,
                     ],
+                },
+                "json": {
+                    "()": structlog.stdlib.ProcessorFormatter,
+                    "processors": processors,
+                    "foreign_pre_chain": [add_log_severity],
                 },
                 **uvicorn.config.LOGGING_CONFIG["formatters"],
             },
             "handlers": {
+                "uvicorn.access": {
+                    "level": loglevel,
+                    "class": "logging.StreamHandler",
+                    "formatter": "json-access",
+                },
                 "uvicorn.default": {
                     "level": loglevel,
                     "class": "logging.StreamHandler",
@@ -55,7 +114,7 @@ def setup_uvicorn_logging(loglevel: str = "INFO") -> None:
                     "propagate": False,
                 },
                 "uvicorn.access": {
-                    "handlers": ["uvicorn.default"],
+                    "handlers": ["uvicorn.access"],
                     "level": loglevel,
                     "propagate": False,
                 },

--- a/src/gafaelfawr/logging.py
+++ b/src/gafaelfawr/logging.py
@@ -1,0 +1,64 @@
+"""Configure logging for Gafaelfawr and uvicorn."""
+
+from __future__ import annotations
+
+import logging.config
+
+import structlog
+import uvicorn
+from safir.logging import add_log_severity
+
+__all__ = ["setup_uvicorn_logging"]
+
+
+def setup_uvicorn_logging(loglevel: str = "INFO") -> None:
+    """Set up logging.
+
+    This configures the uvicorn to use structlog for output formatting.  It is
+    used by the main FastAPI application.
+
+    Parameters
+    ----------
+    loglevel : `str`
+        Log level for uvicorn logging.  Default is ``INFO``.
+    """
+    processors = [
+        structlog.stdlib.ProcessorFormatter.remove_processors_meta,
+        structlog.processors.JSONRenderer(),
+    ]
+    logging.config.dictConfig(
+        {
+            "version": 1,
+            "disable_existing_loggers": False,
+            "formatters": {
+                "json": {
+                    "()": structlog.stdlib.ProcessorFormatter,
+                    "processors": processors,
+                    "foreign_pre_chain": [
+                        add_log_severity,
+                        structlog.processors.TimeStamper(fmt="iso"),
+                    ],
+                },
+                **uvicorn.config.LOGGING_CONFIG["formatters"],
+            },
+            "handlers": {
+                "uvicorn.default": {
+                    "level": loglevel,
+                    "class": "logging.StreamHandler",
+                    "formatter": "json",
+                },
+            },
+            "loggers": {
+                "uvicorn.error": {
+                    "handlers": ["uvicorn.default"],
+                    "level": loglevel,
+                    "propagate": False,
+                },
+                "uvicorn.access": {
+                    "handlers": ["uvicorn.default"],
+                    "level": loglevel,
+                    "propagate": False,
+                },
+            },
+        }
+    )

--- a/src/gafaelfawr/main.py
+++ b/src/gafaelfawr/main.py
@@ -24,6 +24,7 @@ from .exceptions import (
     ValidationError,
 )
 from .handlers import analyze, api, auth, index, influxdb, login, logout, oidc
+from .logging import setup_uvicorn_logging
 from .middleware.state import StateMiddleware
 from .models.state import State
 from .slack import initialize_slack_alerts
@@ -136,6 +137,10 @@ def create_app(*, load_config: bool = True) -> FastAPI:
     app.exception_handler(NotConfiguredError)(not_configured_handler)
     app.exception_handler(PermissionDeniedError)(permission_handler)
     app.exception_handler(ValidationError)(validation_handler)
+
+    # Customize uvicorn logging to use the same structlog configuration as
+    # main application logging.
+    setup_uvicorn_logging()
 
     return app
 


### PR DESCRIPTION
- Redirect uvicorn messages through structlog to add JSON formatting
- Parse the uvicorn access messages to populate a Google-style `httpRequest` log attribute

The motivation of this set of changes is to standardize on JSON as the log format for all Gafaelfawr logs, allowing easier log queries and exploration in systems like Google Log Explorer that automatically understand JSON structure and allow individual fields to be used in queries and filters. As a secondary benefit, this will also avoid misclassification by Google of pure text logs as errors when they're intended to have a lower severity, by lifting the actual Python log severity into JSON in the field where Google expects it.