### PR TITLE
DM-37833: Support camel-case in configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ Versioning follows [semver](https://semver.org/). Versioning assumes that Gafael
 
 Dependencies are updated to the latest available version during each release. Those changes are not noted here explicitly.
 
+## 9.0.1 (unreleased)
+
+### Other changes
+
+- Gafaelfawr now supports camel-case in its configuration file to allow using the same names for most configuration settings and Helm chart values.
+
 ## 9.0.0 (2023-01-09)
 
 ### Backwards-incompatible changes

--- a/examples/docker/gafaelfawr.yaml
+++ b/examples/docker/gafaelfawr.yaml
@@ -13,56 +13,59 @@
 
 realm: "localhost"
 loglevel: "DEBUG"
-session_secret_file: "/run/secrets/session-secret"
-database_url: "postgresql://gafaelfawr:INSECURE@postgresql/gafaelfawr"
-bootstrap_token_file: "/run/secrets/bootstrap-token"
+sessionSecretFile: "/run/secrets/session-secret"
+databaseUrl: "postgresql://gafaelfawr:INSECURE@postgresql/gafaelfawr"
+bootstrapTokenFile: "/run/secrets/bootstrap-token"
 
 # This Redis will be started by the docker-compose.yaml file at the top
 # level of the repository.
-redis_url: "redis://redis:6379/0"
-redis_password_file: "/run/secrets/redis-password"
+redisUrl: "redis://redis:6379/0"
+redisPasswordFile: "/run/secrets/redis-password"
 
 # How long Gafaelfawr-issued tokens should live by default.
-token_lifetime_minutes: 1440 # 1 day
+tokenLifetimeMinutes: 1440 # 1 day
 
 # Where to send the user after logging out.
-after_logout_url: "http://localhost:8080"
+afterLogoutUrl: "http://localhost:8080"
 
 # To get these values, go to Settings > Developer Settings for either a
 # GitHub user or an organization, go into OAuth Apps, and create a new
 # application.  Set the homepage URL to http://localhost:8080/ and the
 # authorization callback URL to http://localhost:8080/login.
 github:
-  client_id: "<github-client-id>"
-  client_secret_file: "/run/secrets/github-client-secret"
+  clientId: "<github-client-id>"
+  clientSecretFile: "/run/secrets/github-client-secret"
 
 # Configuration for the Gafaelfawr OpenID Connect server.
 oidc_server:
   issuer: "http://localhost:8080"
-  key_id: "localhost-key-id"
+  keyId: "localhost-key-id"
   audience: "http://localhost"
-  key_file: "/run/secrets/issuer-key"
-  secrets_file: "/run/secrets/oidc-clients.json"
+  keyFile: "/run/secrets/issuer-key"
+  secretsFile: "/run/secrets/oidc-clients.json"
 
 # Replace this user with your GitHub username.
-initial_admins:
+initialAdmins:
   - "example"
 
 # Sample values.  You can replace these with anything you want to use
 # for a scope.
-known_scopes:
+knownScopes:
   "admin": "Administrative access"
   "admin:token": "Can create and modify tokens for any user"
   "read:all": "Can read anything"
   "user:token": "Can create and modify user tokens"
 
-# To get scopes based on GitHub team membership, replace <org> with the
-# name of the GitHub organization and <team> with the name of the team
-# in that organization.  (This may be truncated for long names; see the
-# manual.)  Members of that team will then get the scope listed on the
+# To get scopes based on GitHub team membership, replace <org> with the name
+# of the GitHub organization and <team> with the name of the team in that
+# organization.  Members of that team will then get the scope listed on the
 # left.  Add as many entries as you'd like.
 group_mapping:
   "admin":
-    - "<org>-<team>"
+    - github:
+        organization: "<org>"
+        team: "<team>"
   "read:all":
-    - "<org>-<other-team>"
+    - github:
+        organization: "<org>"
+        team: "<other-team>"

--- a/examples/gafaelfawr-dev.yaml
+++ b/examples/gafaelfawr-dev.yaml
@@ -13,59 +13,62 @@
 
 realm: "localhost"
 loglevel: "DEBUG"
-session_secret_file: "examples/secrets/session-secret"
-database_url: "postgresql://gafaelfawr:INSECURE@localhost/gafaelfawr"
+sessionSecretFile: "examples/secrets/session-secret"
+databaseUrl: "postgresql://gafaelfawr:INSECURE@localhost/gafaelfawr"
 
 # This Redis will be started by the docker-compose.yaml file at the top
 # level of the repository.
-redis_url: "redis://localhost:6379/0"
-redis_password_file: "examples/secrets/redis-password"
+redisUrl: "redis://localhost:6379/0"
+redisPasswordFile: "examples/secrets/redis-password"
 
 # WARNING: This is public and entirely insecure.  Use only for local
 # development not accessible to the Internet.
-bootstrap_token_file: "examples/secrets/bootstrap-token"
+bootstrapTokenFile: "examples/secrets/bootstrap-token"
 
 # How long Gafaelfawr-issued tokens should live by default.
-token_lifetime_minutes: 1440 # 1 day
+tokenLifetimeMinutes: 1440 # 1 day
 
 # Where to send the user after logging out.
-after_logout_url: "http://localhost:8080"
+afterLogoutUrl: "http://localhost:8080"
 
 # To get these values, go to Settings > Developer Settings for either a
 # GitHub user or an organization, go into OAuth Apps, and create a new
 # application.  Set the homepage URL to http://localhost:8080/ and the
 # authorization callback URL to http://localhost:8080/login.
 github:
-  client_id: "<github-client-id>"
-  client_secret_file: "examples/secrets/github-client-secret"
+  clientId: "<github-client-id>"
+  clientSecretFile: "examples/secrets/github-client-secret"
 
 # Configuration for the Gafaelfawr OpenID Connect server.
-oidc_server:
+oidcServer:
   issuer: "http://localhost:8080"
-  key_id: "localhost-key-id"
+  keyId: "localhost-key-id"
   audience: "http://localhost"
-  key_file: "examples/secrets/issuer-key"
-  secrets_file: "examples/secrets/oidc-clients.json"
+  keyFile: "examples/secrets/issuer-key"
+  secretsFile: "examples/secrets/oidc-clients.json"
 
 # Replace this user with your GitHub username.
-initial_admins:
+initialAdmins:
   - "example"
 
 # Sample values.  You can replace these with anything you want to use
 # for a scope.
-known_scopes:
+knownScopes:
   "admin": "Administrative access"
   "admin:token": "Can create and modify tokens for any user"
   "read:all": "Can read anything"
   "user:token": "Can create and modify user tokens"
 
-# To get scopes based on GitHub team membership, replace <org> with the
-# name of the GitHub organization and <team> with the name of the team
-# in that organization.  (This may be truncated for long names; see the
-# manual.)  Members of that team will then get the scope listed on the
+# To get scopes based on GitHub team membership, replace <org> with the name
+# of the GitHub organization and <team> with the name of the team in that
+# organization.  Members of that team will then get the scope listed on the
 # left.  Add as many entries as you'd like.
-group_mapping:
+groupMapping:
   "admin":
-    - "<org>-<team>"
+    - github:
+        organization: "<org>"
+        team: "<team>"
   "read:all":
-    - "<org>-<other-team>"
+    - github:
+        organization: "<org>"
+        team: "<other-team>"

--- a/examples/gafaelfawr-github.yaml
+++ b/examples/gafaelfawr-github.yaml
@@ -12,11 +12,11 @@
 realm: "example.com"
 
 # File contents should be the result of gafaelfawr generate-session-secret.
-session_secret_file: "/path/to/session-secret"
+sessionSecretFile: "/path/to/session-secret"
 
 # The URL of and password for a Redis instance used for storing sessions.
-redis_url: "redis://redis.example.com:6379/0"
-redis_password_file: "/path/to/redis-password"
+redisUrl: "redis://redis.example.com:6379/0"
+redisPasswordFile: "/path/to/redis-password"
 
 # Replace <password> with the database password and example.com with the
 # hostname of the PostgreSQL database.  In environments where the
@@ -24,13 +24,13 @@ redis_password_file: "/path/to/redis-password"
 # Kubernetes ConfigMap), use the GAFAELFAWR_DATABASE_URL environment
 # variable to set this parameter and don't include it in the settings
 # file.
-database_url: "postgresql://gafaelfawr:<password>@example.com/gafaelfawr"
+databaseUrl: "postgresql://gafaelfawr:<password>@example.com/gafaelfawr"
 
 # File contents should be a token generated via gafaelfawr generate-token.
-bootstrap_token_file: "/path/to/bootstrap-token"
+bootstrapTokenFile: "/path/to/bootstrap-token"
 
 # How long Gafaelfawr-issued tokens should live by default.
-token_lifetime_minutes: 1440 # 1 day
+tokenLifetimeMinutes: 1440 # 1 day
 
 # The IP address ranges used internally in the Kubernetes cluster.  Used
 # to determine the external IP address for logging purposes.
@@ -38,23 +38,23 @@ proxies:
   - "10.0.0.0/8"
 
 # Where to send the user after logging out.
-after_logout_url: "https://example.com/"
+afterLogoutUrl: "https://example.com/"
 
 # To get these values, go to Settings > Developer Settings for either a
 # GitHub user or an organization, go into OAuth Apps, and create a new
 # application.
 github:
-  client_id: "<github-client-id>"
-  client_secret_file: "/path/to/github-client-secret"
+  clientId: "<github-client-id>"
+  clientSecretFile: "/path/to/github-client-secret"
 
 # Replace this with a list of users who should have admin rights when
 # bootstrapping a fresh database.
-initial_admins:
+initialAdmins:
   - "example"
 
 # Sample values for scopes.  You can replace these with anything you want
 # to use for a scope.  Used to populate the new token creation page.
-known_scopes:
+knownScopes:
   "admin": "Administrative access"
   "admin:token": "Can create and modify tokens for any user"
   "read:all": "Can read anything"
@@ -65,13 +65,16 @@ known_scopes:
 # With an OpenID Connect provider, the groups will be taken from an
 # isMemberOf claim in the token returned by that provider.
 #
-# To get scopes based on GitHub team membership, replace <org> with the
-# name of the GitHub organization and <team> with the name of the team in
-# that organization.  (This may be truncated for long names; see the
-# manual.)  Members of that team will then get the scope listed on the
+# To get scopes based on GitHub team membership, replace <org> with the name
+# of the GitHub organization and <team> with the name of the team in that
+# organization.  Members of that team will then get the scope listed on the
 # left.  Add as many entries as you'd like.
 group_mapping:
   "admin":
-    - "<org>-<team>"
+    - github:
+        organization: "<org>"
+        team: "<team>"
   "read:all":
-    - "<org>-<other-team>"
+    - github:
+        organization: "<org>"
+        team: "<other-team>"

--- a/examples/gafaelfawr-oidc.yaml
+++ b/examples/gafaelfawr-oidc.yaml
@@ -12,11 +12,11 @@
 realm: "example.com"
 
 # File contents should be the result of gafaelfawr generate-session-secret.
-session_secret_file: "/path/to/session-secret"
+sessionSecretFile: "/path/to/session-secret"
 
 # The URL of and password for a Redis instance used for storing sessions.
-redis_url: "redis://redis.example.com:6379/0"
-redis_password_file: "/path/to/redis-password"
+redisUrl: "redis://redis.example.com:6379/0"
+redisPasswordFile: "/path/to/redis-password"
 
 # Replace <password> with the database password and example.com with the
 # hostname of the PostgreSQL database.  In environments where the
@@ -24,13 +24,13 @@ redis_password_file: "/path/to/redis-password"
 # Kubernetes ConfigMap), use the GAFAELFAWR_DATABASE_URL environment
 # variable to set this parameter and don't include it in the settings
 # file.
-database_url: "postgresql://gafaelfawr:<password>@example.com/gafaelfawr"
+databaseUrl: "postgresql://gafaelfawr:<password>@example.com/gafaelfawr"
 
 # File contents should be a token generated via gafaelfawr generate-token.
-bootstrap_token_file: "/path/to/bootstrap-token"
+bootstrapTokenFile: "/path/to/bootstrap-token"
 
 # How long Gafaelfawr-issued tokens should live by default.
-token_lifetime_minutes: 1440 # 1 day
+tokenLifetimeMinutes: 1440 # 1 day
 
 # The IP address ranges used internally in the Kubernetes cluster.  Used
 # to determine the external IP address for logging purposes.
@@ -38,17 +38,17 @@ proxies:
   - "10.0.0.0/8"
 
 # Where to send the user after logging out.
-after_logout_url: "https://example.com/"
+afterLogoutUrl: "https://example.com/"
 
 # To get these values, register with an OpenID Connect provider and use
 # the values that they provide.  This example is for CILogon; many of the
 # values will need to be different for another provider.
 oidc:
-  client_id: "cilogon:/client_id/..."
-  client_secret_file: "/path/to/oidc-client-secret"
-  login_url: "https://cilogon.org/authorize"
-  redirect_url: "https://example.com/login"
-  token_url: "https://cilogon.org/oauth2/token"
+  clientId: "cilogon:/client_id/..."
+  clientSecretFile: "/path/to/oidc-client-secret"
+  loginUrl: "https://cilogon.org/authorize"
+  redirectUrl: "https://example.com/login"
+  tokenUrl: "https://cilogon.org/oauth2/token"
   scopes:
     - "email"
     - "org.cilogon.userinfo"
@@ -57,12 +57,12 @@ oidc:
 
 # Replace this with a list of users who should have admin rights when
 # bootstrapping a fresh database.
-initial_admins:
+initialAdmins:
   - "example"
 
 # Sample values for scopes.  You can replace these with anything you want
 # to use for a scope.  Used to populate the new token creation page.
-known_scopes:
+knownScopes:
   "admin": "Administrative access"
   "admin:token": "Can create and modify tokens for any user"
   "read:all": "Can read anything"
@@ -72,14 +72,8 @@ known_scopes:
 #
 # With an OpenID Connect provider, the groups will be taken from an
 # isMemberOf claim in the token returned by that provider.
-#
-# To get scopes based on GitHub team membership, replace <org> with the
-# name of the GitHub organization and <team> with the name of the team in
-# that organization.  (This may be truncated for long names; see the
-# manual.)  Members of that team will then get the scope listed on the
-# left.  Add as many entries as you'd like.
-group_mapping:
+groupMapping:
   "admin":
-    - "<org>-<team>"
+    - "<group>"
   "read:all":
-    - "<org>-<other-team>"
+    - "<other-group>"

--- a/src/gafaelfawr/config.py
+++ b/src/gafaelfawr/config.py
@@ -21,15 +21,9 @@ from pathlib import Path
 from typing import Any, Optional
 
 import yaml
-from pydantic import (
-    AnyHttpUrl,
-    BaseModel,
-    BaseSettings,
-    IPvAnyNetwork,
-    validator,
-)
+from pydantic import AnyHttpUrl, IPvAnyNetwork, validator
 from safir.logging import configure_logging
-from safir.pydantic import validate_exactly_one_of
+from safir.pydantic import CamelCaseModel, validate_exactly_one_of
 
 from .constants import SCOPE_REGEX, USERNAME_REGEX
 from .keypair import RSAKeyPair
@@ -53,7 +47,7 @@ __all__ = [
 ]
 
 
-class GitHubSettings(BaseModel):
+class GitHubSettings(CamelCaseModel):
     """pydantic model of GitHub configuration."""
 
     client_id: str
@@ -63,7 +57,7 @@ class GitHubSettings(BaseModel):
     """File containing secret for the GitHub App."""
 
 
-class OIDCSettings(BaseModel):
+class OIDCSettings(CamelCaseModel):
     """pydantic model of OpenID Connect configuration."""
 
     client_id: str
@@ -121,7 +115,7 @@ class OIDCSettings(BaseModel):
     """Name of claim to use for the group membership."""
 
 
-class LDAPSettings(BaseModel):
+class LDAPSettings(CamelCaseModel):
     """pydantic model of LDAP configuration."""
 
     url: str
@@ -218,14 +212,14 @@ class LDAPSettings(BaseModel):
     """
 
 
-class FirestoreSettings(BaseModel):
+class FirestoreSettings(CamelCaseModel):
     """pydantic model of Firestore configuration."""
 
     project: str
     """Project containing the Firestore collections."""
 
 
-class OIDCServerSettings(BaseModel):
+class OIDCServerSettings(CamelCaseModel):
     """pydantic model of issuer configuration."""
 
     issuer: str
@@ -244,7 +238,7 @@ class OIDCServerSettings(BaseModel):
     """Path to file containing OpenID Connect client secrets in JSON."""
 
 
-class Settings(BaseSettings):
+class Settings(CamelCaseModel):
     """pydantic model of Gafaelfawr configuration file.
 
     This describes the configuration file as parsed from disk.  This model
@@ -420,7 +414,7 @@ class Settings(BaseSettings):
     )
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class GitHubConfig:
     """Metadata for GitHub authentication.
 
@@ -436,7 +430,7 @@ class GitHubConfig:
     """Secret for the GitHub App."""
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class OIDCConfig:
     """Configuration for OpenID Connect authentication."""
 
@@ -495,7 +489,7 @@ class OIDCConfig:
     """Token claim from which to take the group membership."""
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class LDAPConfig:
     """Configuration for LDAP support.
 
