### PR TITLE
DM-38414: Tweak the application setup

### DIFF
--- a/changelog.d/20230413_120335_rra_DM_38414a.md
+++ b/changelog.d/20230413_120335_rra_DM_38414a.md
@@ -1,0 +1,3 @@
+### Other changes
+
+- Gafaelfawr no longer adds timestamps to each of its log messages. This was a workaround for Argo CD not displaying log timestamps, which has now been fixed.

--- a/changelog.d/20230413_123131_rra_DM_38414a.md
+++ b/changelog.d/20230413_123131_rra_DM_38414a.md
@@ -1,0 +1,3 @@
+### New features
+
+- To align with other services, the Gafaelfawr log level should now be set with `config.logLevel` rather than `config.loglevel` (note the capital `L`). The old setting is temporarily supported for backward compatibility but will be removed in a later release.

--- a/docs/user-guide/helm.rst
+++ b/docs/user-guide/helm.rst
@@ -551,12 +551,12 @@ Logging and proxies
 ===================
 
 The default logging level of Gafaelfawr is ``INFO``, which will log a message for every action it takes.
-To change this, set ``config.loglevel``:
+To change this, set ``config.logLevel``:
 
 .. code-block:: yaml
 
    config:
-     loglevel: "WARNING"
+     logLevel: "WARNING"
 
 Valid values are ``DEBUG`` (to increase the logging), ``INFO`` (the default), ``WARNING``, or ``ERROR``.
 

--- a/examples/docker/gafaelfawr.yaml
+++ b/examples/docker/gafaelfawr.yaml
@@ -12,7 +12,7 @@
 # any server that uses these settings.
 
 realm: "localhost"
-loglevel: "DEBUG"
+logLevel: "DEBUG"
 sessionSecretFile: "/run/secrets/session-secret"
 databaseUrl: "postgresql://gafaelfawr:INSECURE@postgresql/gafaelfawr"
 bootstrapTokenFile: "/run/secrets/bootstrap-token"

--- a/examples/gafaelfawr-dev.yaml
+++ b/examples/gafaelfawr-dev.yaml
@@ -12,7 +12,7 @@
 # any server that uses these settings.
 
 realm: "localhost"
-loglevel: "DEBUG"
+logLevel: "DEBUG"
 sessionSecretFile: "examples/secrets/session-secret"
 databaseUrl: "postgresql://gafaelfawr:INSECURE@localhost/gafaelfawr"
 

--- a/src/gafaelfawr/config.py
+++ b/src/gafaelfawr/config.py
@@ -307,7 +307,7 @@ class Settings(CamelCaseModel):
     realm: str
     """Realm for HTTP authentication."""
 
-    loglevel: LogLevel = LogLevel.INFO
+    log_level: LogLevel = LogLevel.INFO
     """Logging level."""
 
     session_secret_file: Path
@@ -750,7 +750,7 @@ class Config:
     realm: str
     """Realm for HTTP authentication."""
 
-    loglevel: LogLevel
+    log_level: LogLevel
     """Level for logging."""
 
     session_secret: str
@@ -1000,7 +1000,7 @@ class Config:
             slack_webhook = cls._load_secret(path).decode()
         return cls(
             realm=settings.realm,
-            loglevel=settings.loglevel,
+            log_level=settings.log_level,
             session_secret=session_secret.decode(),
             redis_url=settings.redis_url,
             redis_password=redis_password,
@@ -1028,7 +1028,7 @@ class Config:
         """Configure logging based on the Gafaelfawr configuration."""
         configure_logging(
             profile=Profile.production,
-            log_level=self.loglevel,
+            log_level=self.log_level,
             name="gafaelfawr",
             add_timestamp=True,
         )

--- a/src/gafaelfawr/config.py
+++ b/src/gafaelfawr/config.py
@@ -1030,7 +1030,6 @@ class Config:
             profile=Profile.production,
             log_level=self.log_level,
             name="gafaelfawr",
-            add_timestamp=True,
         )
 
     @staticmethod

