### PR TITLE
DM-37291: Check Ingress resources on operator resume

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Dependencies are updated to the latest available version during each release. Th
 
 - The response from the `/auth` now reflects `Authorization` and `Cookie` headers from the incoming request with Gafaelfawr tokens and secrets filtered out. `GafaelfawrIngress` resources use this to filter those secrets out of the request passed to the protected service, avoiding leaking user credentials to services. Manual ingress configurations should add `Authorization` and `Cookie` to the `nginx.ingress.kubernetes.io/auth-response-headers` annotation to get the benefits of this filtering.
 - Added a `config.delegate.useAuthorization` field in `GafaelfawrIngress` and a `use_authorization` query parameter for the `/auth` route that, if set, also puts any delegated token in the `Authorization` header, as a bearer token, in the request sent to the protected service. This allows easier integration with some software that expects tokens in standard headers rather than Gafaelfawr's custom `X-Auth-Request-Token` header.
+- `Ingress` resources generated from `GafaelfawrIngress` resources will be checked for correctness when Gafaelfawr starts, even if the `GafaelfawrIngress` resource has not been modified. This ensures changes to the generated `Ingress` due to Gafaelfawr code changes are applied to existing resources.
 
 ### Bug fixes
 

--- a/src/gafaelfawr/operator/ingress.py
+++ b/src/gafaelfawr/operator/ingress.py
@@ -15,6 +15,7 @@ __all__ = ["create"]
 
 
 @kopf.on.create("gafaelfawr.lsst.io", "v1alpha1", "gafaelfawringresses")
+@kopf.on.resume("gafaelfawr.lsst.io", "v1alpha1", "gafaelfawringresses")
 @kopf.on.update("gafaelfawr.lsst.io", "v1alpha1", "gafaelfawringresses")
 async def create(
     name: str | None,

--- a/src/gafaelfawr/operator/tokens.py
+++ b/src/gafaelfawr/operator/tokens.py
@@ -24,7 +24,6 @@ async def _update_token(
     namespace: str | None,
     body: kopf.Body,
     memo: kopf.Memo,
-    **_: Any,
 ) -> dict[str, int | str] | None:
     """Do the work of updating the token, shared by `create` and `periodic`."""
     token_service: KubernetesTokenService = memo.token_service


### PR DESCRIPTION
Add an on-resume hook to the Kopf handling of ingress resources so that we update ingresses for changes in the Gafaelfawr source code. This seems sufficient for ingresses and the full periodic timer checks don't seem necessary, since there's nothing intrinsic to the ingress (unlike the secret generated from a GafaelfawrServiceToken) that should change outside of Gafaelfawr source code changes.