### PR TITLE
DM-38414: Update GitHub Actions configuration

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,8 @@
 name: CI
 
 "on":
+  merge_group: {}
+  pull_request: {}
   push:
     branches-ignore:
       # These should always correspond to pull requests, so ignore them for
@@ -13,7 +15,6 @@ name: CI
       - "u/**"
     tags:
       - "*"
-  pull_request: {}
 
 jobs:
   ui:
@@ -108,8 +109,8 @@ jobs:
       - name: Set up Minikube
         uses: manusa/actions-setup-minikube@v2.7.2
         with:
-          minikube version: 'v1.27.1'
-          kubernetes version: 'v1.25.2'
+          minikube version: "v1.28.0"
+          kubernetes version: "v1.25.4"
 
       - name: Run tox
         uses: lsst-sqre/run-tox@v1
@@ -139,7 +140,7 @@ jobs:
         uses: lsst-sqre/run-tox@v1
         with:
           python-version: "3.11"
-          tox-envs: "docs,docs-linkcheck"
+          tox-envs: "docs"
           cache-key-prefix: "docs"
 
       # Only attempt documentation uploads for long-lived branches, tagged
@@ -154,8 +155,9 @@ jobs:
           username: ${{ secrets.LTD_USERNAME }}
           password: ${{ secrets.LTD_PASSWORD }}
         if: >
-          github.event_name != 'pull_request'
-          || startsWith(github.head_ref, 'tickets/')
+          github.event_name != 'merge_group'
+          && (github.event_name != 'pull_request'
+              || startsWith(github.head_ref, 'tickets/'))
 
   build:
     runs-on: ubuntu-latest
@@ -168,8 +170,9 @@ jobs:
     # but in this case the build will fail with an error since the secret
     # won't be set.
     if: >
-      startsWith(github.ref, 'refs/tags/')
-      || startsWith(github.head_ref, 'tickets/')
+      github.event_name != 'merge_group'
+      && (startsWith(github.ref, 'refs/tags/')
+          || startsWith(github.head_ref, 'tickets/'))
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/linkcheck.yaml
+++ b/.github/workflows/linkcheck.yaml
@@ -1,0 +1,50 @@
+# This is a separate documentation build just to check links.  We don't check
+# links as part of the normal documentation build since, unlike Sphinx errors
+# and warnings, we don't want broken links to block a merge.  (Sometimes they
+# will be fixed by the same merge, sometimes they're temporary rate limit
+# issues.)
+#
+# Instead, we do an advisory run of link checking on relevant PRs that doesn't
+# block merging, and we do a weekly link check to catch any links that have
+# gone stale.
+
+name: Link Check
+
+"on":
+  pull_request: {}
+  push:
+    branches-ignore:
+      # These should always correspond to pull requests, so ignore them for
+      # the push trigger and let them be triggered by the pull_request
+      # trigger, avoiding running the workflow twice.  This is a minor
+      # optimization so there's no need to ensure this is comprehensive.
+      - "dependabot/**"
+      - "gh-readonly-queue/**"
+      - "renovate/**"
+      - "tickets/**"
+      - "u/**"
+    tags:
+      - "*"
+  schedule:
+    - cron: "0 12 * * 1"
+  workflow_dispatch: {}
+
+jobs:
+  linkcheck:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Update package lists
+        run: sudo apt-get update
+
+      - name: Install extra packages
+        run: sudo apt install -y graphviz libpq-dev libldap2-dev libsasl2-dev
+
+      - name: Check links
+        uses: lsst-sqre/run-tox@v1
+        with:
+          python-version: "3.11"
+          tox-envs: "docs-linkcheck"


### PR DESCRIPTION
- Run linkchecks separately so that they can be advisory and not block merges.
- Run a linkcheck weekly.
- Update the minikube and Kubernetes versions.
- Enable support for merge queues, which required tweaking some workflow conditionals.