@@ -597,7 +591,7 @@ class LDAPConfig:
     """
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class FirestoreConfig:
     """Configuration for Firestore-based UID/GID assignment."""
 
@@ -605,7 +599,7 @@ class FirestoreConfig:
     """Project containing the Firestore collections."""
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class OIDCClient:
     """Configuration for a single OpenID Connect client of our server."""
 
@@ -616,7 +610,7 @@ class OIDCClient:
     """Secret used to authenticate this client."""
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class OIDCServerConfig:
     """Configuration for the OpenID Connect server."""
 
@@ -639,7 +633,7 @@ class OIDCServerConfig:
     """Supported OpenID Connect clients."""
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class Config:
     """Configuration for Gafaelfawr.
 

--- a/tests/data/config/bad-admin.yaml
+++ b/tests/data/config/bad-admin.yaml
@@ -1,18 +1,18 @@
 # Bad configuration file with invalid admin.
 
 realm: "testing"
-session_secret_file: "{session_secret_file}"
-database_url: "postgresql://gafaelfawr:INSECURE-PASSWORD@localhost/gafaelfawr"
-initial_admins: ["admin", "weird:admin"]
-redis_url: "dummy"
-after_logout_url: "https://example.com/landing"
-group_mapping:
+sessionSecretFile: "{session_secret_file}"
+databaseUrl: "postgresql://gafaelfawr:INSECURE-PASSWORD@localhost/gafaelfawr"
+initialAdmins: ["admin", "weird:admin"]
+redisUrl: "redis://localhost:6379/0"
+afterLogoutUrl: "https://example.com/landing"
+groupMapping:
   "exec:admin": ["admin"]
   "exec:test": ["test"]
   "read:all": ["foo", "admin", "org-a-team"]
