### PR TITLE
DM-29094: Support a required minimum lifetime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ Dependencies are updated to the latest available version during each release. Th
 
 ### New features
 
-- Add new parameter to the `/auth` route, `required_lifetime`, which can be used to specify the minimum required lifetime of a delegated token (internal or notebook). If the user's authenticating token doesn't have sufficient remaining lifetime to satisfy this request, `/auth` will return a 401 error to force a reauthentication.
+- Add new parameter to the `/auth` route, `minimum_lifetime`, which can be used to specify the minimum required lifetime of a delegated token (internal or notebook). If the user's authenticating token doesn't have sufficient remaining lifetime to satisfy this request, `/auth` will return a 401 error to force a reauthentication.
 - Add new `gafaelfawr generate-session-secret` command to generate the session secret so that users do not have to write a small script to call the Fernet function.
 - Log more details during token creation or modification, including any user identity information stored with the token. Log expiration times in ISO date format instead of seconds since epoch. The names of the attributes logged have changed from previous versions in some cases.
 - Log changes to the list of administrators.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Dependencies are updated to the latest available version during each release. Th
 
 ### New features
 
+- Add new parameter to the `/auth` route, `required_lifetime`, which can be used to specify the minimum required lifetime of a delegated token (internal or notebook). If the user's authenticating token doesn't have sufficient remaining lifetime to satisfy this request, `/auth` will return a 401 error to force a reauthentication.
 - Add new `gafaelfawr generate-session-secret` command to generate the session secret so that users do not have to write a small script to call the Fernet function.
 - Log more details during token creation or modification, including any user identity information stored with the token. Log expiration times in ISO date format instead of seconds since epoch. The names of the attributes logged have changed from previous versions in some cases.
 - Log changes to the list of administrators.

--- a/docs/applications.rst
+++ b/docs/applications.rst
@@ -144,8 +144,12 @@ The URL in the ``nginx.ingress.kubernetes.io/auth-url`` annotation accepts sever
     This must be a subset of the scopes the authenticating token has, or the ``auth_request`` handler will deny access.
     Only meaningful when ``delegate_to`` is also set.
 
-``required_lifetime`` (optional)
+``minimum_lifetime`` (optional)
     The required minimum lifetime for a delegated token (internal or notebook).
+    Since the maximum lifetime of a delegated token is the same as the remaining lifetime of the authenticating token, capped by the maximum token lifetime, this may also be used to set the minimum remaining lifetime of the user's session.
+
+    If the presented authentication credentials don't satisfy this required lifetime, a 401 error will be returned.
+    If the ``nginx.ingress.kubernetes.io/auth-signin`` annotation is set in the ``Ingress``, this will force a user reauthentication.
 
 These parameters must be URL-encoded as GET parameters to the ``/auth`` route.
 

--- a/docs/applications.rst
+++ b/docs/applications.rst
@@ -144,6 +144,9 @@ The URL in the ``nginx.ingress.kubernetes.io/auth-url`` annotation accepts sever
     This must be a subset of the scopes the authenticating token has, or the ``auth_request`` handler will deny access.
     Only meaningful when ``delegate_to`` is also set.
 
+``required_lifetime`` (optional)
+    The required minimum lifetime for a delegated token (internal or notebook).
+
 These parameters must be URL-encoded as GET parameters to the ``/auth`` route.
 
 .. _auth-headers:

