### PR TITLE
DM-36247: Fix bullet for audit alerts

### DIFF
--- a/src/gafaelfawr/cli.py
+++ b/src/gafaelfawr/cli.py
@@ -101,8 +101,8 @@ async def audit(settings: Optional[str]) -> None:
             alerts = await token_service.audit()
         if alerts:
             message = (
-                "Gafaelfawr data inconsistencies found:\n* "
-                + "\n* ".join(alerts)
+                "Gafaelfawr data inconsistencies found:\n• "
+                + "\n• ".join(alerts)
                 + "\n"
             )
             await slack.message(message)

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -84,8 +84,8 @@ def test_audit(
         " but not Redis",
     ]
     expected_alert = (
-        "Gafaelfawr data inconsistencies found:\n* "
-        + "\n* ".join(alerts)
+        "Gafaelfawr data inconsistencies found:\n• "
+        + "\n• ".join(alerts)
         + "\n"
     )
     assert mock_slack.messages == [


### PR DESCRIPTION
Slack doesn't recognize lists in mrkdwn, so we have to simulate them with the Unicode bullet character.