### PR TITLE
DM-37833: Add basic quota support

### DIFF
--- a/src/gafaelfawr/models/token.py
+++ b/src/gafaelfawr/models/token.py
@@ -16,6 +16,8 @@ from ..util import current_datetime, normalize_scopes, random_128_bits
 __all__ = [
     "AdminTokenRequest",
     "NewToken",
+    "NotebookQuota",
+    "Quota",
     "Token",
     "TokenBase",
     "TokenData",
@@ -156,6 +158,36 @@ class TokenGroup(BaseModel):
             " numeric GID will be allocated by Firestore if left unset"
             " when creating a token."
         ),
+    )
+
+
+class NotebookQuota(BaseModel):
+    """Notebook Aspect quota information for a user."""
+
+    cpu: float = Field(..., title="CPU equivalents", example=4.0)
+
+    memory: float = Field(..., title="Maximum memory use (GiB)", example=16.0)
+
+
+class Quota(BaseModel):
+    """Quota information for a user."""
+
+    api: dict[str, int] = Field(
+        {},
+        title="API quotas",
+        description=(
+            "Mapping of service names to allowed requests per 15 minutes."
+        ),
+        example={
+            "datalinker": 500,
+            "hips": 2000,
+            "tap": 500,
+            "vo-cutouts": 100,
+        },
+    )
+
+    notebook: Optional[NotebookQuota] = Field(
+        None, title="Notebook Aspect quotas"
     )
 
 
@@ -326,6 +358,8 @@ class TokenUserInfo(BaseModel):
         title="Groups",
         description="Groups of which the user is a member",
     )
+
+    quota: Optional[Quota] = Field(None, title="Quota")
 
     def to_userinfo_dict(self) -> dict[str, Any]:
         """Convert to a dictionary for logging purposes.

--- a/tests/data/config/github-quota.yaml.in
+++ b/tests/data/config/github-quota.yaml.in
@@ -1,0 +1,34 @@
+realm: "example.com"
+sessionSecretFile: "{session_secret_file}"
+databaseUrl: "{database_url}"
+redisUrl: "redis://localhost:6379/0"
+initialAdmins: ["admin"]
+afterLogoutUrl: "https://example.com/landing"
+groupMapping:
+  "exec:admin": ["admin"]
+  "read:all":
+    - "foo"
+    - "admin"
+    - github:
+        organization: "org"
+        team: "a-team"
+knownScopes:
+  "admin:token": "token administration"
+  "exec:admin": "admin description"
+  "read:all": "can read everything"
+  "user:token": "Can create and modify user tokens"
+github:
+  clientId: "some-github-client-id"
+  clientSecretFile: "{github_secret_file}"
+quota:
+  default:
+    api:
+      datalinker: 1000
+    notebook:
+      cpu: 8
+      memory: 4.0
+  groups:
+    foo:
+      notebook:
+        cpu: 0.0
+        memory: 4.0

--- a/tests/handlers/api_tokens_test.py
+++ b/tests/handlers/api_tokens_test.py
@@ -343,12 +343,7 @@ async def test_token_info(
         "email": "example@example.com",
         "uid": 45613,
         "gid": 12345,
-        "groups": [
-            {
-                "name": "foo",
-                "id": 12313,
-            }
-        ],
+        "groups": [{"name": "foo", "id": 12313}],
     }
 
     # Check the same with a user token, which has some additional associated
@@ -777,9 +772,7 @@ async def test_no_expires(client: AsyncClient, factory: Factory) -> None:
     assert r.json()["expires"] == int(expires.timestamp())
 
     r = await client.patch(
-        token_url,
-        headers={"X-CSRF-Token": csrf},
-        json={"expires": None},
+        token_url, headers={"X-CSRF-Token": csrf}, json={"expires": None}
     )
     assert r.status_code == 200
     assert "expires" not in r.json()
@@ -1328,10 +1321,7 @@ async def test_create_admin_firestore(
         headers={"Authorization": f"bearer {str(service_token)}"},
     )
     assert r.status_code == 200
-    assert r.json() == {
-        "username": "bot-user",
-        "uid": UID_BOT_MIN,
-    }
+    assert r.json() == {"username": "bot-user", "uid": UID_BOT_MIN}
 
 
 @pytest.mark.asyncio

--- a/tests/handlers/quota_test.py
+++ b/tests/handlers/quota_test.py
@@ -1,0 +1,60 @@
+"""Test quota handling."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from httpx import AsyncClient
+
+from gafaelfawr.factory import Factory
+from gafaelfawr.models.token import TokenGroup, TokenUserInfo
+
+from ..support.config import reconfigure
+
+
+@pytest.mark.asyncio
+async def test_info(
+    client: AsyncClient, factory: Factory, tmp_path: Path
+) -> None:
+    await reconfigure(tmp_path, "github-quota", factory)
+    user_info = TokenUserInfo(
+        username="example", groups=[TokenGroup(name="bar", id=12312)]
+    )
+    token_service = factory.create_token_service()
+    async with factory.session.begin():
+        token = await token_service.create_session_token(
+            user_info, scopes=["user:token"], ip_address="127.0.0.1"
+        )
+
+    r = await client.get(
+        "/auth/api/v1/user-info", headers={"Authorization": f"bearer {token}"}
+    )
+    assert r.status_code == 200
+    assert r.json() == {
+        "username": "example",
+        "groups": [{"name": "bar", "id": 12312}],
+        "quota": {
+            "api": {"datalinker": 1000},
+            "notebook": {"cpu": 8.0, "memory": 4.0},
+        },
+    }
+
+    user_info.groups = [TokenGroup(name="foo", id=12313)]
+    async with factory.session.begin():
+        token = await token_service.create_session_token(
+            user_info, scopes=["user:token"], ip_address="127.0.0.1"
+        )
+
+    r = await client.get(
+        "/auth/api/v1/user-info", headers={"Authorization": f"bearer {token}"}
+    )
+    assert r.status_code == 200
+    assert r.json() == {
+        "username": "example",
+        "groups": [{"name": "foo", "id": 12313}],
+        "quota": {
+            "api": {"datalinker": 1000},
+            "notebook": {"cpu": 8.0, "memory": 8.0},
+        },
+    }


### PR DESCRIPTION
Support configuring default and per-group quotas in the Gafaelfawr settings, calculate the user's total quotas when user information is requested, and include that in the token user information model. Also reorder settings in gafaelfawr.config to match between settings and the frozen configuration and hopefully be a bit more readable.

Includes a bit of reformatting in the test suite that I noticed while updating the tests for quota handling.