### PR TITLE
DM-36447: Add support for fixing some audit issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ Versioning follows [semver](https://semver.org/). Versioning assumes that Gafael
 
 Dependencies are updated to the latest available version during each release. Those changes are not noted here explicitly.
 
+## 6.1.0 (unreleased)
+
+### New features
+
+- Add `--fix` flag to the `gafaelfawr audit` command, which attempts to fix discovered issues where possible. Only some discoverable issues have code to fix them.
+
 ## 6.0.0 (2022-09-27)
 
 ### Backwards-incompatible changes

--- a/src/gafaelfawr/cli.py
+++ b/src/gafaelfawr/cli.py
@@ -71,6 +71,9 @@ def help(ctx: click.Context, topic: Union[None, str]) -> None:
 
 @main.command()
 @click.option(
+    "--fix", default=False, is_flag=True, help="Fix issues found, if possible"
+)
+@click.option(
     "--settings",
     envvar="GAFAELFAWR_SETTINGS_PATH",
     type=str,
@@ -78,7 +81,7 @@ def help(ctx: click.Context, topic: Union[None, str]) -> None:
     help="Application settings file.",
 )
 @run_with_asyncio
-async def audit(settings: Optional[str]) -> None:
+async def audit(fix: bool, settings: Optional[str]) -> None:
     """Run a consistency check on Gafaelfawr's data stores.
 
     Any problems found will be reported to Slack.
@@ -98,7 +101,7 @@ async def audit(settings: Optional[str]) -> None:
     async with Factory.standalone(config, engine) as factory:
         token_service = factory.create_token_service()
         async with factory.session.begin():
-            alerts = await token_service.audit()
+            alerts = await token_service.audit(fix=fix)
         if alerts:
             message = (
                 "Gafaelfawr data inconsistencies found:\n• "

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -99,6 +99,18 @@ def test_audit(
         }
     ]
 
+    mock_slack.messages = []
+    runner = CliRunner()
+    result = runner.invoke(main, ["audit", "--fix"])
+    assert result.exit_code == 0
+    assert len(mock_slack.messages) == 1
+
+    mock_slack.messages = []
+    runner = CliRunner()
+    result = runner.invoke(main, ["audit"])
+    assert result.exit_code == 0
+    assert len(mock_slack.messages) == 0
+
 
 def test_delete_all_data(
     tmp_path: Path,


### PR DESCRIPTION
Add a flag --fix to the gafaelfawr audit command that attempts to fix some issues, specifically the ones that have turned up to date in the IDF.  (The theory is that I'll only bother to write fix code for problems that we've seen.)