### PR TITLE
DM-37291: Support passing delegated token in Authorization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ Dependencies are updated to the latest available version during each release. Th
 ### New features
 
 - The response from the `/auth` now reflects `Authorization` and `Cookie` headers from the incoming request with Gafaelfawr tokens and secrets filtered out. `GafaelfawrIngress` resources use this to filter those secrets out of the request passed to the protected service, avoiding leaking user credentials to services. Manual ingress configurations should add `Authorization` and `Cookie` to the `nginx.ingress.kubernetes.io/auth-response-headers` annotation to get the benefits of this filtering.
-- Added a `config.delegate.useAuthorization` field in `GafaelfawrIngress` and a `use_authoriation` query parameter for the `/auth` route that, if set, also puts any delegated token in the `Authorization` header, as a bearer token, in the request sent to the protected service. This allows easier integration with some software that expects tokens in standard headers rather than Gafaelfawr's custom `X-Auth-Request-Token` header.
+- Added a `config.delegate.useAuthorization` field in `GafaelfawrIngress` and a `use_authorization` query parameter for the `/auth` route that, if set, also puts any delegated token in the `Authorization` header, as a bearer token, in the request sent to the protected service. This allows easier integration with some software that expects tokens in standard headers rather than Gafaelfawr's custom `X-Auth-Request-Token` header.
 
 ### Bug fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Dependencies are updated to the latest available version during each release. Th
 ### New features
 
 - The response from the `/auth` now reflects `Authorization` and `Cookie` headers from the incoming request with Gafaelfawr tokens and secrets filtered out. `GafaelfawrIngress` resources use this to filter those secrets out of the request passed to the protected service, avoiding leaking user credentials to services. Manual ingress configurations should add `Authorization` and `Cookie` to the `nginx.ingress.kubernetes.io/auth-response-headers` annotation to get the benefits of this filtering.
+- Added a `config.delegate.useAuthorization` field in `GafaelfawrIngress` and a `use_authoriation` query parameter for the `/auth` route that, if set, also puts any delegated token in the `Authorization` header, as a bearer token, in the request sent to the protected service. This allows easier integration with some software that expects tokens in standard headers rather than Gafaelfawr's custom `X-Auth-Request-Token` header.
 
 ### Bug fixes
 

--- a/crds/ingress.yaml
+++ b/crds/ingress.yaml
@@ -148,6 +148,12 @@ spec:
                         Minimum lifetime of delegated token in seconds. If
                         the user's token has less than that time
                         remaining, force them to reauthenticate.
+                    useAuthorization:
+                      type: boolean
+                      description: >-
+                        If set to true, put the delegated token in the
+                        Authorization header of the request as a bearer token,
+                        in addition to X-Auth-Request-Token.
                   oneOf:
                     - required:
                         - internal

--- a/docs/user-guide/gafaelfawringress.rst
+++ b/docs/user-guide/gafaelfawringress.rst
@@ -159,6 +159,23 @@ Presumably logging in again will create a token with sufficient remaining lifeti
 Obviously, do not request a minimum lifetime longer than the default token lifetime!
 See :ref:`basic-settings` for more details.
 
+Delegate token in Authorization header
+--------------------------------------
+
+The delegated token is passed to the protected service in the ``X-Auth-Request-Token`` header, but this is a custom Gafaelfawr header.
+Some services may expect that token to be passed in the ``Authorization`` header as a bearer token, as specified in :rfc:`6750`.
+To tell Gafaelfawr to do this, use:
+
+.. code-block:: yaml
+
+   config:
+     delegate:
+       useAuthorization: true
+
+The same token will also still be passed in the ``X-Auth-Request-Token`` header.
+
+If this configuration option is set, the incoming ``Authorization`` header will be entirely replaced by one containing only the delegated token, unlike Gafaelfawr's normal behavior of preserving any incoming ``Authorization`` header that doesn't include a Gafaelfawr token.
+
 .. _auth-headers:
 
 Request headers

--- a/docs/user-guide/manual-ingress.rst
+++ b/docs/user-guide/manual-ingress.rst
@@ -93,6 +93,8 @@ For the special case of notebook tokens, instead use:
 
 In both cases, services designed for API instead of browser access can omit the ``nginx.ingress.kubernetes.io/auth-signin`` to return authentication challenges to the user instead of redirecting them to the login page.
 
+To request that the delegated token also be passed in the ``Authorization`` header as a bearer token, append ``&use_authorization=true`` to the ``nginx.ingress.kubernetes.io/auth-url`` annotation.
+
 Disabling error caching
 =======================
 
