### PR TITLE
DM-38414: Report Redis deserialization errors to Slack

### DIFF
--- a/changelog.d/20230414_125547_rra_DM_38414.md
+++ b/changelog.d/20230414_125547_rra_DM_38414.md
@@ -1,0 +1,3 @@
+### New features
+
+- Failures to deserialize or decrypt data stored in Redis are now reported to Slack if Slack alerting is enabled.

--- a/src/gafaelfawr/factory.py
+++ b/src/gafaelfawr/factory.py
@@ -536,7 +536,10 @@ class Factory:
             encryption_key=self._context.config.session_secret,
             key_prefix="token:",
         )
-        token_redis_store = TokenRedisStore(storage, self._logger)
+        slack_client = self.create_slack_client()
+        token_redis_store = TokenRedisStore(
+            storage, slack_client, self._logger
+        )
         token_db_store = TokenDatabaseStore(self.session)
         token_change_store = TokenChangeHistoryStore(self.session)
         return TokenCacheService(
@@ -564,7 +567,10 @@ class Factory:
             encryption_key=self._context.config.session_secret,
             key_prefix="token:",
         )
-        token_redis_store = TokenRedisStore(storage, self._logger)
+        slack_client = self.create_slack_client()
+        token_redis_store = TokenRedisStore(
+            storage, slack_client, self._logger
+        )
         token_change_store = TokenChangeHistoryStore(self.session)
         token_cache_service = TokenCacheService(
             config=self._context.config,

--- a/src/gafaelfawr/factory.py
+++ b/src/gafaelfawr/factory.py
@@ -389,10 +389,12 @@ class Factory:
         )
         authorization_store = OIDCAuthorizationStore(storage)
         token_service = self.create_token_service()
+        slack_client = self.create_slack_client()
         return OIDCService(
             config=self._context.config.oidc_server,
             authorization_store=authorization_store,
             token_service=token_service,
+            slack_client=slack_client,
             logger=self._logger,
         )
 

--- a/tests/data/config/github-oidc-server.yaml.in
+++ b/tests/data/config/github-oidc-server.yaml.in
@@ -3,6 +3,7 @@ sessionSecretFile: "{session_secret_file}"
 databaseUrl: "{database_url}"
 redisUrl: "redis://localhost:6379/0"
 bootstrapTokenFile: "{bootstrap_token_file}"
+slackWebhookFile: "{slack_webhook_file}"
 initialAdmins: ["admin"]
 proxies:
   - "10.0.0.0/8"

--- a/tests/services/token_cache_test.py
+++ b/tests/services/token_cache_test.py
@@ -106,7 +106,8 @@ async def test_expiration(config: Config, factory: Factory) -> None:
         encryption_key=config.session_secret,
         key_prefix="token:",
     )
-    token_store = TokenRedisStore(storage, logger)
+    slack_client = factory.create_slack_client()
+    token_store = TokenRedisStore(storage, slack_client, logger)
     token_cache = factory.create_token_cache_service()
 
     # Store a token whose expiration is five seconds more than half the


### PR DESCRIPTION
When we were unable to deserialize data stored in Redis, the OpenID Connect provider reported an error saying that the user's code was invalid (with a more detailed error message), and the token code treated the token as nonexistent. A more detailed error message was logged, but that would be easy to miss.

Keep the same public-facing behavior, but report these errors to Slack since they possibly indicate infrastructure data corruption. Do not do this when the problem is that the secret portion of the token is invalid; instead, continue to treat that as an invalid code or token and log an error but not to Slack.