### PR TITLE
DM-37291: Document authType, change tox cache

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -118,6 +118,7 @@ jobs:
           python-version: ${{ matrix.python }}
           tox-envs: "typing,py-full,coverage-report"
           tox-plugins: tox-docker
+          cache-key-prefix: "test"
 
   docs:
     runs-on: ubuntu-latest
@@ -140,6 +141,7 @@ jobs:
         with:
           python-version: "3.10"
           tox-envs: "docs,docs-linkcheck"
+          cache-key-prefix: "docs"
 
       # Only attempt documentation uploads for long-lived branches, tagged
       # releases, and pull requests from ticket branches.  This avoids version

--- a/docs/user-guide/gafaelfawringress.rst
+++ b/docs/user-guide/gafaelfawringress.rst
@@ -87,6 +87,21 @@ If you want unauthorized users to be redirected to the login page instead, use t
 
 This setting should be used for services that are accessed interactively from a web browser.
 
+Changing the challenge type
+===========================
+
+When presenting an authentication challenge (a 401 response) instead of redirecting the user to the login page, the default is to request a bearer token (:rfc:`6750`).
+In some cases, you may want Gafaelfawr to request Basic authentication (:rfc:`7617`) instead.
+Do this with the ``config.authType`` parameter:
+
+.. code-block:: yaml
+
+   config:
+     authType: basic
+
+This will normally cause the browser to pop up a request for username and password.
+This setting cannot be used with ``config.loginRedirect``; Gafaelfawr can either redirect the user or present a challenge, but not both.
+
 .. _delegated-tokens:
 
 Requesting delegated tokens

--- a/docs/user-guide/manual-ingress.rst
+++ b/docs/user-guide/manual-ingress.rst
@@ -115,6 +115,7 @@ Configuring authentication
 ==========================
 
 The URL in the ``nginx.ingress.kubernetes.io/auth-url`` annotation accepts several parameters to customize the authentication request.
+Most but not all of these are discussed above.
 
 ``scope`` (required)
     The scope claim that the client JWT must have.


### PR DESCRIPTION
- Document how to request a basic auth challenge
- Use separate tox caches for docs and test to reduce download and upload sizes