@@ -155,5 +157,9 @@ The URL in the ``nginx.ingress.kubernetes.io/auth-url`` annotation accepts sever
 
     If the presented authentication credentials don't satisfy this required lifetime, a 401 error will be returned.
     If the ``nginx.ingress.kubernetes.io/auth-signin`` annotation is set in the ``Ingress``, this will force a user reauthentication.
+
+``use_authorization`` (optional)
+    If set to a true value, replace the ``Authorization`` header with one containing the delegated token as a bearer token.
+    This option only makes sense in combination with ``notebook`` or ``delegate_to``.
 
 These parameters must be URL-encoded as GET parameters to the ``/auth`` route.

--- a/src/gafaelfawr/models/kubernetes.py
+++ b/src/gafaelfawr/models/kubernetes.py
@@ -139,6 +139,9 @@ class GafaelfawrIngressDelegate(BaseModel):
     minimum_lifetime: Optional[timedelta] = None
     """The minimum lifetime of the delegated token."""
 
+    use_authorization: bool = False
+    """Whether to put the delegated token in the ``Authorization`` header."""
+
     _normalize_minimum_lifetime = validator(
         "minimum_lifetime", allow_reuse=True, pre=True
     )(normalize_timedelta)

--- a/src/gafaelfawr/services/kubernetes.py
+++ b/src/gafaelfawr/services/kubernetes.py
@@ -111,6 +111,8 @@ class KubernetesIngressService:
                 minimum_lifetime = ingress.config.delegate.minimum_lifetime
                 minimum_str = str(int(minimum_lifetime.total_seconds()))
                 query.append(("minimum_lifetime", minimum_str))
+            if ingress.config.delegate.use_authorization:
+                query.append(("use_authorization", "true"))
         if ingress.config.auth_type:
             query.append(("auth_type", ingress.config.auth_type.value))
         auth_url += "?" + urlencode(query)

--- a/tests/data/kubernetes/input/ingresses.yaml
+++ b/tests/data/kubernetes/input/ingresses.yaml
@@ -94,3 +94,34 @@ template:
                   name: something
                   port:
                     number: 80
+---
+apiVersion: gafaelfawr.lsst.io/v1alpha1
+kind: GafaelfawrIngress
+metadata:
+  name: authorization-ingress
+  namespace: {namespace}
+config:
+  baseUrl: "https://foo.example.com"
+  scopes:
+    all: ["read:all"]
+  delegate:
+    internal:
+      service: some-service
+      scopes:
+        - "read:all"
+    useAuthorization: true
+template:
+  metadata:
+    name: authorization
+  spec:
+    rules:
+      - host: foo.example.com
+        http:
+          paths:
+            - path: /foo
+              pathType: Prefix
+              backend:
+                service:
+                  name: something
+                  port:
+                    name: http

--- a/tests/data/kubernetes/output/ingresses.yaml
+++ b/tests/data/kubernetes/output/ingresses.yaml
@@ -115,3 +115,39 @@ spec:
                 port:
                   number: 80
 status: {any}
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: authorization
+  namespace: {namespace}
+  annotations:
+    nginx.ingress.kubernetes.io/auth-method: GET
+    nginx.ingress.kubernetes.io/auth-response-headers: "Authorization,Cookie,X-Auth-Request-Email,X-Auth-Request-User,X-Auth-Request-Token"
+    nginx.ingress.kubernetes.io/auth-url: "https://foo.example.com/auth?scope=read%3Aall&delegate_to=some-service&delegate_scope=read%3Aall&use_authorization=true"
+  creationTimestamp: {any}
+  generation: {any}
+  managedFields: {any}
+  ownerReferences:
+    - apiVersion: gafaelfawr.lsst.io/v1alpha1
+      blockOwnerDeletion: true
+      controller: true
+      kind: GafaelfawrIngress
+      name: authorization-ingress
+      uid: {any}
+  resourceVersion: {any}
+  uid: {any}
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: foo.example.com
+      http:
+        paths:
+          - path: /foo
+            pathType: Prefix
+            backend:
+              service:
+                name: something
+                port:
+                  name: http
+status: {any}


### PR DESCRIPTION
Add new config.delegate.useAuthorization GafaelfawrIngress setting and use_authorization query parameter to the /auth route that also puts a copy of any delegated token into the Authorization header as a bearer token.  The CADC TAP service requires the token be passed that way to work well with their authentication layer, and this removes the need for a custom NGINX configuration snippet.