### PR TITLE
Fix pytest-sugar dependencies

### DIFF
--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -30,3 +30,6 @@ documenteer[guide]>=0.7.0b2
 sphinx-click
 sphinx-diagrams
 sphinxcontrib-redoc
+
+# Temporary until https://github.com/Teemu/pytest-sugar/issues/241 is fixed.
+py

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -439,9 +439,9 @@ hyperframe==6.0.1 \
     # via
     #   h2
     #   selenium-wire
-identify==2.5.7 \
-    --hash=sha256:5b8fd1e843a6d4bf10685dd31f4520a7f1c7d0e14e9bc5d34b1d6f111cabc011 \
-    --hash=sha256:7a67b2a6208d390fd86fd04fb3def94a3a8b7f0bcbd1d1fcd6736f4defe26390
+identify==2.5.8 \
+    --hash=sha256:48b7925fe122720088aeb7a6c34f17b27e706b72c61070f27fe3789094233440 \
+    --hash=sha256:7a214a10313b9489a0d61467db2856ae8d0b8306fc923e03a9effa53d8aedc58
     # via pre-commit
 idna==3.4 \
     --hash=sha256:814f528e8dead7d329833b91c5faa87d60bf71824cd12a7530b5526063d02cb4 \
@@ -607,6 +607,10 @@ pluggy==1.0.0 \
 pre-commit==2.20.0 \
     --hash=sha256:51a5ba7c480ae8072ecdb6933df22d2f812dc897d5fe848778116129a681aac7 \
     --hash=sha256:a978dac7bc9ec0bcee55c18a277d553b0f419d259dadb4b9418ff2d00eb43959
+    # via -r requirements/dev.in
+py==1.11.0 \
+    --hash=sha256:51c75c4126074b472f746a24399ad32f6053d1b34b68d2fa41e558e6f4a98719 \
+    --hash=sha256:607c53218732647dff4acdfcd50cb62615cedf612e72d1724fb1a0cc6405b378
     # via -r requirements/dev.in
 pyasn1==0.4.8 \
     --hash=sha256:39c7e2ec30515947ff4e87fb6f456dfc6e84857d34be479c9d4a4ba4bf46aa5d \


### PR DESCRIPTION
pytest-sugar needs py but pytest no longer depends on it.