-known_scopes:
+knownScopes:
   "admin:token": "Can create and modify tokens for any user"
   "user:token": "Can create and modify user tokens"
 github:
-  client_id: "some-github-client-id"
-  client_secret_file: "{github_secret_file}"
+  clientId: "some-github-client-id"
+  clientSecretFile: "{github_secret_file}"

--- a/tests/data/config/bad-loglevel.yaml
+++ b/tests/data/config/bad-loglevel.yaml
@@ -2,21 +2,21 @@
 
 realm: "testing"
 loglevel: "INVALID"
-session_secret_file: "{session_secret_file}"
-database_url: "postgresql://gafaelfawr:INSECURE-PASSWORD@localhost/gafaelfawr"
-initial_admins: ["admin"]
-redis_url: "dummy"
-after_logout_url: "https://example.com/landing"
-group_mapping:
+sessionSecretFile: "{session_secret_file}"
+databaseUrl: "postgresql://gafaelfawr:INSECURE-PASSWORD@localhost/gafaelfawr"
+initialAdmins: ["admin"]
+redisUrl: "redis://localhost:6379/0"
+afterLogoutUrl: "https://example.com/landing"
+groupMapping:
   "exec:admin": ["admin"]
   "exec:test": ["test"]
   "read:all": ["foo", "admin", "org-a-team"]
-known_scopes:
+knownScopes:
   "admin:token": "Can create and modify tokens for any user"
   "exec:admin": "admin description"
   "exec:test": "test description"
   "read:all": "can read everything"
   "user:token": "Can create and modify user tokens"
 github:
-  client_id: "some-github-client-id"
-  client_secret_file: "{github_secret_file}"
+  clientId: "some-github-client-id"
+  clientSecretFile: "{github_secret_file}"

--- a/tests/data/config/bad-scope.yaml
+++ b/tests/data/config/bad-scope.yaml
@@ -1,19 +1,19 @@
 # Bad configuration file with invalid scope.
 
 realm: "testing"
