### PR TITLE
DM-37291: Add Authorization and Cookie header filtering

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -107,7 +107,7 @@ jobs:
         run: sudo apt install -y libpq-dev libldap2-dev libsasl2-dev
 
       - name: Set up Minikube
-        uses: manusa/actions-setup-minikube@v2.7.1
+        uses: manusa/actions-setup-minikube@v2.7.2
         with:
           minikube version: 'v1.27.1'
           kubernetes version: 'v1.25.2'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ Dependencies are updated to the latest available version during each release. Th
 - All commands that took a `--settings` option to specify the path to the configuration file now take a `--config-path` option instead. This name is clearer and avoids introducing a separate "settings" term.
 - The default path to the Gafaelfawr configuration file is now taken from the `GAFAELFAWR_CONFIG_PATH` environment variable rather than `GAFAELFAWR_SETTINGS_PATH`, for the same reason.
 
+### New features
+
+- The response from the `/auth` now includes any `Authorization` or `Cookie` headers from the incoming request with Gafaelfawr tokens and secrets filtered out. This is automatically used by `GafaelfawrIngress` resources to filter those secrets out of the request passed to the protected service so that the user's credentials are not leaked to services. Manual ingress configurations should add `Authorization` and `Cookie` to the `nginx.ingress.kubernetes.io/auth-response-headers` annotation.
+
 ### Bug fixes
 
 - If a user's login was rejected because they were not a member of any known groups, invalidate the LDAP cache for that user before returning the error. The user is likely to immediately try to fix this problem, and making them wait until the LDAP cache times out to see if the fix worked is confusing.
@@ -446,7 +450,7 @@ This release changes the construction of identity and groups from GitHub authent
 
 ## 1.2.1 (2020-05-14)
 
