### PR TITLE
DM-36366: Temporarily stop running linkcheck

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -129,7 +129,7 @@ jobs:
         uses: lsst-sqre/run-tox@v1
         with:
           python-version: "3.10"
-          tox-envs: "docs,docs-linkcheck"
+          tox-envs: "docs"
 
       # Only attempt documentation uploads for long-lived branches, tagged
       # releases, and pull requests from ticket branches.  This avoids version


### PR DESCRIPTION
This is failing because I updated a link in CHANGELOG.md to point to the new structure, but the new structure hasn't been deployed on the live site yet because the linkcheck is failing.