### PR TITLE
DM-38170: Disable caching of enrollment redirects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ Dependencies are updated to the latest available version during each release. Th
 
 ## 9.0.1 (unreleased)
 
+### Bug fixes
+
+- Explicitly disable caching of enrollment redirects. Some browsers appear to cache 307 redirects and redirected the user back to enrollment the next time they logged in.
+- Uniformly use `Cache-Control: no-cache, no-store` to disable caching of errors and redirects. Previously, Gafaelfawr also added `must-revalidate` (but not `max-age`). This appears to not be necessary or useful with modern browsers.
+
 ### Other changes
 
 - Gafaelfawr now supports camel-case in its configuration file to allow using the same names for most configuration settings and Helm chart values.

--- a/docs/dev/requirements.rst
+++ b/docs/dev/requirements.rst
@@ -76,14 +76,19 @@ This is done by adding a ``server-snippet`` key to the ingress-nginx ``ConfigMap
      controller:
        config:
          server-snippet: |
-           location @autherror {
-             add_header Cache-Control "no-cache, must-revalidate" always;
-             add_header WWW-Authenticate $auth_www_authenticate always;
-             if ($auth_status = 400) {
-               add_header Content-Type "application/json" always;
-               return 400 $auth_error_body;
-             }
-             return 403;
-           }
+            set $auth_error_body '';
+            set $auth_status '';
+            set $auth_www_authenticate '';
+            location @autherror {
+              default_type application/json;
+              if ($auth_status = 400) {
+                add_header Cache-Control "no-cache, no-store" always;
+                add_header WWW-Authenticate $auth_www_authenticate always;
+                return 400 $auth_error_body;
+              }
+              add_header Cache-Control "no-cache, no-store" always;
+              add_header WWW-Authenticate $auth_www_authenticate always;
+              return 403;
+            }
 
 This will be added to every server block, not just the ones used by Gafaelfawr-protected services, and therefore may be unused, but this should be harmless.

--- a/src/gafaelfawr/auth.py
+++ b/src/gafaelfawr/auth.py
@@ -173,7 +173,7 @@ def generate_challenge(
     )
     detail = {"msg": str(exc), "type": exc.error}
     headers = {
-        "Cache-Control": "no-cache, must-revalidate",
+        "Cache-Control": "no-cache, no-store",
         "WWW-Authenticate": challenge.to_header(),
     }
     if error_in_headers:
