### PR TITLE
DM-37192: Invalidate the LDAP cache if login was rejected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ Dependencies are updated to the latest available version during each release. Th
 - All commands that took a `--settings` option to specify the path to the configuration file now take a `--config-path` option instead. This name is clearer and avoids introducing a separate "settings" term.
 - The default path to the Gafaelfawr configuration file is now taken from the `GAFAELFAWR_CONFIG_PATH` environment variable rather than `GAFAELFAWR_SETTINGS_PATH`, for the same reason.
 
+### Bug fixes
+
+- If a user's login was rejected because they were not a member of any known groups, invalidate the LDAP cache for that user before returning the error. The user is likely to immediately try to fix this problem, and making them wait until the LDAP cache times out to see if the fix worked is confusing.
+
 ## 7.1.0 (2022-11-29)
 
 ### New features

--- a/src/gafaelfawr/cache.py
+++ b/src/gafaelfawr/cache.py
@@ -285,6 +285,16 @@ class LDAPCache(PerUserCache, Generic[S]):
         """Initialize the cache."""
         self._cache = TTLCache(LDAP_CACHE_SIZE, LDAP_CACHE_LIFETIME)
 
+    def invalidate(self, username: str) -> None:
+        """Invalidate any cached data for a user.
+
+        Parameters
+        ----------
+        username
+            Username for which to invalidate the cache.
+        """
+        del self._cache[username]
+
     def store(self, username: str, data: S) -> None:
         """Store data in the cache.
 

--- a/src/gafaelfawr/handlers/login.py
+++ b/src/gafaelfawr/handlers/login.py
@@ -245,6 +245,7 @@ async def handle_provider_return(
     if scopes is None:
         await provider.logout(context.state)
         msg = f"{user_info.username} is not a member of any authorized groups"
+        await user_info_service.invalidate_cache(user_info.username)
         return login_error(context, LoginError.GROUPS_MISSING, details=msg)
 
     # Construct a token.

--- a/src/gafaelfawr/services/ldap.py
+++ b/src/gafaelfawr/services/ldap.py
@@ -140,3 +140,21 @@ class LDAPService:
             data = await self._ldap.get_data(username)
             self._user_cache.store(username, data)
             return data
+
+    async def invalidate_cache(self, username: str) -> None:
+        """Invalidate the cache for a given user.
+
+        Parameters
+        ----------
+        username
+            Username of the user.
+        """
+        if self._group_name_cache.get(username) is not None:
+            async with await self._group_name_cache.lock(username):
+                self._group_name_cache.invalidate(username)
+        if self._group_cache.get(username) is not None:
+            async with await self._group_cache.lock(username):
+                self._group_cache.invalidate(username)
+        if self._user_cache.get(username) is not None:
+            async with await self._user_cache.lock(username):
+                self._user_cache.invalidate(username)

--- a/src/gafaelfawr/services/userinfo.py
+++ b/src/gafaelfawr/services/userinfo.py
@@ -187,6 +187,21 @@ class UserInfoService:
 
         return sorted(scopes) if found else None
 
+    async def invalidate_cache(self, username: str) -> None:
+        """Invalidate any cached data for a given user.
+
+        Used after failed login due to missing group memberships, so that if
+        the user immediately fixes the problem, they don't have to wait for
+        the LDAP cache to expire.
+
+        Parameters
+        ----------
+        username
+            User for which to invalidate cached data.
+        """
+        if self._ldap:
+            await self._ldap.invalidate_cache(username)
+
 
 class OIDCUserInfoService(UserInfoService):
     """Retrieve user metadata from external systems for OIDC authentication.


### PR DESCRIPTION
If we reject the login because the user is not a member of any valid groups, invalidate the LDAP cache so that the next attempt will check LDAP again.  The user is probably going to try to fix the problem right away, and we don't want to make them wait for the LDAP cache to time out before they can see if their fix worked.