### PR TITLE
DM-28493: Add a schema for GafaelfawrServiceToken status

### DIFF
--- a/tests/crds/service-token.yaml
+++ b/tests/crds/service-token.yaml
@@ -24,23 +24,19 @@ spec:
           name: "Service"
           type: string
         - description: "If the secret was created/updated successfully"
-          jsonPath: >-
-            .status.conditions[?(@.type=="SecretCreated")].status
+          jsonPath: .status.create.status
           name: "Succeeded"
           type: string
         - description: "Reason for the current status"
-          jsonPath: >-
-            .status.conditions[?(@.type=="SecretCreated")].reason
+          jsonPath: .status.create.reason
           name: "Reason"
           type: string
         - description: "More information about the current status"
-          jsonPath: >-
-            .status.conditions[?(@.type=="SecretCreated")].message
+          jsonPath: .status.create.message
           name: "Message"
           type: string
         - description: "Time when the condition was last updated"
-          jsonPath: >-
-            .status.conditions[?(@.type=="SecretCreated")].lastTransitionTime
+          jsonPath: .status.create.lastTransitionTime
           name: "Last Transition"
           type: date
         - description: "Time when the GafaelfawrServiceToken was created"
@@ -74,6 +70,129 @@ spec:
             status:
               type: object
               description: >-
-                GafaelfawrServiceTokenStatus defines the observed state of the
-                GafaelfawrServiceToken.
+                The observed state of the GafaelfawrServiceToken.
               x-kubernetes-preserve-unknown-fields: true
+              parameters:
+                create:
+                  type: object
+                  description: >-
+                    Status of processing of the last creation or update of the
+                    GafaelfawrServiceToken object.
+                  required:
+                    - lastTransitionTime
+                    - message
+                    - reason
+                    - status
+                    - type
+                  properties:
+                    lastTransitionTime:
+                      type: string
+                      format: date-time
+                      description: >
+                        The last time the child Secret status changed.
+                    message:
+                      type: string
+                      description: >
+                        A human readable message indicating details about the
+                        transition. This may be an empty string.
+                      maxLength: 32768
+                    observedGeneration:
+                      description: >
+                        The .metadata.generation that the condition was set
+                        based upon. For instance, if .metadata.generation is
+                        currently 12, but the
+                        .status.create.observedGeneration is 9, the condition
+                        is out of date with respect to the current state of
+                        the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      type: string
+                      description: >
+                        A programmatic identifier indicating the reason for
+                        the condition's last transition. Producers of specific
+                        condition types may define expected values and
+                        meanings for this field, and whether the values are
+                        considered a guaranteed API. The value should be a
+                        CamelCase string. This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: "^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$"
+                    status:
+                      type: string
+                      description: >
+                        Status of the condition, one of True, False, Unknown.
+                      enum:
+                        - "True"
+                        - "False"
+                        - "Unknown"
+                    type:
+                      type: string
+                      description: >
+                        Type of condition in CamelCase or in
+                        foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$"
+                periodic:
+                  type: object
+                  description: >-
+                    Status of the last periodic validation of the Secret for
+                    this GafaelfawrServiceToken object.
+                  required:
+                    - lastTransitionTime
+                    - message
+                    - reason
+                    - status
+                    - type
+                  properties:
+                    lastTransitionTime:
+                      type: string
+                      format: date-time
+                      description: >
+                        The last time the child Secret status changed due to a
+                        periodic revalidation.
+                    message:
+                      type: string
+                      description: >
+                        A human readable message indicating details about the
+                        transition. This may be an empty string.
+                      maxLength: 32768
+                    observedGeneration:
+                      description: >
+                        The .metadata.generation that the condition was set
+                        based upon. For instance, if .metadata.generation is
+                        currently 12, but the
+                        .status.create.observedGeneration is 9, the condition
+                        is out of date with respect to the current state of
+                        the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      type: string
+                      description: >
+                        A programmatic identifier indicating the reason for
+                        the condition's last transition. Producers of specific
+                        condition types may define expected values and
+                        meanings for this field, and whether the values are
+                        considered a guaranteed API. The value should be a
+                        CamelCase string. This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: "^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$"
+                    status:
+                      type: string
+                      description: >
+                        Status of the condition, one of True, False, Unknown.
+                      enum:
+                        - "True"
+                        - "False"
+                        - "Unknown"
+                    type:
+                      type: string
+                      description: >
+                        Type of condition in CamelCase or in
+                        foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$"


### PR DESCRIPTION
I had deleted the schema for the GafaelfawrServiceToken status section, since Kopf also uses it and the format had changed. However, the create and periodic portions of the status do have a reliable schema.  Only the Kopf stuff may change independently and is handled by the x-kubernetes-preserve-unknown-fields annotation.

Also update additionalPrinterColumns to not refer to status columns that had been removed.