### PR TITLE
DM-37291: Add support for anonymous ingresses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,13 @@ Dependencies are updated to the latest available version during each release. Th
 
 - All commands that took a `--settings` option to specify the path to the configuration file now take a `--config-path` option instead. This name is clearer and avoids introducing a separate "settings" term.
 - The default path to the Gafaelfawr configuration file is now taken from the `GAFAELFAWR_CONFIG_PATH` environment variable rather than `GAFAELFAWR_SETTINGS_PATH`, for the same reason.
+- A `GafaelfawrIngress` that sets `config.loginRedirect` to true and also sets `config.authType` to `basic` is now rejected with an error, since this combination isn't possible. Previously, the `authType` setting was silently ignored.
 
 ### New features
 
 - The response from the `/auth` now reflects `Authorization` and `Cookie` headers from the incoming request with Gafaelfawr tokens and secrets filtered out. `GafaelfawrIngress` resources use this to filter those secrets out of the request passed to the protected service, avoiding leaking user credentials to services. Manual ingress configurations should add `Authorization` and `Cookie` to the `nginx.ingress.kubernetes.io/auth-response-headers` annotation to get the benefits of this filtering.
-- Added a `config.delegate.useAuthorization` field in `GafaelfawrIngress` and a `use_authorization` query parameter for the `/auth` route that, if set, also puts any delegated token in the `Authorization` header, as a bearer token, in the request sent to the protected service. This allows easier integration with some software that expects tokens in standard headers rather than Gafaelfawr's custom `X-Auth-Request-Token` header.
+- Add support for anonymous ingresses. If `config.scopes.anonymous` in a `GafaelfawrIngress` is set to true, no authentication or authorization will be done but Gafaelfawr will still be invoked as an auth subrequest handler solely to strip Gafaelfawr tokens and cookies from the `Authorization` and `Cookie` headers before passing the request to the protected service. This can also be configured manually using the new `/auth/anonymous` route.
+- Add a `config.delegate.useAuthorization` field in `GafaelfawrIngress` and a `use_authorization` query parameter for the `/auth` route that, if set, also puts any delegated token in the `Authorization` header, as a bearer token, in the request sent to the protected service. This allows easier integration with some software that expects tokens in standard headers rather than Gafaelfawr's custom `X-Auth-Request-Token` header.
 - `Ingress` resources generated from `GafaelfawrIngress` resources will be checked for correctness when Gafaelfawr starts, even if the `GafaelfawrIngress` resource has not been modified. This ensures changes to the generated `Ingress` due to Gafaelfawr code changes are applied to existing resources.
 
 ### Bug fixes

--- a/crds/ingress.yaml
+++ b/crds/ingress.yaml
@@ -63,32 +63,6 @@ spec:
                   type: string
                   description: "Base URL for Gafaelfawr APIs."
                   pattern: "^https://[a-z.-]+"
-                scopes:
-                  type: object
-                  description: >-
-                    The token scope or scopes required to access this
-                    service.  May be omitted if the service allows
-                    anonymous access.
-                  properties:
-                    any:
-                      type: array
-                      description: >-
-                        Access is granted if any of the listed scopes are
-                        present.
-                      items:
-                        type: string
-                    all:
-                      type: array
-                      description: >-
-                        Access is granted if all of the listed scopes are
-                        present.
-                      items:
-                        type: string
-                  oneOf:
-                    - required:
-                        - any
-                    - required:
-                        - all
                 authType:
                   type: string
                   enum:
@@ -98,18 +72,6 @@ spec:
                     Controls the authentication type in the challenge
                     returned in the `WWW-Authenticate` header if the user
                     is not authenticated. By default, this is `bearer`.
-                loginRedirect:
-                  type: boolean
-                  description: >-
-                    Whether to redirect to the login flow if the user is
-                    not currently authenticated.
-                replace403:
-                  type: boolean
-                  description: >-
-                    Whether to replace 403 responses with a custom 403
-                    response from Gafaelfawr that disables caching and
-                    includes authorization-related errors in the
-                    `WWW-Authenticate` header.
                 delegate:
                   type: object
                   description: >-
@@ -159,6 +121,57 @@ spec:
                         - internal
                     - required:
                         - notebook