--- a/src/gafaelfawr/handlers/api.py
+++ b/src/gafaelfawr/handlers/api.py
@@ -75,7 +75,7 @@ _pagination_headers = {
 
 
 @router.get(
-    "/admins",
+    "/auth/api/v1/admins",
     dependencies=[Depends(authenticate_admin_read)],
     response_model=list[Admin],
     summary="List all administrators",
@@ -90,7 +90,7 @@ async def get_admins(
 
 
 @router.post(
-    "/admins",
+    "/auth/api/v1/admins",
     status_code=204,
     summary="Add new administrator",
     tags=["admin"],
@@ -110,7 +110,7 @@ async def add_admin(
 
 
 @router.delete(
-    "/admins/{username}",
+    "/auth/api/v1/admins/{username}",
     responses={
         403: {"description": "Permission denied", "model": ErrorModel},
         404: {"description": "Specified user is not an administrator"},
@@ -143,7 +143,7 @@ async def delete_admin(
 
 
 @router.get(
-    "/history/token-changes",
+    "/auth/api/v1/history/token-changes",
     description=(
         "Get the change history of tokens for any user. If a limit or cursor"
         " was specified, links to paginated results may be found in the `Link`"
@@ -246,7 +246,7 @@ async def get_admin_token_change_history(
 
 
 @router.get(
-    "/login",
+    "/auth/api/v1/login",
     description=(
         "Used by the JavaScript UI to obtain a CSRF token, user metadata,"
         " and server configuration. Not used with regular API calls."
@@ -275,7 +275,7 @@ async def get_login(
 
 
 @router.get(
-    "/token-info",
+    "/auth/api/v1/token-info",
     description="Return metadata about the authentication token",
     response_model=TokenInfo,
     response_model_exclude_none=True,
@@ -304,7 +304,7 @@ async def get_token_info(
 
 
 @router.post(
-    "/tokens",
+    "/auth/api/v1/tokens",
     responses={
         201: {
             "headers": {
@@ -338,7 +338,7 @@ async def post_admin_tokens(
 
 
 @router.get(
-    "/user-info",
+    "/auth/api/v1/user-info",
     description="Get metadata about the autheticated user",
     response_model=TokenUserInfo,
     response_model_exclude_none=True,
@@ -366,7 +366,7 @@ async def get_user_info(
 
 
 @router.get(
-    "/users/{username}/token-change-history",
+    "/auth/api/v1/users/{username}/token-change-history",
     description=(
         "Get the change history of tokens for the current user. If a limit"
         " or cursor was specified, links to paginated results may be found"
@@ -458,7 +458,7 @@ async def get_user_token_change_history(
 
 
 @router.get(
-    "/users/{username}/tokens",
+    "/auth/api/v1/users/{username}/tokens",
     response_model=list[TokenInfo],
     response_model_exclude_none=True,
     summary="List tokens",
@@ -482,7 +482,7 @@ async def get_tokens(
 
 
 @router.post(
-    "/users/{username}/tokens",
+    "/auth/api/v1/users/{username}/tokens",
     responses={
         201: {
             "headers": {
@@ -528,7 +528,7 @@ async def post_tokens(
 
 
 @router.get(
-    "/users/{username}/tokens/{key}",
+    "/auth/api/v1/users/{username}/tokens/{key}",
     response_model=TokenInfo,
     response_model_exclude_none=True,
     responses={404: {"description": "Token not found", "model": ErrorModel}},
@@ -564,7 +564,7 @@ async def get_token(
 
 
 @router.delete(
-    "/users/{username}/tokens/{key}",
+    "/auth/api/v1/users/{username}/tokens/{key}",
     responses={404: {"description": "Token not found", "model": ErrorModel}},
     summary="Revoke token",
     status_code=204,
@@ -599,7 +599,7 @@ async def delete_token(
 
 
 @router.patch(
-    "/users/{username}/tokens/{key}",
+    "/auth/api/v1/users/{username}/tokens/{key}",
     description=(
         "Replace metadata of a user token with provided values. Only the"
         " token name, scope, and expiration may be changed. Only token"
@@ -652,7 +652,7 @@ async def patch_token(
 
 
 @router.get(
-    "/users/{username}/tokens/{key}/change-history",
+    "/auth/api/v1/users/{username}/tokens/{key}/change-history",
     response_model=list[TokenChangeHistoryEntry],
     response_model_exclude_unset=True,
     responses={404: {"description": "Token not found", "model": ErrorModel}},

--- a/src/gafaelfawr/main.py
+++ b/src/gafaelfawr/main.py
@@ -90,7 +90,6 @@ def create_app(*, load_config: bool = True) -> FastAPI:
     app.include_router(analyze.router)
     app.include_router(
         api.router,
-        prefix="/auth/api/v1",
         responses={
             401: {"description": "Unauthenticated"},
             403: {"description": "Permission denied", "model": ErrorModel},

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -59,9 +59,9 @@ def test_config_invalid_admin() -> None:
         parse_config(config_path("bad-admin.yaml"))
 
 
-def test_config_invalid_loglevel() -> None:
+def test_config_invalid_log_level() -> None:
     with pytest.raises(ValidationError):
-        parse_config(config_path("bad-loglevel.yaml"))
+        parse_config(config_path("bad-log-level.yaml"))
 
 
 def test_config_invalid_scope() -> None:

--- a/tests/data/config/bad-log-level.yaml
+++ b/tests/data/config/bad-log-level.yaml
@@ -1,7 +1,7 @@
-# Bad configuration file with invalid loglevel setting.
+# Bad configuration file with invalid logLevel setting.
 
 realm: "testing"
-loglevel: "INVALID"
+logLevel: "INVALID"
 sessionSecretFile: "{session_secret_file}"
 databaseUrl: "postgresql://gafaelfawr:INSECURE-PASSWORD@localhost/gafaelfawr"
 initialAdmins: ["admin"]

--- a/tests/data/config/bad-token.yaml.in
+++ b/tests/data/config/bad-token.yaml.in
@@ -1,7 +1,7 @@
 # Configuration file supporting invalid bootstrap_token_file contents.
 
 realm: "testing"
-loglevel: "INFO"
+logLevel: "INFO"
 sessionSecretFile: "{session_secret_file}"
 databaseUrl: "postgresql://gafaelfawr:INSECURE-PASSWORD@localhost/gafaelfawr"
 initialAdmins: ["admin"]

--- a/tests/data/config/oidc-forgerock.yaml.in
+++ b/tests/data/config/oidc-forgerock.yaml.in
@@ -1,5 +1,5 @@
 realm: "example.com"
-loglevel: "DEBUG"
+logLevel: "DEBUG"
 sessionSecretFile: "{session_secret_file}"
 databaseUrl: "{database_url}"
 redisUrl: "redis://localhost:6379/0"

--- a/tests/data/config/oidc-ldap-gid.yaml.in
+++ b/tests/data/config/oidc-ldap-gid.yaml.in
@@ -1,5 +1,5 @@
 realm: "example.com"
-loglevel: "DEBUG"
+logLevel: "DEBUG"
 sessionSecretFile: "{session_secret_file}"
 databaseUrl: "{database_url}"
 redisUrl: "redis://localhost:6379/0"

--- a/tests/data/config/oidc-ldap-groups.yaml.in
+++ b/tests/data/config/oidc-ldap-groups.yaml.in
@@ -1,5 +1,5 @@
 realm: "example.com"
-loglevel: "DEBUG"
+logLevel: "DEBUG"
 sessionSecretFile: "{session_secret_file}"
 databaseUrl: "{database_url}"
 redisUrl: "redis://localhost:6379/0"

--- a/tests/data/config/oidc-ldap-uid.yaml.in
+++ b/tests/data/config/oidc-ldap-uid.yaml.in
@@ -1,5 +1,5 @@
 realm: "example.com"
-loglevel: "DEBUG"
+logLevel: "DEBUG"
 sessionSecretFile: "{session_secret_file}"
 databaseUrl: "{database_url}"
 redisUrl: "redis://localhost:6379/0"

--- a/tests/data/config/oidc-ldap.yaml.in
+++ b/tests/data/config/oidc-ldap.yaml.in
@@ -1,5 +1,5 @@
 realm: "example.com"
-loglevel: "DEBUG"
+logLevel: "DEBUG"
 sessionSecretFile: "{session_secret_file}"
 databaseUrl: "{database_url}"
 redisUrl: "redis://localhost:6379/0"

--- a/tests/support/config.py
+++ b/tests/support/config.py
@@ -207,7 +207,7 @@ def configure(
     # Pick up any change to the log level.
     configure_logging(
         profile=Profile.production,
-        log_level=config.loglevel,
+        log_level=config.log_level,
         name="gafaelfawr",
         add_timestamp=True,
     )


### PR DESCRIPTION
- Use `logLevel` as the configuration option and `log_level` as the internal attribute, not `loglevel`, to match other packages
- Stop adding timestamps to log messages now that Argo CD supports showing timestamps
- Use full paths in all of the handlers to make the code clearer
- Move lifecycle and exception handlers into `create_app` since they're private implementation details and it makes the code more succinct