--- a/src/gafaelfawr/auth.py
+++ b/src/gafaelfawr/auth.py
@@ -128,7 +128,7 @@ def generate_challenge(
         A prepopulated ``fastapi.HTTPException`` object ready for raising.
         The headers will contain a ``WWW-Authenticate`` challenge.
     """
-    context.logger.warning("%s", exc.message, error=str(exc))
+    context.logger.warning(exc.message, error=str(exc))
     challenge = AuthErrorChallenge(
         auth_type=auth_type,
         realm=context.config.realm,
@@ -200,7 +200,7 @@ def generate_unauthorized_challenge(
     ``error_description`` attribute of a ``WWW-Authenticate`` header.
     """
     if exc:
-        context.logger.warning("%s", exc.message, error=str(exc))
+        context.logger.warning(exc.message, error=str(exc))
         challenge: AuthChallenge = AuthErrorChallenge(
             auth_type=auth_type,
             realm=context.config.realm,

--- a/src/gafaelfawr/exceptions.py
+++ b/src/gafaelfawr/exceptions.py
@@ -25,6 +25,7 @@ __all__ = [
     "InvalidGrantError",
     "InvalidIPAddressError",
     "InvalidRequestError",
+    "InvalidRequiredLifetimeError",
     "InvalidReturnURLError",
     "InvalidScopesError",
     "InvalidTokenClaimsError",
@@ -143,6 +144,15 @@ class InvalidCursorError(ValidationError):
         super().__init__(message, ErrorLocation.query, "cursor")
 
 
+class InvalidDelegateToError(ValidationError):
+    """The ``delegate_to`` parameter was set to an invalid value."""
+
+    error = "invalid_delegate_to"
+
+    def __init__(self, message: str) -> None:
+        super().__init__(message, ErrorLocation.query, "delegate_to")
+
+
 class InvalidExpiresError(ValidationError):
     """The provided token expiration time was invalid."""
 
@@ -161,13 +171,13 @@ class InvalidIPAddressError(ValidationError):
         super().__init__(message, ErrorLocation.query, "ip_address")
 
 
-class InvalidDelegateToError(ValidationError):
-    """The ``delegate_to`` parameter was set to an invalid value."""
+class InvalidRequiredLifetimeError(ValidationError):
+    """The ``required_lifetime`` parameter was set to an invalid value."""
 
-    error = "invalid_delegate_to"
+    error = "invalid_required_lifetime"
 
     def __init__(self, message: str) -> None:
-        super().__init__(message, ErrorLocation.query, "delegate_to")
+        super().__init__(message, ErrorLocation.query, "required_lifetime")
 
 
 class InvalidReturnURLError(ValidationError):

--- a/src/gafaelfawr/exceptions.py
+++ b/src/gafaelfawr/exceptions.py
@@ -24,8 +24,8 @@ __all__ = [
     "InvalidExpiresError",
     "InvalidGrantError",
     "InvalidIPAddressError",
+    "InvalidMinimumLifetimeError",
     "InvalidRequestError",
-    "InvalidRequiredLifetimeError",
     "InvalidReturnURLError",
     "InvalidScopesError",
     "InvalidTokenClaimsError",
@@ -171,13 +171,13 @@ class InvalidIPAddressError(ValidationError):
         super().__init__(message, ErrorLocation.query, "ip_address")
 
 
-class InvalidRequiredLifetimeError(ValidationError):
-    """The ``required_lifetime`` parameter was set to an invalid value."""
+class InvalidMinimumLifetimeError(ValidationError):
+    """The ``minimum_lifetime`` parameter was set to an invalid value."""
 
-    error = "invalid_required_lifetime"
+    error = "invalid_minimum_lifetime"
 
     def __init__(self, message: str) -> None:
-        super().__init__(message, ErrorLocation.query, "required_lifetime")
+        super().__init__(message, ErrorLocation.query, "minimum_lifetime")
 
 
 class InvalidReturnURLError(ValidationError):

--- a/src/gafaelfawr/handlers/auth.py
+++ b/src/gafaelfawr/handlers/auth.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from datetime import timedelta
 from enum import Enum
 from typing import Dict, List, Optional, Set
 
@@ -17,12 +18,25 @@ from fastapi import (
 )
 from fastapi.responses import HTMLResponse
 
-from ..auth import AuthError, AuthErrorChallenge, AuthType, generate_challenge
+from ..auth import (
+    AuthError,
+    AuthErrorChallenge,
+    AuthType,
+    generate_challenge,
+    generate_unauthorized_challenge,
+)
+from ..constants import MINIMUM_LIFETIME
 from ..dependencies.auth import AuthenticateRead
 from ..dependencies.context import RequestContext, context_dependency
-from ..exceptions import InsufficientScopeError, InvalidDelegateToError
+from ..exceptions import (
+    InsufficientScopeError,
+    InvalidDelegateToError,
+    InvalidRequiredLifetimeError,
+    InvalidTokenError,
+)
 from ..models.token import TokenData
 from ..slack import SlackRouteErrorHandler
+from ..util import current_datetime
 
 router = APIRouter(route_class=SlackRouteErrorHandler)
 
@@ -63,6 +77,9 @@ class AuthConfig:
 
     delegate_scopes: List[str]
     """List of scopes the delegated token should have."""
+
+    required_lifetime: Optional[timedelta]
+    """Required minimum lifetime of the token."""
 
 
 def auth_uri(
@@ -133,6 +150,16 @@ def auth_config(
         ),
         example="read:all,write:all",
     ),
+    required_lifetime: Optional[int] = Query(
+        None,
+        title="Required minimum lifetime",
+        description=(
+            "Force reauthentication if the delegated token (internal or"
+            " notebook) would have a shorter lifetime, in seconds, than this"
+            " parameter."
+        ),
+        example=86400,
+    ),
     auth_uri: str = Depends(auth_uri),
     context: RequestContext = Depends(context_dependency),
 ) -> AuthConfig:
@@ -158,6 +185,10 @@ def auth_config(
         required_scopes=sorted(set(scope) | set(delegate_scopes)),
         satisfy=satisfy.name.lower(),
     )
+    if required_lifetime:
+        lifetime = timedelta(seconds=required_lifetime)
+    else:
+        lifetime = None
     return AuthConfig(
         scopes=set(scope) | set(delegate_scopes),
         satisfy=satisfy,
@@ -165,6 +196,7 @@ def auth_config(
         notebook=notebook,
         delegate_to=delegate_to,
         delegate_scopes=delegate_scopes,
+        required_lifetime=lifetime,
     )
 
 
@@ -202,25 +234,6 @@ async def get_auth(
 
     Notes
     -----
-    Expects the following query parameters to be set:
-
-    scope
-        One or more scopes to check (required, may be given multiple times).
-    satisfy (optional)
-        Require that ``all`` (the default) or ``any`` of the scopes requested
-        via the ``scope`` parameter be satisfied.
-    auth_type (optional)
-        The authentication type to use in challenges.  If given, must be
-        either ``bearer`` or ``basic``.  Defaults to ``bearer``.
-
-    Expects the following headers to be set in the request:
-
-    Authorization
-        The JWT token. This must always be the full JWT token. The token
-        should be in this  header as type ``Bearer``, but it may be type
-        ``Basic`` if ``x-oauth-basic`` is the username or password.  This may
-        be omitted if the user has a valid session cookie instead.
-
     The following headers may be set in the response:
 
     X-Auth-Request-Email
@@ -233,6 +246,52 @@ async def get_auth(
     WWW-Authenticate
         If the request is unauthenticated, this header will be set.
     """
+    # Check if the token lifetime is long enough.
+    #
+    # It's awkward to do this check here, since what we have access to is the
+    # lifetime of the user's authentication token, but what we need is the
+    # lifetime of any delegated internal or notebook token we will pass along.
+    # However, getting the latter is more expensive: we would have to do all
+    # the work of creating the token, then retrieve it from Redis, and then
+    # check its lifetime.
+    #
+    # Thankfully, we can know in advance whether the token we will create will
+    # have a long enough lifetime, since we can request tokens up to the
+    # lifetime of the parent token and therefore can check the required
+    # lifetime against the lifetime of the parent token as long as we require
+    # the child token have the required lifetime (which we do, in
+    # build_success_headers).
+    #
+    # The only special case we need to handle is where the required lifetime
+    # is too close to the maximum lifetime for new tokens, since the lifetime
+    # of delegated tokens will be capped at that.  In this case, we can never
+    # satisfy this request and need to raise a 422 error instead of a 401 or
+    # 403 error.  We don't allow required lifetimes within MINIMUM_LIFETIME of
+    # the maximum lifetime to avoid the risk of a slow infinite redirect loop
+    # when the login process takes a while.
+    if auth_config.required_lifetime:
+        grace_period = timedelta(seconds=MINIMUM_LIFETIME)
+        max_lifetime = context.config.token_lifetime - grace_period
+        if auth_config.required_lifetime > max_lifetime:
+            required_lifetime_seconds = int(
+                auth_config.required_lifetime.total_seconds()
+            )
+            max_lifetime_seconds = int(max_lifetime.total_seconds())
+            msg = (
+                f"Requested lifetime {required_lifetime_seconds}s longer"
+                f" than maximum lifetime {max_lifetime_seconds}s"
+            )
+            raise InvalidRequiredLifetimeError(msg)
+        if token_data.expires:
+            lifetime = token_data.expires - current_datetime()
+            if auth_config.required_lifetime > lifetime:
+                raise generate_unauthorized_challenge(
+                    context,
+                    auth_config.auth_type,
+                    InvalidTokenError("Remaining token lifetime too short"),
+                    ajax_forbidden=True,
+                )
+
     # Determine whether the request is authorized.
     if auth_config.satisfy == Satisfy.ANY:
         authorized = any([s in token_data.scopes for s in auth_config.scopes])
@@ -241,9 +300,11 @@ async def get_auth(
 
     # If not authorized, log and raise the appropriate error.
     if not authorized:
-        exc = InsufficientScopeError("Token missing required scope")
         raise generate_challenge(
-            context, auth_config.auth_type, exc, auth_config.scopes
+            context,
+            auth_config.auth_type,
+            InsufficientScopeError("Token missing required scope"),
+            auth_config.scopes,
         )
 
     # Log and return the results.
@@ -343,7 +404,9 @@ async def build_success_headers(
         token_service = context.factory.create_token_service()
         async with context.session.begin():
             token = await token_service.get_notebook_token(
-                token_data, ip_address=context.ip_address
+                token_data,
+                ip_address=context.ip_address,
+                minimum_lifetime=auth_config.required_lifetime,
             )
         headers["X-Auth-Request-Token"] = str(token)
     elif auth_config.delegate_to:
@@ -354,6 +417,7 @@ async def build_success_headers(
                 service=auth_config.delegate_to,
                 scopes=auth_config.delegate_scopes,
                 ip_address=context.ip_address,
+                minimum_lifetime=auth_config.required_lifetime,
             )
         headers["X-Auth-Request-Token"] = str(token)
 

--- a/src/gafaelfawr/services/token.py
+++ b/src/gafaelfawr/services/token.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import ipaddress
 import re
 import time
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import List, Optional
 
 from structlog.stdlib import BoundLogger
@@ -664,6 +664,7 @@ class TokenService:
         scopes: List[str],
         *,
         ip_address: str,
+        minimum_lifetime: Optional[timedelta] = None,
     ) -> Token:
         """Get or create a new internal token.
 
@@ -677,6 +678,8 @@ class TokenService:
             The scopes the new token should have.
         ip_address : `str`
             The IP address from which the request came.
+        minimum_lifetime : `datetime.timedelta` or `None`, optional
+            If set, the minimum required lifetime of the token.
 
         Returns
         -------
@@ -692,11 +695,19 @@ class TokenService:
         self._validate_username(token_data.username)
         scopes = sorted(scopes)
         return await self._token_cache.get_internal_token(
-            token_data, service, scopes, ip_address
+            token_data,
+            service,
+            scopes,
+            ip_address,
+            minimum_lifetime=minimum_lifetime,
         )
 
     async def get_notebook_token(
-        self, token_data: TokenData, ip_address: str
+        self,
+        token_data: TokenData,
+        ip_address: str,
+        *,
+        minimum_lifetime: Optional[timedelta] = None,
     ) -> Token:
         """Get or create a new notebook token.
 
@@ -706,6 +717,8 @@ class TokenService:
             The authentication data on which to base the new token.
         ip_address : `str`
             The IP address from which the request came.
+        minimum_lifetime : `datetime.timedelta` or `None`, optional
+            If set, the minimum required lifetime of the token.
 
         Returns
         -------
@@ -719,7 +732,7 @@ class TokenService:
         """
         self._validate_username(token_data.username)
         return await self._token_cache.get_notebook_token(
-            token_data, ip_address
+            token_data, ip_address, minimum_lifetime=minimum_lifetime
         )
 
     async def get_token_info(

--- a/tests/handlers/auth_test.py
+++ b/tests/handlers/auth_test.py
@@ -556,7 +556,7 @@ async def test_success_unicode_name(
 
 
 @pytest.mark.asyncio
-async def test_required_lifetime(
+async def test_minimum_lifetime(
     config: Config, client: AsyncClient, factory: Factory
 ) -> None:
     user_info = TokenUserInfo(username="user", uid=1234, name="Some User")
@@ -577,14 +577,14 @@ async def test_required_lifetime(
         params={
             "scope": "read:all",
             "notebook": "true",
-            "required_lifetime": int(
+            "minimum_lifetime": int(
                 (config.token_lifetime - minimum_lifetime).total_seconds()
             ),
         },
         headers={"Authorization": f"Bearer {token}"},
     )
     assert r.status_code == 422
-    assert r.json()["detail"][0]["type"] == "invalid_required_lifetime"
+    assert r.json()["detail"][0]["type"] == "invalid_minimum_lifetime"
 
     # Create a user token with a short lifetime.
     async with factory.session.begin():
@@ -604,7 +604,7 @@ async def test_required_lifetime(
         params={
             "scope": "read:all",
             "notebook": "true",
-            "required_lifetime": 4000,
+            "minimum_lifetime": 4000,
         },
         headers={"Authorization": f"Bearer {token}"},
     )
@@ -619,7 +619,7 @@ async def test_required_lifetime(
         params={
             "scope": "read:all",
             "notebook": "true",
-            "required_lifetime": 3000,
+            "minimum_lifetime": 3000,
         },
         headers={"Authorization": f"Bearer {token}"},
     )
@@ -633,7 +633,7 @@ async def test_required_lifetime(
         params={
             "scope": "read:all",
             "notebook": "true",
-            "required_lifetime": 4000,
+            "minimum_lifetime": 4000,
         },
         headers={
             "Authorization": f"Bearer {token}",


### PR DESCRIPTION
Add a parameter to the /auth route to specify a required minimum lifetime.  This is measured against the lifetime of any delegated token that we would pass on to the service, such as a notebook token for the Notebook Aspect (the motivating application), but it can be used as a check against the user's session token lifetime if desired.

This is a bit more complicated than immediately apparent since we have to do some careful logic to extrapolate from the lifetime of the user's authentication token to the lifetime of a delegated token, and we have to support invalidating the cache and generating a new delegated token even if more than half of its lifetime is still remaining.