### PR TITLE
DM-36438: Set minimum expiration for delegated tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Dependencies are updated to the latest available version during each release. Th
 
 - Add `--fix` flag to the `gafaelfawr audit` command, which attempts to fix discovered issues where possible. Only some discoverable issues have code to fix them.
 
+### Bug fixes
+
+- If a delegated token is requested from the `/auth` route, the authenticating token now must have a remaining lifetime of at least five minutes or it is treated as if it is expired. This avoids creating delegated tokens with unusably short or zero lifetimes.
+
 ## 6.0.0 (2022-09-27)
 
 ### Backwards-incompatible changes

--- a/src/gafaelfawr/constants.py
+++ b/src/gafaelfawr/constants.py
@@ -43,8 +43,8 @@ LDAP_TIMEOUT = 5.0
 CHANGE_HISTORY_RETENTION = timedelta(days=365)
 """Retention of old token change history entries."""
 
-MINIMUM_LIFETIME = 5 * 60
-"""Minimum expiration lifetime for a token in seconds."""
+MINIMUM_LIFETIME = timedelta(minutes=5)
+"""Minimum expiration lifetime for a token."""
 
 OIDC_AUTHORIZATION_LIFETIME = 60 * 60
 """How long (in seconds) an authorization code is good for."""

--- a/src/gafaelfawr/handlers/auth.py
+++ b/src/gafaelfawr/handlers/auth.py
@@ -272,8 +272,7 @@ async def get_auth(
     # the maximum lifetime to avoid the risk of a slow infinite redirect loop
     # when the login process takes a while.
     if auth_config.minimum_lifetime:
-        grace_period = timedelta(seconds=MINIMUM_LIFETIME)
-        max_lifetime = context.config.token_lifetime - grace_period
+        max_lifetime = context.config.token_lifetime - MINIMUM_LIFETIME
         if auth_config.minimum_lifetime > max_lifetime:
             minimum_lifetime_seconds = int(
                 auth_config.minimum_lifetime.total_seconds()

--- a/src/gafaelfawr/handlers/auth.py
+++ b/src/gafaelfawr/handlers/auth.py
@@ -158,6 +158,7 @@ def auth_config(
             " notebook) would have a shorter lifetime, in seconds, than this"
             " parameter."
         ),
+        ge=MINIMUM_LIFETIME.total_seconds(),
         example=86400,
     ),
     auth_uri: str = Depends(auth_uri),
@@ -187,10 +188,11 @@ def auth_config(
         delegate_scopes = set(s.strip() for s in delegate_scope.split(","))
     else:
         delegate_scopes = set()
+    lifetime = None
     if minimum_lifetime:
         lifetime = timedelta(seconds=minimum_lifetime)
-    else:
-        lifetime = None
+    elif not minimum_lifetime and (notebook or delegate_to):
+        lifetime = MINIMUM_LIFETIME
     return AuthConfig(
         scopes=scopes,
         satisfy=satisfy,

--- a/src/gafaelfawr/services/token.py
+++ b/src/gafaelfawr/services/token.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import ipaddress
 import re
-import time
 from datetime import datetime, timedelta
 from typing import List, Optional
 
@@ -1186,8 +1185,8 @@ class TokenService:
         """
         if not expires:
             return
-        if expires.timestamp() < time.time() + MINIMUM_LIFETIME:
-            msg = "token must be valid for at least five minutes"
+        if expires < current_datetime() + MINIMUM_LIFETIME:
+            msg = "Token must be valid for at least five minutes"
             raise InvalidExpiresError(msg)
 
     def _validate_scopes(

--- a/src/gafaelfawr/services/token_cache.py
+++ b/src/gafaelfawr/services/token_cache.py
@@ -26,6 +26,9 @@ class TokenCacheService:
     request data matches, the token is still valid, and less than half of its
     lifetime has passed.
 
+    This class handles both the creation and the caching of internal and
+    notebook tokens.
+
     Parameters
     ----------
     config : `gafaelfawr.config.Config`

--- a/tests/handlers/auth_test.py
+++ b/tests/handlers/auth_test.py
@@ -619,7 +619,7 @@ async def test_minimum_lifetime(
         assert token_data
 
     # Required lifetime is within MINIMUM_LIFETIME of maximum token lifetime.
-    minimum_lifetime = timedelta(seconds=MINIMUM_LIFETIME - 1)
+    minimum_lifetime = MINIMUM_LIFETIME - timedelta(seconds=1)
     r = await client.get(
         "/auth",
         params={


### PR DESCRIPTION
If and only if a delegated token is requested, force the minimum lifetime to be at least MINIMUM_LIFETIME (five minutes).  This will hopefully fix a problem that caused an exception in production due to an invalid Redis key expiration time, presumably because someone attempted to authenticate with a token that was about to expire, resulting in a delegated token with a lifetime of 0 seconds.
