### PR TITLE
DM-38414: Fix error reporting when knownScopes incomplete

### DIFF
--- a/src/gafaelfawr/config.py
+++ b/src/gafaelfawr/config.py
@@ -399,7 +399,7 @@ class Settings(CamelCaseModel):
                 raise ValueError(f"invalid scope {scope}")
         for required in ("admin:token", "user:token"):
             if required not in v:
-                raise ValueError(f"required scope {scope} missing")
+                raise ValueError(f"required scope {required} missing")
         return v
 
     @validator("ldap", always=True)


### PR DESCRIPTION
When some required scopes are missing from the knownScopes configuration, the error reporting failed because it referenced an invalid variable.