-session_secret_file: "{session_secret_file}"
-database_url: "postgresql://gafaelfawr:INSECURE-PASSWORD@localhost/gafaelfawr"
-initial_admins: ["admin"]
-redis_url: "dummy"
-after_logout_url: "https://example.com/landing"
-group_mapping:
+sessionSecretFile: "{session_secret_file}"
+databaseUrl: "postgresql://gafaelfawr:INSECURE-PASSWORD@localhost/gafaelfawr"
+initialAdmins: ["admin"]
+redisUrl: "redis://localhost:6379/0"
+afterLogoutUrl: "https://example.com/landing"
+groupMapping:
   "exec:admin": ["admin"]
   "exec:test": ["test"]
   "read:all": ["foo", "admin", "org-a-team"]
-known_scopes:
+knownScopes:
   "admin:token": "Can create and modify tokens for any user"
   "user:token": "Can create and modify user tokens"
   "foo bar": "An invalid scope"
 github:
-  client_id: "some-github-client-id"
-  client_secret_file: "{github_secret_file}"
+  clientId: "some-github-client-id"
+  clientSecretFile: "{github_secret_file}"

--- a/tests/data/config/bad-token.yaml.in
+++ b/tests/data/config/bad-token.yaml.in
@@ -2,21 +2,21 @@
 
 realm: "testing"
 loglevel: "INFO"
-session_secret_file: "{session_secret_file}"
-database_url: "postgresql://gafaelfawr:INSECURE-PASSWORD@localhost/gafaelfawr"
-initial_admins: ["admin"]
-redis_url: "dummy"
-after_logout_url: "https://example.com/landing"
-group_mapping:
+sessionSecretFile: "{session_secret_file}"
+databaseUrl: "postgresql://gafaelfawr:INSECURE-PASSWORD@localhost/gafaelfawr"
+initialAdmins: ["admin"]
+redisUrl: "redis://localhost:6379/0"
+afterLogoutUrl: "https://example.com/landing"
+groupMapping:
   "exec:admin": ["admin"]
   "exec:test": ["test"]
   "read:all": ["foo", "admin", "org-a-team"]
-known_scopes:
+knownScopes:
   "admin:token": "Can create and modify tokens for any user"
   "exec:admin": "admin description"
   "exec:test": "test description"
   "read:all": "can read everything"
   "user:token": "Can create and modify user tokens"
 github:
-  client_id: "some-github-client-id"
-  client_secret_file: "{github_secret_file}"
+  clientId: "some-github-client-id"
+  clientSecretFile: "{github_secret_file}"

--- a/tests/data/config/both-providers.yaml
+++ b/tests/data/config/both-providers.yaml
@@ -1,30 +1,30 @@
 realm: "testing"
-session_secret_file: "{session_secret_file}"
-database_url: "postgresql://gafaelfawr:INSECURE-PASSWORD@localhost/gafaelfawr"
-initial_admins: ["admin"]
-redis_url: "dummy"
-after_logout_url: "https://example.com/landing"
-group_mapping:
+sessionSecretFile: "{session_secret_file}"
+databaseUrl: "postgresql://gafaelfawr:INSECURE-PASSWORD@localhost/gafaelfawr"
+initialAdmins: ["admin"]
+redisUrl: "redis://localhost:6379/0"
+afterLogoutUrl: "https://example.com/landing"
+groupMapping:
   "exec:admin": ["admin"]
   "exec:test": ["test"]
   "read:all": ["foo", "admin", "org-a-team"]
-known_scopes:
+knownScopes:
   "admin:token": "Can create and modify tokens for any user"
   "exec:admin": "admin description"
   "exec:test": "test description"
   "read:all": "can read everything"
   "user:token": "Can create and modify user tokens"
 github:
-  client_id: "some-github-client-id"
-  client_secret_file: "{github_secret_file}"
+  clientId: "some-github-client-id"
+  clientSecretFile: "{github_secret_file}"
 oidc:
-  client_id: "some-oidc-client-id"
-  client_secret_file: "{oidc_secret_file}"
-  login_url: "https://example.com/oidc/login"
-  login_params:
+  clientId: "some-oidc-client-id"
+  clientSecretFile: "{oidc_secret_file}"
+  loginUrl: "https://example.com/oidc/login"
+  loginParams:
     skin: "test"
-  redirect_url: "https://example.com/login"
-  token_url: "https://example.com/token"
+  redirectUrl: "https://example.com/login"
+  tokenUrl: "https://example.com/token"
   scopes:
     - "email"
     - "voPerson"

--- a/tests/data/config/github-oidc-server.yaml.in
+++ b/tests/data/config/github-oidc-server.yaml.in
@@ -1,31 +1,31 @@
 realm: "example.com"
-session_secret_file: "{session_secret_file}"
-database_url: "{database_url}"
-redis_url: "redis://localhost:6379/0"
-bootstrap_token_file: "{bootstrap_token_file}"
-initial_admins: ["admin"]
+sessionSecretFile: "{session_secret_file}"
+databaseUrl: "{database_url}"
+redisUrl: "redis://localhost:6379/0"
+bootstrapTokenFile: "{bootstrap_token_file}"
+initialAdmins: ["admin"]
 proxies:
   - "10.0.0.0/8"
-after_logout_url: "https://example.com/landing"
-group_mapping:
+afterLogoutUrl: "https://example.com/landing"
+groupMapping:
   "exec:admin": ["admin"]
   "exec:test": ["test"]
   "read:all": ["foo", "admin", "org-a-team"]
-known_scopes:
+knownScopes:
   "admin:token": "token administration"
   "exec:admin": "admin description"
   "exec:test": "test description"
   "read:all": "can read everything"
   "read:some": "can read some things"
   "user:token": "Can create and modify user tokens"
-oidc_server:
+oidcServer:
   issuer: "https://test.example.com/"
-  key_id: "some-kid"
-  key_file: "{issuer_key_file}"
+  keyId: "some-kid"
+  keyFile: "{issuer_key_file}"
   audience: "https://example.com/"
-  secrets_file: "{oidc_server_secrets_file}"
+  secretsFile: "{oidc_server_secrets_file}"
 github:
-  client_id: "some-github-client-id"
-  client_secret_file: "{github_secret_file}"
-error_footer: |
+  clientId: "some-github-client-id"
+  clientSecretFile: "{github_secret_file}"
+errorFooter: |
   Some <strong>error instructions</strong> with HTML.

--- a/tests/data/config/github.yaml.in
+++ b/tests/data/config/github.yaml.in
@@ -1,14 +1,14 @@
 realm: "example.com"
-session_secret_file: "{session_secret_file}"
-database_url: "{database_url}"
-redis_url: "redis://localhost:6379/0"
-bootstrap_token_file: "{bootstrap_token_file}"
-slack_webhook_file: "{slack_webhook_file}"
-initial_admins: ["admin"]
+sessionSecretFile: "{session_secret_file}"
+databaseUrl: "{database_url}"
+redisUrl: "redis://localhost:6379/0"
+bootstrapTokenFile: "{bootstrap_token_file}"
+slackWebhookFile: "{slack_webhook_file}"
+initialAdmins: ["admin"]
 proxies:
   - "10.0.0.0/8"
-after_logout_url: "https://example.com/landing"
-group_mapping:
+afterLogoutUrl: "https://example.com/landing"
+groupMapping:
   "exec:admin": ["admin"]
   "exec:test":
     - "test"
@@ -21,7 +21,7 @@ group_mapping:
     - github:
         organization: "org"
         team: "a-team"
