### PR TITLE
DM-37470: Accept tokens in either field of Basic Auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ Versioning follows [semver](https://semver.org/). Versioning assumes that Gafael
 
 Dependencies are updated to the latest available version during each release. Those changes are not noted here explicitly.
 
+## 8.1.0 (unreleased)
+
+### New features
+
+- Gafaelfawr now accepts tokens in either the username or password portion of HTTP Basic Auth without requiring the other field be ``x-oath-basic``. If both components are tokens, they must match; if they do not, Gafaelfawr raises an error.
+
 ## 8.0.0 (2022-12-16)
 
 ### Backwards-incompatible changes

--- a/docs/user-guide/ingress-overview.rst
+++ b/docs/user-guide/ingress-overview.rst
@@ -10,7 +10,9 @@ This is done via annotations added to the Kubernetes ``Ingress`` resource that a
 For each HTTP request to a protected service, NGINX will send a request to the Gafaelfawr ``/auth`` route with the headers of the incoming request (including, for example, any cookies or ``Authorization`` header).
 Gafaelfawr, when receiving that request, will find the user's authentication token, check that it is valid, and check that the user has the required scope.
 
-If the user is not authenticated, it will either return a 401 error with an appropriate ``WWW-Authenticate`` challenge, or a redirect to the sign-in URL, depending on Gafaelfawr's configuration.
+The user may authenticate with a cookie (set by Gafaelfawr by the ``/login`` route), with a bearer token in the ``Authorization`` header, or with a token in either the username or password field of an HTTP Basic Auth ``Authorization`` header.
+
+If the user is not authenticated, Gafaelfawr will either return a 401 error with an appropriate ``WWW-Authenticate`` challenge, or a redirect to the sign-in URL, depending on its configuration.
 The sign-in URL would then send the user to CILogon, an OpenID Connect server, or GitHub to authenticate.
 
 If the user is already authenticated but does not have the desired scope, Gafaelfawr will return a 403 error, which will be passed back to the user.


### PR DESCRIPTION
Rather than requiring the user use an x-oath-basic placeholder in the other field, take advantage of the fact that our tokens have a well-known format and accept tokens in either the username or the password field.  If both fields are tokens, they must match.

The original design was based on an earlier iteration of how GitHub handled Basic Auth, but GitHub now supports putting the token in either field without any special marking, which seems more convenient and easier to explain.