@@ -257,7 +257,7 @@ def generate_unauthorized_challenge(
         msg = "Authentication required"
 
     headers = {
-        "Cache-Control": "no-cache, must-revalidate",
+        "Cache-Control": "no-cache, no-store",
         "WWW-Authenticate": challenge.to_header(),
     }
 

--- a/src/gafaelfawr/handlers/login.py
+++ b/src/gafaelfawr/handlers/login.py
@@ -224,7 +224,8 @@ async def handle_provider_return(
         if context.config.oidc and context.config.oidc.enrollment_url:
             url = context.config.oidc.enrollment_url
             context.logger.info("Redirecting user to enrollment URL", url=url)
-            return RedirectResponse(url)
+            headers = {"Cache-Control": "no-cache, no-store"}
+            return RedirectResponse(url, headers=headers)
         else:
             return login_error(context, LoginError.NOT_ENROLLED, str(e))
     except FirestoreError as e:
@@ -305,6 +306,6 @@ def login_error(
             "details": details,
             "error_footer": context.config.error_footer,
         },
-        headers={"Cache-Control": "no-cache, must-revalidate"},
+        headers={"Cache-Control": "no-cache, no-store"},
         status_code=status.HTTP_403_FORBIDDEN,
     )

--- a/tests/handlers/auth_test.py
+++ b/tests/handlers/auth_test.py
@@ -122,7 +122,7 @@ async def test_invalid_auth(
         headers={"Authorization": "Bearer token"},
     )
     assert r.status_code == 401
-    assert r.headers["Cache-Control"] == "no-cache, must-revalidate"
+    assert r.headers["Cache-Control"] == "no-cache, no-store"
     authenticate = parse_www_authenticate(r.headers["WWW-Authenticate"])
     assert isinstance(authenticate, AuthErrorChallenge)
     assert authenticate.auth_type == AuthType.Bearer
@@ -137,7 +137,7 @@ async def test_invalid_auth(
         headers={"Authorization": f"Bearer {token}"},
     )
     assert r.status_code == 401
-    assert r.headers["Cache-Control"] == "no-cache, must-revalidate"
+    assert r.headers["Cache-Control"] == "no-cache, no-store"
     authenticate = parse_www_authenticate(r.headers["WWW-Authenticate"])
     assert isinstance(authenticate, AuthErrorChallenge)
     assert authenticate.auth_type == AuthType.Bearer
@@ -163,7 +163,7 @@ async def test_access_denied(
         headers={"Authorization": f"Bearer {token_data.token}"},
     )
     assert r.status_code == 403
-    assert r.headers["Cache-Control"] == "no-cache, must-revalidate"
+    assert r.headers["Cache-Control"] == "no-cache, no-store"
     authenticate = parse_www_authenticate(r.headers["WWW-Authenticate"])
     assert isinstance(authenticate, AuthErrorChallenge)
     assert authenticate.auth_type == AuthType.Bearer
@@ -191,7 +191,7 @@ async def test_satisfy_all(
         headers={"Authorization": f"Bearer {token_data.token}"},
     )
     assert r.status_code == 403
-    assert r.headers["Cache-Control"] == "no-cache, must-revalidate"
+    assert r.headers["Cache-Control"] == "no-cache, no-store"
     authenticate = parse_www_authenticate(r.headers["WWW-Authenticate"])
     assert isinstance(authenticate, AuthErrorChallenge)
     assert authenticate.auth_type == AuthType.Bearer

--- a/tests/handlers/login_github_test.py
+++ b/tests/handlers/login_github_test.py
@@ -499,7 +499,7 @@ async def test_no_valid_groups(
         client, respx_mock, user_info, expect_revoke=True
     )
     assert r.status_code == 403
-    assert r.headers["Cache-Control"] == "no-cache, must-revalidate"
+    assert r.headers["Cache-Control"] == "no-cache, no-store"
     assert "githubuser is not a member of any authorized groups" in r.text
     assert "Some <strong>error instructions</strong> with HTML." in r.text
 

--- a/tests/handlers/login_oidc_test.py
+++ b/tests/handlers/login_oidc_test.py
@@ -437,7 +437,7 @@ async def test_no_valid_groups(
 
     r = await simulate_oidc_login(client, respx_mock, token)
     assert r.status_code == 403
-    assert r.headers["Cache-Control"] == "no-cache, must-revalidate"
+    assert r.headers["Cache-Control"] == "no-cache, no-store"
     username = token.claims[config.oidc.username_claim]
     expected = f"{username} is not a member of any authorized groups"
     assert expected in r.text
@@ -572,6 +572,7 @@ async def test_enrollment_url(
         client, respx_mock, token, expect_enrollment=True
     )
     assert r.status_code == 307
+    assert r.headers["Cache-Control"] == "no-cache, no-store"
 
 
 @pytest.mark.asyncio
@@ -587,7 +588,7 @@ async def test_no_enrollment_url(
 
     r = await simulate_oidc_login(client, respx_mock, token)
     assert r.status_code == 403
-    assert r.headers["Cache-Control"] == "no-cache, must-revalidate"
+    assert r.headers["Cache-Control"] == "no-cache, no-store"
     assert "User is not enrolled" in r.text
 
     # None of these errors should have resulted in Slack alerts.

--- a/tests/support/headers.py
+++ b/tests/support/headers.py
@@ -37,7 +37,7 @@ def assert_unauthorized_is_correct(
         Expected authentication type.
     """
     assert r.status_code == 401
-    assert r.headers["Cache-Control"] == "no-cache, must-revalidate"
+    assert r.headers["Cache-Control"] == "no-cache, no-store"
     challenge = parse_www_authenticate(r.headers["WWW-Authenticate"])
     assert not isinstance(challenge, AuthErrorChallenge)
     assert challenge.auth_type == auth_type


### PR DESCRIPTION
Some browsers appear to cache the 307 enrollment flow redirect and send the user back into the enrollment flow when they try to log in after they have enrolled.

Uniformly use Cache-Control: no-cache, no-store when disabling caching. (no-store should make no-cache unnecessary, but I believe it is a later keyword that earlier browsers may not support.) Previously, Gafaelfawr also added must-revalidate, but this doesn't appear to be necessary with modern browsers and was likely only meaningful combined with max-age=0 (which Gafaelfawr didn't set).