-known_scopes:
+knownScopes:
   "admin:token": "token administration"
   "exec:admin": "admin description"
   "exec:test": "test description"
@@ -29,7 +29,7 @@ known_scopes:
   "read:some": "can read some things"
   "user:token": "Can create and modify user tokens"
 github:
-  client_id: "some-github-client-id"
-  client_secret_file: "{github_secret_file}"
-error_footer: |
+  clientId: "some-github-client-id"
+  clientSecretFile: "{github_secret_file}"
+errorFooter: |
   Some <strong>error instructions</strong> with HTML.

--- a/tests/data/config/missing-scope.yaml
+++ b/tests/data/config/missing-scope.yaml
@@ -1,17 +1,17 @@
 # Bad configuration file with missing required scope user:token.
 
 realm: "testing"
-session_secret_file: "{session_secret_file}"
-database_url: "postgresql://gafaelfawr:INSECURE-PASSWORD@localhost/gafaelfawr"
-initial_admins: ["admin"]
-redis_url: "dummy"
-after_logout_url: "https://example.com/landing"
-group_mapping:
+sessionSecretFile: "{session_secret_file}"
+databaseUrl: "postgresql://gafaelfawr:INSECURE-PASSWORD@localhost/gafaelfawr"
+initialAdmins: ["admin"]
+redisUrl: "redis://localhost:6379/0"
+afterLogoutUrl: "https://example.com/landing"
+groupMapping:
   "exec:admin": ["admin"]
   "exec:test": ["test"]
   "read:all": ["foo", "admin", "org-a-team"]
-known_scopes:
+knownScopes:
   "admin:token": "Can create and modify tokens for any user"
 github:
-  client_id: "some-github-client-id"
-  client_secret_file: "{github_secret_file}"
+  clientId: "some-github-client-id"
+  clientSecretFile: "{github_secret_file}"

--- a/tests/data/config/no-provider.yaml
+++ b/tests/data/config/no-provider.yaml
@@ -1,16 +1,16 @@
 # Bad configuration file with no authentication provider section.
 
 realm: "testing"
-session_secret_file: "/dummy"
-database_url: "postgresql://gafaelfawr:INSECURE-PASSWORD@localhost/gafaelfawr"
-initial_admins: ["admin"]
-redis_url: "dummy"
-after_logout_url: "https://example.com/landing"
-group_mapping:
+sessionSecretFile: "/dummy"
+databaseUrl: "postgresql://gafaelfawr:INSECURE-PASSWORD@localhost/gafaelfawr"
+initialAdmins: ["admin"]
+redisUrl: "redis://localhost:6379/0"
+afterLogoutUrl: "https://example.com/landing"
+groupMapping:
   "exec:admin": ["admin"]
   "exec:test": ["test"]
   "read:all": ["foo", "admin", "org-a-team"]
-known_scopes:
+knownScopes:
   "admin:token": "Can create and modify tokens for any user"
   "exec:admin": "admin description"
   "exec:test": "test description"

--- a/tests/data/config/oidc-claims.yaml.in
+++ b/tests/data/config/oidc-claims.yaml.in
@@ -1,34 +1,34 @@
 realm: "example.com"
-session_secret_file: "{session_secret_file}"
-database_url: "{database_url}"
-redis_url: "redis://localhost:6379/0"
-initial_admins: ["admin"]
-after_logout_url: "https://example.com/landing"
-group_mapping:
+sessionSecretFile: "{session_secret_file}"
+databaseUrl: "{database_url}"
+redisUrl: "redis://localhost:6379/0"
+initialAdmins: ["admin"]
+afterLogoutUrl: "https://example.com/landing"
+groupMapping:
   "exec:admin": ["admin"]
   "exec:test": ["test"]
   "read:all": ["foo", "admin", "org-a-team"]
-known_scopes:
+knownScopes:
   "admin:token": "Can create and modify tokens for any user"
   "exec:admin": "admin description"
   "exec:test": "test description"
   "read:all": "can read everything"
   "user:token": "Can create and modify user tokens"
 oidc:
-  client_id: "some-oidc-client-id"
-  client_secret_file: "{oidc_secret_file}"
-  login_url: "https://upstream.example.com/oidc/login"
-  login_params:
+  clientId: "some-oidc-client-id"
+  clientSecretFile: "{oidc_secret_file}"
+  loginUrl: "https://upstream.example.com/oidc/login"
+  loginParams:
     skin: "test"
-  redirect_url: "https://upstream.example.com/login"
-  token_url: "https://upstream.example.com/token"
+  redirectUrl: "https://upstream.example.com/login"
+  tokenUrl: "https://upstream.example.com/token"
   scopes:
     - "email"
     - "voPerson"
   issuer: "https://upstream.example.com/"
   audience: "https://test.example.com/"
-  username_claim: "username"
-  uid_claim: "numeric_uid"
-  groups_claim: "group_membership"
-error_footer: |
+  usernameClaim: "username"
+  uidClaim: "numeric_uid"
+  groupsClaim: "group_membership"
+errorFooter: |
   Some <strong>error instructions</strong> with HTML.

--- a/tests/data/config/oidc-enrollment.yaml.in
+++ b/tests/data/config/oidc-enrollment.yaml.in
@@ -1,31 +1,31 @@
 realm: "example.com"
-session_secret_file: "{session_secret_file}"
-database_url: "{database_url}"
-redis_url: "redis://localhost:6379/0"
-initial_admins: ["admin"]
-after_logout_url: "https://example.com/landing"
-group_mapping:
+sessionSecretFile: "{session_secret_file}"
+databaseUrl: "{database_url}"
+redisUrl: "redis://localhost:6379/0"
+initialAdmins: ["admin"]
+afterLogoutUrl: "https://example.com/landing"
+groupMapping:
   "exec:admin": ["admin"]
   "exec:test": ["test"]
   "read:all": ["foo", "admin", "org-a-team"]
-known_scopes:
+knownScopes:
   "admin:token": "Can create and modify tokens for any user"
   "exec:admin": "admin description"
   "exec:test": "test description"
   "read:all": "can read everything"
   "user:token": "Can create and modify user tokens"
 oidc:
-  client_id: "some-oidc-client-id"
-  client_secret_file: "{oidc_secret_file}"
-  login_url: "https://upstream.example.com/oidc/login"
-  login_params:
+  clientId: "some-oidc-client-id"
+  clientSecretFile: "{oidc_secret_file}"
+  loginUrl: "https://upstream.example.com/oidc/login"
+  loginParams:
     skin: "test"
-  redirect_url: "https://upstream.example.com/login"
-  token_url: "https://upstream.example.com/token"
-  enrollment_url: "https://upstream.example.com/enroll"
+  redirectUrl: "https://upstream.example.com/login"
+  tokenUrl: "https://upstream.example.com/token"
+  enrollmentUrl: "https://upstream.example.com/enroll"
   scopes:
     - "email"
     - "voPerson"
   issuer: "https://upstream.example.com/"
   audience: "https://test.example.com/"
-  username_claim: "username"
+  usernameClaim: "username"

--- a/tests/data/config/oidc-firestore.yaml.in
+++ b/tests/data/config/oidc-firestore.yaml.in
@@ -1,14 +1,14 @@
 realm: "example.com"