-Gafaelfawr can now analyze the `X-Forwarded-For` header to determine the true client IP for logging purposes. This requires some configuration of both Gafaelfawr and the NGINX ingress. See [the logging documentation](https://gafaelfawr.lsst.io/user-guide/prerequisites.html#client-ips) for more information.
+Gafaelfawr can now analyze the `X-Forwarded-For` header to determine the true client IP for logging purposes. This requires some configuration of both Gafaelfawr and the NGINX ingress. See [the logging documentation](https://gafaelfawr.lsst.io/dev/requirements.html#client-ips) for more information.
 
 ### New features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ Dependencies are updated to the latest available version during each release. Th
 
 ### New features
 
-- The response from the `/auth` now includes any `Authorization` or `Cookie` headers from the incoming request with Gafaelfawr tokens and secrets filtered out. This is automatically used by `GafaelfawrIngress` resources to filter those secrets out of the request passed to the protected service so that the user's credentials are not leaked to services. Manual ingress configurations should add `Authorization` and `Cookie` to the `nginx.ingress.kubernetes.io/auth-response-headers` annotation.
+- The response from the `/auth` now reflects `Authorization` and `Cookie` headers from the incoming request with Gafaelfawr tokens and secrets filtered out. `GafaelfawrIngress` resources use this to filter those secrets out of the request passed to the protected service, avoiding leaking user credentials to services. Manual ingress configurations should add `Authorization` and `Cookie` to the `nginx.ingress.kubernetes.io/auth-response-headers` annotation to get the benefits of this filtering.
 
 ### Bug fixes
 

--- a/docs/user-guide/gafaelfawringress.rst
+++ b/docs/user-guide/gafaelfawringress.rst
@@ -177,6 +177,9 @@ In addition, if a delegated token was requested, it will be sent in the ``X-Auth
 HTTP headers starting with ``X-Auth-Request-*`` are reserved for Gafaelfawr.
 More headers may be added in the future.
 
+As discussed in :ref:`header-filtering`, Gafaelfawr also modifies the ``Authorization`` and ``Cookie`` headers to hide Gafaelfawr's own tokens and cookies.
+This should be invisible to the protected application, and it can still set and receive its own cookies.
+
 .. _error-caching:
 
 Disabling error caching

--- a/docs/user-guide/ingress-overview.rst
+++ b/docs/user-guide/ingress-overview.rst
@@ -26,7 +26,7 @@ Header filtering
 Gafaelfawr authentication tokens should only be sent to Gafaelfawr (and, unavoidably, the NGINX ingress), not to protected applications.
 Otherwise, a protected application, even one that didn't request delegated tokens, could take the cookie or token from the incoming request and then impersonate the user to other services.
 Even if no protected services are malicious, they may have security vulnerabilities that would allow an attacker to gain access to their incoming requests.
-Thosse requests unavoidably expose any credentials needed by that service, but they ideally shouldn't expose anything else.
+Those requests unavoidably expose any credentials needed by that service, but they ideally shouldn't expose anything else.
 
 For more details on this security concern, see :sqr:`051`.
 

--- a/docs/user-guide/manual-ingress.rst
+++ b/docs/user-guide/manual-ingress.rst
@@ -26,6 +26,7 @@ The required minimum annotations for a web service that returns 401 if the user 
 
    annotations:
     nginx.ingress.kubernetes.io/auth-method: "GET"
+    nginx.ingress.kubernetes.io/auth-response-headers: "Authorization,Cookie,X-Auth-Request-Email,X-Auth-Request-User"
     nginx.ingress.kubernetes.io/auth-url: "https://<hostname>/auth?scope=<scope>"
 
 Replace ``<hostname>`` with the hostname of the ingress on which the Gafaelfawr routes are configured, and ``<scope>`` with the name of the scope that should be required in order to visit this site.
@@ -37,7 +38,7 @@ For example, to require both ``read:tap`` and ``read:image`` scopes, use:
 
    annotations:
     nginx.ingress.kubernetes.io/auth-method: "GET"
-    nginx.ingress.kubernetes.io/auth-response-headers: "X-Auth-Request-Email,X-Auth-Request-User"
+    nginx.ingress.kubernetes.io/auth-response-headers: "Authorization,Cookie,X-Auth-Request-Email,X-Auth-Request-User"
     nginx.ingress.kubernetes.io/auth-url: "https://<hostname>/auth?scope=read:tap&scope=read:image"
 
 To allow any one of the listed scopes to grant access, instead of requiring the user have all of the scopes, add ``satisfy=any``:
@@ -46,7 +47,7 @@ To allow any one of the listed scopes to grant access, instead of requiring the 
 
    annotations:
     nginx.ingress.kubernetes.io/auth-method: "GET"
-    nginx.ingress.kubernetes.io/auth-response-headers: "X-Auth-Request-Email,X-Auth-Request-User"
+    nginx.ingress.kubernetes.io/auth-response-headers: "Authorization,Cookie,X-Auth-Request-Email,X-Auth-Request-User"
     nginx.ingress.kubernetes.io/auth-url: "https://<hostname>/auth?scope=read:tap&scope=read:image&satisfy=any"
 
 Redirecting users to log in
@@ -58,7 +59,7 @@ To redirect the user to the login page instead of returning a 401 error if the u
 
    annotations:
     nginx.ingress.kubernetes.io/auth-method: "GET"
-    nginx.ingress.kubernetes.io/auth-response-headers: "X-Auth-Request-Email,X-Auth-Request-User"
+    nginx.ingress.kubernetes.io/auth-response-headers: "Authorization,Cookie,X-Auth-Request-Email,X-Auth-Request-User"
     nginx.ingress.kubernetes.io/auth-signin: "https://<hostname>/login"
     nginx.ingress.kubernetes.io/auth-url: "https://<hostname>/auth?scope=<scope>"
 
@@ -71,8 +72,7 @@ To request a delegated internal token, use these annotations:
 
    annotations:
     nginx.ingress.kubernetes.io/auth-method: "GET"
-    nginx.ingress.kubernetes.io/auth-response-headers: "X-Auth-Request-Email,X-Auth-Request-User,X-Auth-Request-Token"
-    nginx.ingress.kubernetes.io/auth-response-headers: "X-Auth-Request-Token"
+    nginx.ingress.kubernetes.io/auth-response-headers: "Authorization,Cookie,X-Auth-Request-Email,X-Auth-Request-User,X-Auth-Request-Token"
     nginx.ingress.kubernetes.io/auth-signin: "https://<hostname>/login"
     nginx.ingress.kubernetes.io/auth-url: "https://<hostname>/auth?scope=<scope>&delegate_to=<service>&delegate_scope=<delegate-scope>,<delegate-scope>"
 
@@ -87,7 +87,7 @@ For the special case of notebook tokens, instead use:
 
    annotations:
     nginx.ingress.kubernetes.io/auth-method: "GET"
-    nginx.ingress.kubernetes.io/auth-response-headers: "X-Auth-Request-Email,X-Auth-Request-User,X-Auth-Request-Token"
+    nginx.ingress.kubernetes.io/auth-response-headers: "Authorization,Cookie,X-Auth-Request-Email,X-Auth-Request-User,X-Auth-Request-Token"
     nginx.ingress.kubernetes.io/auth-signin: "https://<hostname>/login"
     nginx.ingress.kubernetes.io/auth-url: "https://<hostname>/auth?scope=<scope>&notebook=true"
 

--- a/src/gafaelfawr/auth.py
+++ b/src/gafaelfawr/auth.py
@@ -68,17 +68,17 @@ def clean_authorization(headers: list[str]) -> list[str]:
 
     Notes
     -----
-    We don't drop all ``Authorization`` headers because Jupyter labs use an
-    ``Authorization`` header of type ``token`` to pass their internal tokens
-    around.  That header has to be passed through to the backend for
-    JuptyerHub to work correctly.
+    We don't drop all ``Authorization`` because Gafaelfawr may be doing
+    stripping for anonymous routes that may be in front of services doing
+    their own authentication, possibly with authentication types we don't
+    recognize.
     """
     output = []
     for header in headers:
         if " " not in header:
             output.append(header)
             continue
-        auth_type, auth_blob = header.split(" ", 1)
+        auth_type, auth_blob = header.split(None, 1)
         if auth_type.lower() == "bearer":
             if not Token.is_token(auth_blob):
                 output.append(header)
@@ -292,7 +292,7 @@ def parse_authorization(context: RequestContext) -> str | None:
         return None
     if " " not in header:
         raise InvalidRequestError("Malformed Authorization header")
-    auth_type, auth_blob = header.split(" ")
+    auth_type, auth_blob = header.split(None, 1)
     if auth_type.lower() == "bearer":
         context.rebind_logger(token_source="bearer")
         return auth_blob

--- a/src/gafaelfawr/models/token.py
+++ b/src/gafaelfawr/models/token.py
@@ -79,6 +79,29 @@ class Token(BaseModel):
 
         return cls(key=key, secret=secret)
 
+    @classmethod
+    def is_token(cls, token: str) -> bool:
+        """Determine if a string is a Gafaelfawr token.
+
+        Parameters
+        ----------
+        token
+            The string to check.
+
+        Returns
+        -------
+        bool
+            Whether that string looks like a Gafaelfawr token.  The token
+            isn't checked for validity, only format.
+        """
+        if not token.startswith("gt-"):
+            return False
+        trimmed_token = token[len("gt-") :]
+        if "." not in trimmed_token:
+            return False
+        key, secret = trimmed_token.split(".", 1)
+        return len(key) == 22 and len(secret) == 22
+
     def __str__(self) -> str:
         """Return the encoded token."""
         return f"gt-{self.key}.{self.secret}"

--- a/src/gafaelfawr/services/kubernetes.py
+++ b/src/gafaelfawr/services/kubernetes.py
@@ -115,7 +115,9 @@ class KubernetesIngressService:
             query.append(("auth_type", ingress.config.auth_type.value))
         auth_url += "?" + urlencode(query)
 
-        headers = "X-Auth-Request-Email,X-Auth-Request-User"
+        headers = (
+            "Authorization,Cookie,X-Auth-Request-Email,X-Auth-Request-User"
+        )
         if ingress.config.delegate:
             headers += ",X-Auth-Request-Token"
         annotations = {

--- a/tests/data/kubernetes/output/ingresses.yaml
+++ b/tests/data/kubernetes/output/ingresses.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: {namespace}
   annotations:
     nginx.ingress.kubernetes.io/auth-method: GET
-    nginx.ingress.kubernetes.io/auth-response-headers: "X-Auth-Request-Email,X-Auth-Request-User"
+    nginx.ingress.kubernetes.io/auth-response-headers: "Authorization,Cookie,X-Auth-Request-Email,X-Auth-Request-User"
     nginx.ingress.kubernetes.io/auth-url: "https://foo.example.com/auth?scope=read%3Aall"
   creationTimestamp: {any}
   generation: {any}
@@ -42,7 +42,7 @@ metadata:
   annotations:
     another.annotation.example.com: bar
     nginx.ingress.kubernetes.io/auth-method: GET
-    nginx.ingress.kubernetes.io/auth-response-headers: "X-Auth-Request-Email,X-Auth-Request-User,X-Auth-Request-Token"
+    nginx.ingress.kubernetes.io/auth-response-headers: "Authorization,Cookie,X-Auth-Request-Email,X-Auth-Request-User,X-Auth-Request-Token"
     nginx.ingress.kubernetes.io/auth-signin: "https://foo.example.com/login"
     nginx.ingress.kubernetes.io/auth-url: "https://foo.example.com/auth?scope=read%3Aall&satisfy=any&notebook=true&minimum_lifetime=600&auth_type=basic"
     nginx.ingress.kubernetes.io/configuration-snippet: |-
@@ -87,7 +87,7 @@ metadata:
   namespace: {namespace}
   annotations:
     nginx.ingress.kubernetes.io/auth-method: GET
-    nginx.ingress.kubernetes.io/auth-response-headers: "X-Auth-Request-Email,X-Auth-Request-User,X-Auth-Request-Token"
+    nginx.ingress.kubernetes.io/auth-response-headers: "Authorization,Cookie,X-Auth-Request-Email,X-Auth-Request-User,X-Auth-Request-Token"
     nginx.ingress.kubernetes.io/auth-url: "https://foo.example.com/auth?scope=read%3Aall&scope=read%3Asome&delegate_to=some-service&delegate_scope=read%3Aall%2Cread%3Asome"
   creationTimestamp: {any}
   generation: {any}

--- a/tests/handlers/auth_test.py
+++ b/tests/handlers/auth_test.py
@@ -261,7 +261,7 @@ async def test_success_minimal(client: AsyncClient, factory: Factory) -> None:
     r = await client.get(
         "/auth",
         params={"scope": "read:all"},
-        headers={"Authorization": f"Bearer {token}"},
+        headers={"Authorization": f"Bearer   {token}"},
     )
     assert r.status_code == 200
     assert r.headers["X-Auth-Request-User"] == "user"
@@ -522,7 +522,7 @@ async def test_basic(client: AsyncClient, factory: Factory) -> None:
     r = await client.get(
         "/auth",
         params={"scope": "exec:admin"},
-        headers={"Authorization": f"Basic {basic_b64}"},
+        headers={"Authorization": f"Basic  {basic_b64}"},
     )
     assert r.status_code == 200
     assert r.headers["X-Auth-Request-User"] == token_data.username
@@ -812,9 +812,9 @@ async def test_authorization_filtering(
         "/auth",
         params={"scope": "read:all"},
         headers=[
-            ("Authorization", f"Basic {basic_b64}"),
+            ("Authorization", f"Basic  {basic_b64}"),
             ("Authorization", "some broken stuff"),
-            ("Authorization", f"BEARER {token_data.token}"),
+            ("Authorization", f"BEARER   {token_data.token}"),
             ("Authorization", "basic"),
             ("Authorization", "basic notreally:base64"),
         ],


### PR DESCRIPTION
Reflect the Authorization and Cookie headers from the request back in the response from the /auth route with Gafaelfawr tokens and cookies filtered out.  Lift those headers into the request to the protected service via NGINX Ingress annotation in the Ingress resources created from GafaelfawrIngress, and document how to do this for manually-configured ingresses.

This prevents leaking the user's original credentials to protected services, which could reuse them to impersonate the user beyond the scope of their delegated tokens.