+                loginRedirect:
+                  type: boolean
+                  description: >-
+                    Whether to redirect to the login flow if the user is
+                    not currently authenticated.
+                replace403:
+                  type: boolean
+                  description: >-
+                    Whether to replace 403 responses with a custom 403
+                    response from Gafaelfawr that disables caching and
+                    includes authorization-related errors in the
+                    `WWW-Authenticate` header.
+                scopes:
+                  type: object
+                  description: >-
+                    The token scope or scopes required to access this
+                    service.  May be omitted if the service allows
+                    anonymous access.
+                  properties:
+                    any:
+                      type: array
+                      description: >-
+                        Access is granted if any of the listed scopes are
+                        present.
+                      items:
+                        type: string
+                    all:
+                      type: array
+                      description: >-
+                        Access is granted if all of the listed scopes are
+                        present.
+                      items:
+                        type: string
+                    anonymous:
+                      type: boolean
+                      description: >-
+                        Allow anonymous access to this ingress. No access
+                        control checks will be made and no token delegation is
+                        possible, but Gafaelfawr tokens will still be stripped
+                        from the `Authorization` and `Cookie` headers.
+                  oneOf:
+                    - required:
+                        - any
+                    - required:
+                        - all
+                    - properties:
+                        anonymous:
+                          enum:
+                            - true
+                      required:
+                        - anonymous
             template:
               type: object
               description: "The template used to create the ingress."

--- a/docs/user-guide/gafaelfawringress.rst
+++ b/docs/user-guide/gafaelfawringress.rst
@@ -191,6 +191,25 @@ The same token will also still be passed in the ``X-Auth-Request-Token`` header.
 
 If this configuration option is set, the incoming ``Authorization`` header will be entirely replaced by one containing only the delegated token, unlike Gafaelfawr's normal behavior of preserving any incoming ``Authorization`` header that doesn't include a Gafaelfawr token.
 