-session_secret_file: "{session_secret_file}"
-database_url: "{database_url}"
-redis_url: "redis://localhost:6379/0"
-initial_admins: ["admin"]
-after_logout_url: "https://example.com/landing"
-group_mapping:
+sessionSecretFile: "{session_secret_file}"
+databaseUrl: "{database_url}"
+redisUrl: "redis://localhost:6379/0"
+initialAdmins: ["admin"]
+afterLogoutUrl: "https://example.com/landing"
+groupMapping:
   "exec:admin": ["admin"]
   "exec:test": ["test"]
   "read:all": ["foo", "admin", "org-a-team"]
-known_scopes:
+knownScopes:
   "admin:token": "Can create and modify tokens for any user"
   "exec:admin": "admin description"
   "exec:test": "test description"
@@ -17,17 +17,17 @@ known_scopes:
 firestore:
   project: "some-google-project"
 oidc:
-  client_id: "some-oidc-client-id"
-  client_secret_file: "{oidc_secret_file}"
-  login_url: "https://upstream.example.com/oidc/login"
-  login_params:
+  clientId: "some-oidc-client-id"
+  clientSecretFile: "{oidc_secret_file}"
+  loginUrl: "https://upstream.example.com/oidc/login"
+  loginParams:
     skin: "test"
-  redirect_url: "https://upstream.example.com/login"
-  token_url: "https://upstream.example.com/token"
+  redirectUrl: "https://upstream.example.com/login"
+  tokenUrl: "https://upstream.example.com/token"
   scopes:
     - "email"
     - "voPerson"
   issuer: "https://upstream.example.com/"
   audience: "https://test.example.com/"
-error_footer: |
+errorFooter: |
   Some <strong>error instructions</strong> with HTML.

--- a/tests/data/config/oidc-gid.yaml.in
+++ b/tests/data/config/oidc-gid.yaml.in
@@ -1,31 +1,31 @@
 realm: "example.com"
-session_secret_file: "{session_secret_file}"
-database_url: "{database_url}"
-redis_url: "redis://localhost:6379/0"
-slack_webhook_file: "{slack_webhook_file}"
-initial_admins: ["admin"]
-after_logout_url: "https://example.com/landing"
-group_mapping:
+sessionSecretFile: "{session_secret_file}"
+databaseUrl: "{database_url}"
+redisUrl: "redis://localhost:6379/0"
+slackWebhookFile: "{slack_webhook_file}"
+initialAdmins: ["admin"]
+afterLogoutUrl: "https://example.com/landing"
+groupMapping:
   "exec:admin": ["admin"]
   "exec:test": ["test"]
   "read:all": ["foo", "admin", "org-a-team"]
-known_scopes:
+knownScopes:
   "admin:token": "Can create and modify tokens for any user"
   "exec:admin": "admin description"
   "exec:test": "test description"
   "read:all": "can read everything"
   "user:token": "Can create and modify user tokens"
 oidc:
-  client_id: "some-oidc-client-id"
-  client_secret_file: "{oidc_secret_file}"
-  login_url: "https://upstream.example.com/oidc/login"
-  login_params:
+  clientId: "some-oidc-client-id"
+  clientSecretFile: "{oidc_secret_file}"
+  loginUrl: "https://upstream.example.com/oidc/login"
+  loginParams:
     skin: "test"
-  redirect_url: "https://upstream.example.com/login"
-  token_url: "https://upstream.example.com/token"
+  redirectUrl: "https://upstream.example.com/login"
+  tokenUrl: "https://upstream.example.com/token"
   scopes:
     - "email"
     - "voPerson"
   issuer: "https://upstream.example.com/"
   audience: "https://test.example.com/"
-  gid_claim: "gid_number"
+  gidClaim: "gid_number"

--- a/tests/data/config/oidc-ldap-firestore.yaml.in
+++ b/tests/data/config/oidc-ldap-firestore.yaml.in
@@ -1,14 +1,14 @@
 realm: "example.com"
-session_secret_file: "{session_secret_file}"
-database_url: "{database_url}"
-redis_url: "redis://localhost:6379/0"
-initial_admins: ["admin"]
-after_logout_url: "https://example.com/landing"
-group_mapping:
+sessionSecretFile: "{session_secret_file}"
+databaseUrl: "{database_url}"
+redisUrl: "redis://localhost:6379/0"
+initialAdmins: ["admin"]
+afterLogoutUrl: "https://example.com/landing"
+groupMapping:
   "exec:admin": ["admin"]
   "exec:test": ["test"]
   "read:all": ["foo", "admin", "org-a-team"]
-known_scopes:
+knownScopes:
   "admin:token": "Can create and modify tokens for any user"
   "exec:admin": "admin description"
   "exec:test": "test description"
@@ -18,14 +18,14 @@ firestore:
   project: "some-google-project"
 ldap:
   url: "ldaps://ldap.example.com/"
-  group_base_dn: "dc=example,dc=com"
-  user_base_dn: "ou=people,dc=example,dc=com"
-  add_user_group: true
+  groupBaseDn: "dc=example,dc=com"
+  userBaseDn: "ou=people,dc=example,dc=com"
+  addUserGroup: true
 oidc:
-  client_id: "some-oidc-client-id"
-  client_secret_file: "{oidc_secret_file}"
-  login_url: "https://upstream.example.com/oidc/login"
-  redirect_url: "https://upstream.example.com/login"
-  token_url: "https://upstream.example.com/token"
+  clientId: "some-oidc-client-id"
+  clientSecretFile: "{oidc_secret_file}"
+  loginUrl: "https://upstream.example.com/oidc/login"
+  redirectUrl: "https://upstream.example.com/login"
+  tokenUrl: "https://upstream.example.com/token"
   issuer: "https://upstream.example.com/"
   audience: "https://test.example.com/"

--- a/tests/data/config/oidc-ldap-gid.yaml.in
+++ b/tests/data/config/oidc-ldap-gid.yaml.in
@@ -1,15 +1,15 @@
 realm: "example.com"
 loglevel: "DEBUG"
-session_secret_file: "{session_secret_file}"
-database_url: "{database_url}"
-redis_url: "redis://localhost:6379/0"
-initial_admins: ["admin"]
-after_logout_url: "https://example.com/landing"
-group_mapping:
+sessionSecretFile: "{session_secret_file}"
+databaseUrl: "{database_url}"
+redisUrl: "redis://localhost:6379/0"
+initialAdmins: ["admin"]
+afterLogoutUrl: "https://example.com/landing"
+groupMapping:
   "exec:admin": ["admin"]
   "exec:test": ["test"]
   "read:all": ["foo", "admin", "org-a-team"]
-known_scopes:
+knownScopes:
   "admin:token": "Can create and modify tokens for any user"
   "exec:admin": "admin description"
   "exec:test": "test description"
@@ -17,15 +17,15 @@ known_scopes:
   "user:token": "Can create and modify user tokens"
 ldap:
   url: "ldaps://ldap.example.com/"
-  group_base_dn: "dc=example,dc=com"
-  user_base_dn: "ou=people,dc=example,dc=com"
-  uid_attr: "uidNumber"
-  gid_attr: "gidNumber"
+  groupBaseDn: "dc=example,dc=com"
+  userBaseDn: "ou=people,dc=example,dc=com"
+  uidAttr: "uidNumber"
+  gidAttr: "gidNumber"
 oidc:
-  client_id: "some-oidc-client-id"
-  client_secret_file: "{oidc_secret_file}"
-  login_url: "https://upstream.example.com/oidc/login"
-  redirect_url: "https://upstream.example.com/login"
-  token_url: "https://upstream.example.com/token"
+  clientId: "some-oidc-client-id"
+  clientSecretFile: "{oidc_secret_file}"
+  loginUrl: "https://upstream.example.com/oidc/login"
+  redirectUrl: "https://upstream.example.com/login"
+  tokenUrl: "https://upstream.example.com/token"
   issuer: "https://upstream.example.com/"
   audience: "https://test.example.com/"

--- a/tests/data/config/oidc-ldap-groups.yaml.in
+++ b/tests/data/config/oidc-ldap-groups.yaml.in
@@ -1,15 +1,15 @@
 realm: "example.com"
 loglevel: "DEBUG"
-session_secret_file: "{session_secret_file}"
-database_url: "{database_url}"
-redis_url: "redis://localhost:6379/0"
-initial_admins: ["admin"]
-after_logout_url: "https://example.com/landing"
-group_mapping:
+sessionSecretFile: "{session_secret_file}"
+databaseUrl: "{database_url}"
+redisUrl: "redis://localhost:6379/0"
+initialAdmins: ["admin"]
+afterLogoutUrl: "https://example.com/landing"
+groupMapping:
   "exec:admin": ["admin"]
   "exec:test": ["test"]
   "read:all": ["foo", "admin", "org-a-team"]
-known_scopes:
+knownScopes:
   "admin:token": "Can create and modify tokens for any user"
   "exec:admin": "admin description"
   "exec:test": "test description"
@@ -17,12 +17,12 @@ known_scopes:
   "user:token": "Can create and modify user tokens"
 ldap:
   url: "ldaps://ldap.example.com/"
-  group_base_dn: "dc=example,dc=com"
+  groupBaseDn: "dc=example,dc=com"
 oidc:
-  client_id: "some-oidc-client-id"
-  client_secret_file: "{oidc_secret_file}"
-  login_url: "https://upstream.example.com/oidc/login"
-  redirect_url: "https://upstream.example.com/login"
-  token_url: "https://upstream.example.com/token"
+  clientId: "some-oidc-client-id"
+  clientSecretFile: "{oidc_secret_file}"
+  loginUrl: "https://upstream.example.com/oidc/login"
+  redirectUrl: "https://upstream.example.com/login"
+  tokenUrl: "https://upstream.example.com/token"
   issuer: "https://upstream.example.com/"
   audience: "https://test.example.com/"

--- a/tests/data/config/oidc-ldap-uid.yaml.in
+++ b/tests/data/config/oidc-ldap-uid.yaml.in
@@ -1,15 +1,15 @@
 realm: "example.com"
 loglevel: "DEBUG"
-session_secret_file: "{session_secret_file}"
-database_url: "{database_url}"
-redis_url: "redis://localhost:6379/0"
-initial_admins: ["admin"]
-after_logout_url: "https://example.com/landing"
-group_mapping:
+sessionSecretFile: "{session_secret_file}"
+databaseUrl: "{database_url}"
+redisUrl: "redis://localhost:6379/0"
+initialAdmins: ["admin"]
+afterLogoutUrl: "https://example.com/landing"
+groupMapping:
   "exec:admin": ["admin"]
   "exec:test": ["test"]
   "read:all": ["foo", "admin", "org-a-team"]
-known_scopes:
+knownScopes:
   "admin:token": "Can create and modify tokens for any user"
   "exec:admin": "admin description"
   "exec:test": "test description"
@@ -17,17 +17,17 @@ known_scopes:
   "user:token": "Can create and modify user tokens"
 ldap:
   url: "ldaps://ldap.example.com/"
-  group_base_dn: "dc=example,dc=com"
-  user_base_dn: "ou=people,dc=example,dc=com"
-  name_attr: null
-  email_attr: null
-  uid_attr: "uidNumber"
-  add_user_group: true
+  groupBaseDn: "dc=example,dc=com"
+  userBaseDn: "ou=people,dc=example,dc=com"
+  nameAttr: null
+  emailAttr: null
+  uidAttr: "uidNumber"
+  addUserGroup: true
 oidc:
-  client_id: "some-oidc-client-id"
-  client_secret_file: "{oidc_secret_file}"
-  login_url: "https://upstream.example.com/oidc/login"
-  redirect_url: "https://upstream.example.com/login"
-  token_url: "https://upstream.example.com/token"
+  clientId: "some-oidc-client-id"
+  clientSecretFile: "{oidc_secret_file}"
+  loginUrl: "https://upstream.example.com/oidc/login"
+  redirectUrl: "https://upstream.example.com/login"
+  tokenUrl: "https://upstream.example.com/token"
   issuer: "https://upstream.example.com/"
   audience: "https://test.example.com/"

--- a/tests/data/config/oidc-ldap.yaml.in
+++ b/tests/data/config/oidc-ldap.yaml.in
@@ -1,15 +1,15 @@
 realm: "example.com"
 loglevel: "DEBUG"
-session_secret_file: "{session_secret_file}"
-database_url: "{database_url}"
-redis_url: "redis://localhost:6379/0"
-initial_admins: ["admin"]
-after_logout_url: "https://example.com/landing"
-group_mapping:
+sessionSecretFile: "{session_secret_file}"
+databaseUrl: "{database_url}"
+redisUrl: "redis://localhost:6379/0"
+initialAdmins: ["admin"]
+afterLogoutUrl: "https://example.com/landing"
+groupMapping:
   "exec:admin": ["admin"]
   "exec:test": ["test"]
   "read:all": ["foo", "admin", "org-a-team"]
-known_scopes:
+knownScopes:
   "admin:token": "Can create and modify tokens for any user"
   "exec:admin": "admin description"
   "exec:test": "test description"
@@ -17,22 +17,22 @@ known_scopes:
   "user:token": "Can create and modify user tokens"
 ldap:
   url: "ldaps://ldap.example.com/"
-  group_base_dn: "dc=example,dc=com"
-  user_base_dn: "ou=people,dc=example,dc=com"
-  uid_attr: "uidNumber"
+  groupBaseDn: "dc=example,dc=com"
+  userBaseDn: "ou=people,dc=example,dc=com"
+  uidAttr: "uidNumber"
 oidc:
-  client_id: "some-oidc-client-id"
-  client_secret_file: "{oidc_secret_file}"
-  login_url: "https://upstream.example.com/oidc/login"
-  login_params:
+  clientId: "some-oidc-client-id"
+  clientSecretFile: "{oidc_secret_file}"
+  loginUrl: "https://upstream.example.com/oidc/login"
+  loginParams:
     skin: "test"
-  redirect_url: "https://upstream.example.com/login"
-  token_url: "https://upstream.example.com/token"
-  enrollment_url: "https://upstream.example.com/enroll"
+  redirectUrl: "https://upstream.example.com/login"
+  tokenUrl: "https://upstream.example.com/token"
+  enrollmentUrl: "https://upstream.example.com/enroll"
   scopes:
     - "email"
     - "voPerson"
   issuer: "https://upstream.example.com/"
   audience: "https://test.example.com/"