+.. _anonymous:
+
+Anonymous ingresses
+===================
+
+An anonymous ingress (one that doesn't require authentication and performs no authorization checks) can be configured using ``GafaelfawrIngress`` as follows:
+
+.. code-block:: yaml
+
+   config:
+     scopes:
+       anonymous: true
+
+None of the other configuration options are supported in this mode.
+
+The reason to use this configuration over simply writing an ``Ingress`` resource directly is that Gafaelfawr will still be invoked to strip Gafaelfawr tokens and secrets from the request before it is passed to the underlying service.
+This prevents credential leakage to anonymous services.
+See :ref:`header-filtering` for more details.
+
 .. _auth-headers:
 
 Request headers

--- a/docs/user-guide/manual-ingress.rst
+++ b/docs/user-guide/manual-ingress.rst
@@ -95,6 +95,23 @@ In both cases, services designed for API instead of browser access can omit the 
 
 To request that the delegated token also be passed in the ``Authorization`` header as a bearer token, append ``&use_authorization=true`` to the ``nginx.ingress.kubernetes.io/auth-url`` annotation.
 
+Header filtering for anonymous ingresses
+========================================
+
+If an ingress shares a hostname with any authenticated service, it should still configure Gafaelfawr to perform header filtering even if it allows anonymous access.
+This prevents leakage of Gafaelfawr credentials to underlying services.
+
+To do this with a manually-configured ingress, add the following annotations:
+
+.. code-block:: yaml
+
+   annotations:
+    nginx.ingress.kubernetes.io/auth-method: "GET"
+    nginx.ingress.kubernetes.io/auth-response-headers: "Authorization,Cookie"
+    nginx.ingress.kubernetes.io/auth-url: "https://<hostname>/auth/anonymous"
+
+Note the different ``auth-url`` route.
+
 Disabling error caching
 =======================
 

--- a/src/gafaelfawr/handlers/auth.py
+++ b/src/gafaelfawr/handlers/auth.py
@@ -318,6 +318,34 @@ async def get_auth(
 
 
 @router.get(
+    "/auth/anonymous",
+    description=(
+        "Intended for use as an auth-url handler for anonymous routes. No"
+        " authentication is done and no authorization checks are performed,"
+        " but the `Authorization` and `Cookie` headers are still reflected"
+        " in the response with Gafaelfawr tokens and cookies stripped."
+    ),
+    summary="Filter headers for anonymous routes",
+    tags=["internal"],
+)
+async def get_anonymous(
+    response: Response,
+    context: RequestContext = Depends(context_dependency),
+) -> dict[str, str]:
+    if "Authorization" in context.request.headers:
+        raw_authorizations = context.request.headers.getlist("Authorization")
+        authorizations = clean_authorization(raw_authorizations)
+        for authorization in authorizations:
+            response.headers.append("Authorization", authorization)
+    if "Cookie" in context.request.headers:
+        raw_cookies = context.request.headers.getlist("Cookie")
+        cookies = clean_cookies(raw_cookies)
+        for cookie in cookies:
+            response.headers.append("Cookie", cookie)
+    return {"status": "ok"}
+
+
+@router.get(
     "/auth/forbidden",
     description=(
         "This route exists to set a Cache-Control header on 403 errors so"

--- a/src/gafaelfawr/models/kubernetes.py
+++ b/src/gafaelfawr/models/kubernetes.py
@@ -294,7 +294,7 @@ class GafaelfawrIngressConfig(BaseModel):
             for snake_name in fields:
                 if values.get(snake_name):
                     camel_name = to_camel_case(snake_name)
-                    msg = f"{camel_name} has no effect for anonyous ingresses"
+                    msg = f"{camel_name} has no effect for anonymous ingresses"
                     raise ValueError(msg)
 
         return values

--- a/tests/data/kubernetes/input/ingresses.yaml
+++ b/tests/data/kubernetes/input/ingresses.yaml
@@ -32,7 +32,6 @@ config:
   baseUrl: "https://foo.example.com"
   scopes:
     any: ["read:all"]
-  authType: basic
   loginRedirect: true
   replace403: true
   delegate:
@@ -69,6 +68,7 @@ metadata:
   namespace: {namespace}
 config:
   baseUrl: "https://foo.example.com"
+  authType: basic
   scopes:
     all:
       - "read:all"
@@ -113,6 +113,33 @@ config:
 template:
   metadata:
     name: authorization
+  spec:
+    rules:
+      - host: foo.example.com
+        http:
+          paths:
+            - path: /foo
+              pathType: Prefix
+              backend:
+                service:
+                  name: something
+                  port:
+                    name: http
+---
+apiVersion: gafaelfawr.lsst.io/v1alpha1
+kind: GafaelfawrIngress
+metadata:
+  name: anonymous-ingress
+  namespace: {namespace}
+config:
+  baseUrl: "https://foo.example.com"
+  scopes:
+    anonymous: true
+template:
+  metadata:
+    name: anonymous
+    annotations:
+      some.annotation: foo
   spec:
     rules:
       - host: foo.example.com

--- a/tests/data/kubernetes/output/ingresses.yaml
+++ b/tests/data/kubernetes/output/ingresses.yaml
@@ -44,9 +44,9 @@ metadata:
     nginx.ingress.kubernetes.io/auth-method: GET
     nginx.ingress.kubernetes.io/auth-response-headers: "Authorization,Cookie,X-Auth-Request-Email,X-Auth-Request-User,X-Auth-Request-Token"
     nginx.ingress.kubernetes.io/auth-signin: "https://foo.example.com/login"
-    nginx.ingress.kubernetes.io/auth-url: "https://foo.example.com/auth?scope=read%3Aall&satisfy=any&notebook=true&minimum_lifetime=600&auth_type=basic"
+    nginx.ingress.kubernetes.io/auth-url: "https://foo.example.com/auth?scope=read%3Aall&satisfy=any&notebook=true&minimum_lifetime=600"
     nginx.ingress.kubernetes.io/configuration-snippet: |-
-      error_page 403 = "/auth/forbidden?scope=read%3Aall&satisfy=any&notebook=true&minimum_lifetime=600&auth_type=basic";
+      error_page 403 = "/auth/forbidden?scope=read%3Aall&satisfy=any&notebook=true&minimum_lifetime=600";
   creationTimestamp: {any}
   generation: {any}
   labels:
@@ -88,7 +88,7 @@ metadata:
   annotations:
     nginx.ingress.kubernetes.io/auth-method: GET
     nginx.ingress.kubernetes.io/auth-response-headers: "Authorization,Cookie,X-Auth-Request-Email,X-Auth-Request-User,X-Auth-Request-Token"
-    nginx.ingress.kubernetes.io/auth-url: "https://foo.example.com/auth?scope=read%3Aall&scope=read%3Asome&delegate_to=some-service&delegate_scope=read%3Aall%2Cread%3Asome"
+    nginx.ingress.kubernetes.io/auth-url: "https://foo.example.com/auth?scope=read%3Aall&scope=read%3Asome&delegate_to=some-service&delegate_scope=read%3Aall%2Cread%3Asome&auth_type=basic"
   creationTimestamp: {any}
   generation: {any}
   managedFields: {any}
@@ -134,6 +134,43 @@ metadata:
       controller: true
       kind: GafaelfawrIngress
       name: authorization-ingress
+      uid: {any}
+  resourceVersion: {any}
+  uid: {any}
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: foo.example.com
+      http:
+        paths:
+          - path: /foo
+            pathType: Prefix
+            backend:
+              service:
+                name: something
+                port:
+                  name: http
+status: {any}
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: anonymous
+  namespace: {namespace}
+  annotations:
+    nginx.ingress.kubernetes.io/auth-method: GET
+    nginx.ingress.kubernetes.io/auth-response-headers: "Authorization,Cookie"
+    nginx.ingress.kubernetes.io/auth-url: "https://foo.example.com/auth/anonymous"
+    some.annotation: foo
+  creationTimestamp: {any}
+  generation: {any}
+  managedFields: {any}
+  ownerReferences:
+    - apiVersion: gafaelfawr.lsst.io/v1alpha1
+      blockOwnerDeletion: true
+      controller: true
+      kind: GafaelfawrIngress
+      name: anonymous-ingress
       uid: {any}
   resourceVersion: {any}
   uid: {any}

--- a/tests/models/kubernetes_test.py
+++ b/tests/models/kubernetes_test.py
@@ -105,3 +105,74 @@ def test_service_port() -> None:
 
     with pytest.raises(ValidationError):
         GafaelfawrIngressPathService.parse_obj({"name": "", "port": {}})
+
+
+def test_basic_login_redirect() -> None:
+    GafaelfawrIngressConfig.parse_obj(
+        {
+            "baseUrl": "https://example.com/",
+            "authType": "bearer",
+            "loginRedirect": True,
+            "scopes": {"all": ["read:all"]},
+        }
+    )
+    with pytest.raises(ValidationError):
+        GafaelfawrIngressConfig.parse_obj(
+            {
+                "baseUrl": "https://example.com/",
+                "authType": "basic",
+                "loginRedirect": True,
+                "scopes": {"all": ["read:all"]},
+            }
+        )
+
+
+def test_anonymous() -> None:
+    GafaelfawrIngressConfig.parse_obj(
+        {
+            "baseUrl": "https://example.com/",
+            "authType": "basic",
+            "scopes": {"all": ["read:all"]},
+        }
+    )
+    with pytest.raises(ValidationError):
+        GafaelfawrIngressConfig.parse_obj(
+            {
+                "baseUrl": "https://example.com/",
+                "authType": "basic",
+                "scopes": {"anonymous": True},
+            }
+        )
+    GafaelfawrIngressConfig.parse_obj(
+        {
+            "baseUrl": "https://example.com/",
+            "delegate": {"notebook": {}},
+            "scopes": {"all": ["read:all"]},
+        }
+    )
+    with pytest.raises(ValidationError):
+        GafaelfawrIngressConfig.parse_obj(
+            {
+                "baseUrl": "https://example.com/",
+                "delegate": {"notebook": {}},
+                "scopes": {"anonymous": True},
+            }
+        )
+
+    # Boolean fields should produce an error if set to True, but not if False.
+    for field in ("loginRedirect", "replace403"):
+        GafaelfawrIngressConfig.parse_obj(
+            {
+                "baseUrl": "https://example.com/",
+                field: False,
+                "scopes": {"anonymous": True},
+            }
+        )
+        with pytest.raises(ValidationError):
+            GafaelfawrIngressConfig.parse_obj(
+                {
+                    "baseUrl": "https://example.com/",
+                    field: True,
+                    "scopes": {"anonymous": True},
+                }
+            )

--- a/tests/operator/ingress_test.py
+++ b/tests/operator/ingress_test.py
@@ -88,6 +88,7 @@ async def test_replace(api_client: ApiClient, namespace: str) -> None:
             "gafaelfawringresses",
             ingress["metadata"]["name"],
         )
+        ingress["config"]["authType"] = "bearer"
         ingress["config"]["loginRedirect"] = True
         await custom_api.replace_namespaced_custom_object(
             "gafaelfawr.lsst.io",
@@ -99,6 +100,9 @@ async def test_replace(api_client: ApiClient, namespace: str) -> None:
         )
         await asyncio.sleep(1)
 
+        expected["metadata"]["annotations"][
+            "nginx.ingress.kubernetes.io/auth-url"
+        ] = "https://foo.example.com/auth?scope=read%3Aall&auth_type=bearer"
         expected["metadata"]["annotations"][
             "nginx.ingress.kubernetes.io/auth-signin"
         ] = "https://foo.example.com/login"


### PR DESCRIPTION
Allow a GafaelfawrIngress to specify that it is anonymous.  In this case, most of the configuration is not allowed, but Gafaelfawr is still configured as the auth-uri so that it can strip tokens and cookies from the Authorization and Cookie headers.  Add a new route, /auth/anonymous, that does only this stripping.

Also diagnose a GafaelfawrIngress that requests a basic authentication challenge but also wants an auth redirect, since those are mutually incompatible.