-error_footer: |
+errorFooter: |
   Some <strong>error instructions</strong> with HTML.

--- a/tests/data/config/oidc-no-kids.yaml.in
+++ b/tests/data/config/oidc-no-kids.yaml.in
@@ -1,27 +1,27 @@
 realm: "example.com"
-session_secret_file: "{session_secret_file}"
-database_url: "{database_url}"
-redis_url: "redis://localhost:6379/0"
-initial_admins: ["admin"]
-after_logout_url: "https://example.com/landing"
-group_mapping:
+sessionSecretFile: "{session_secret_file}"
+databaseUrl: "{database_url}"
+redisUrl: "redis://localhost:6379/0"
+initialAdmins: ["admin"]
+afterLogoutUrl: "https://example.com/landing"
+groupMapping:
   "exec:admin": ["admin"]
   "exec:test": ["test"]
   "read:all": ["foo", "admin", "org-a-team"]
-known_scopes:
+knownScopes:
   "admin:token": "Can create and modify tokens for any user"
   "exec:admin": "admin description"
   "exec:test": "test description"
   "read:all": "can read everything"
   "user:token": "Can create and modify user tokens"
 oidc:
-  client_id: "some-oidc-client-id"
-  client_secret_file: "{oidc_secret_file}"
-  login_url: "https://example.com/oidc/login"
-  login_params:
+  clientId: "some-oidc-client-id"
+  clientSecretFile: "{oidc_secret_file}"
+  loginUrl: "https://example.com/oidc/login"
+  loginParams:
     skin: "test"
-  redirect_url: "https://example.com/login"
-  token_url: "https://example.com/token"
+  redirectUrl: "https://example.com/login"
+  tokenUrl: "https://example.com/token"
   scopes:
     - "email"
     - "voPerson"

--- a/tests/data/config/oidc-subdomain.yaml.in
+++ b/tests/data/config/oidc-subdomain.yaml.in
@@ -1,24 +1,24 @@
 realm: "example.com"
-session_secret_file: "{session_secret_file}"
-database_url: "{database_url}"
-redis_url: "redis://localhost:6379/0"
-initial_admins: ["admin"]
-after_logout_url: "https://example.com/landing"
-group_mapping:
+sessionSecretFile: "{session_secret_file}"
+databaseUrl: "{database_url}"
+redisUrl: "redis://localhost:6379/0"
+initialAdmins: ["admin"]
+afterLogoutUrl: "https://example.com/landing"
+groupMapping:
   "exec:admin": ["admin"]
   "exec:test": ["test"]
   "read:all": ["foo", "admin", "org-a-team"]
-known_scopes:
+knownScopes:
   "admin:token": "Can create and modify tokens for any user"
   "exec:admin": "admin description"
   "exec:test": "test description"
   "read:all": "can read everything"
   "user:token": "Can create and modify user tokens"
 oidc:
-  client_id: "some-oidc-client-id"
-  client_secret_file: "{oidc_secret_file}"
-  login_url: "https://upstream.example.com/some/path/login"
-  redirect_url: "https://test.example.com/login"
-  token_url: "https://upstream.example.com/some/path/token"
+  clientId: "some-oidc-client-id"
+  clientSecretFile: "{oidc_secret_file}"
+  loginUrl: "https://upstream.example.com/some/path/login"
+  redirectUrl: "https://test.example.com/login"
+  tokenUrl: "https://upstream.example.com/some/path/token"
   issuer: "https://upstream.example.com/some/path"
   audience: "https://test.example.com/"

--- a/tests/data/config/oidc.yaml.in
+++ b/tests/data/config/oidc.yaml.in
@@ -1,32 +1,32 @@
 realm: "example.com"
-session_secret_file: "{session_secret_file}"
-database_url: "{database_url}"
-redis_url: "redis://localhost:6379/0"
-slack_webhook_file: "{slack_webhook_file}"
-initial_admins: ["admin"]
-after_logout_url: "https://example.com/landing"
-group_mapping:
+sessionSecretFile: "{session_secret_file}"
+databaseUrl: "{database_url}"
+redisUrl: "redis://localhost:6379/0"
+slackWebhookFile: "{slack_webhook_file}"
+initialAdmins: ["admin"]
+afterLogoutUrl: "https://example.com/landing"
+groupMapping:
   "exec:admin": ["admin"]
   "exec:test": ["test"]
   "read:all": ["foo", "admin", "org-a-team"]
-known_scopes:
+knownScopes:
   "admin:token": "Can create and modify tokens for any user"
   "exec:admin": "admin description"
   "exec:test": "test description"
   "read:all": "can read everything"
   "user:token": "Can create and modify user tokens"
 oidc:
-  client_id: "some-oidc-client-id"
-  client_secret_file: "{oidc_secret_file}"
-  login_url: "https://upstream.example.com/oidc/login"
-  login_params:
+  clientId: "some-oidc-client-id"
+  clientSecretFile: "{oidc_secret_file}"
+  loginUrl: "https://upstream.example.com/oidc/login"
+  loginParams:
     skin: "test"
-  redirect_url: "https://upstream.example.com/login"
-  token_url: "https://upstream.example.com/token"
+  redirectUrl: "https://upstream.example.com/login"
+  tokenUrl: "https://upstream.example.com/token"
   scopes:
     - "email"
     - "voPerson"
   issuer: "https://upstream.example.com/"
   audience: "https://test.example.com/"
-error_footer: |
+errorFooter: |
   Some <strong>error instructions</strong> with HTML.

--- a/tests/data/config/selenium.yaml.in
+++ b/tests/data/config/selenium.yaml.in
@@ -1,19 +1,19 @@
 realm: "localhost"
-session_secret_file: "{session_secret_file}"
-database_url: "{database_url}"
-redis_url: "redis://localhost:6379/0"
-initial_admins: ["admin"]
-after_logout_url: "https://example.com/landing"
-group_mapping:
+sessionSecretFile: "{session_secret_file}"
+databaseUrl: "{database_url}"
+redisUrl: "redis://localhost:6379/0"
+initialAdmins: ["admin"]
+afterLogoutUrl: "https://example.com/landing"
+groupMapping:
   "exec:admin": ["admin"]
   "exec:test": ["test"]
   "read:all": ["foo", "admin", "org-a-team"]
-known_scopes:
+knownScopes:
   "admin:token": "Can create and modify tokens for any user"
   "exec:admin": "admin description"
   "exec:test": "test description"
   "read:all": "can read everything"
   "user:token": "Can create and modify user tokens"
 github:
-  client_id: "some-github-client-id"
-  client_secret_file: "{github_secret_file}"
+  clientId: "some-github-client-id"
+  clientSecretFile: "{github_secret_file}"


### PR DESCRIPTION
To avoid the divergence between the on-disk configuration file and the Helm values file in Phalanx, enable camel-case support for the parsing of the disk configuration file.  Update all examples and test configuration files accordingly.

Stop using BaseSettings because we don't want to support environment variables or .env files, and those are the only things BaseSettings adds over BaseModel.

Enable slots for the frozen configuration for minor performance and memory benefits.