### PR TITLE
DM-38414: Improve API documentation

### DIFF
--- a/docs/_templates/autosummary_core/exception.rst
+++ b/docs/_templates/autosummary_core/exception.rst
@@ -1,0 +1,15 @@
+{% if referencefile %}
+.. include:: {{ referencefile }}
+{% endif %}
+
+{{ objname }}
+{{ underline }}
+
+.. currentmodule:: {{ module }}
+
+.. autoexception:: {{ objname }}
+   :members:
+   :show-inheritance:
+   {% if noindex -%}
+   :noindex:
+   {%- endif %}

--- a/docs/dev/internals.rst
+++ b/docs/dev/internals.rst
@@ -80,6 +80,9 @@ Python internal API
 .. automodapi:: gafaelfawr.operator
    :include-all-objects:
 
+.. automodapi:: gafaelfawr.operator.ingress
+   :include-all-objects:
+
 .. automodapi:: gafaelfawr.operator.startup
    :include-all-objects:
 

--- a/docs/dev/internals.rst
+++ b/docs/dev/internals.rst
@@ -6,15 +6,19 @@ Python internal API
    :include-all-objects:
 
 .. automodapi:: gafaelfawr.auth
+   :include-all-objects:
 
 .. automodapi:: gafaelfawr.cache
+   :include-all-objects:
 
 .. automodapi:: gafaelfawr.config
+   :include-all-objects:
 
 .. automodapi:: gafaelfawr.constants
    :include-all-objects:
 
 .. automodapi:: gafaelfawr.dependencies.auth
+   :include-all-objects:
 
 .. automodapi:: gafaelfawr.dependencies.config
    :include-all-objects:
@@ -23,14 +27,19 @@ Python internal API
    :include-all-objects:
 
 .. automodapi:: gafaelfawr.dependencies.return_url
+   :include-all-objects:
 
 .. automodapi:: gafaelfawr.exceptions
+   :include-all-objects:
 
 .. automodapi:: gafaelfawr.factory
+   :include-all-objects:
 
 .. automodapi:: gafaelfawr.keypair
+   :include-all-objects:
 
 .. automodapi:: gafaelfawr.middleware.state
+   :include-all-objects:
 
 .. automodapi:: gafaelfawr.models.admin
    :include-all-objects:
@@ -69,50 +78,73 @@ Python internal API
    :inherited-members:
 
 .. automodapi:: gafaelfawr.operator
+   :include-all-objects:
 
 .. automodapi:: gafaelfawr.operator.startup
+   :include-all-objects:
 
 .. automodapi:: gafaelfawr.operator.tokens
+   :include-all-objects:
 
 .. automodapi:: gafaelfawr.providers.base
+   :include-all-objects:
 
 .. automodapi:: gafaelfawr.providers.github
+   :include-all-objects:
 
 .. automodapi:: gafaelfawr.providers.oidc
+   :include-all-objects:
 
 .. automodapi:: gafaelfawr.services.admin
+   :include-all-objects:
 
 .. automodapi:: gafaelfawr.services.firestore
+   :include-all-objects:
 
 .. automodapi:: gafaelfawr.services.kubernetes
+   :include-all-objects:
 
 .. automodapi:: gafaelfawr.services.ldap
+   :include-all-objects:
 
 .. automodapi:: gafaelfawr.services.oidc
+   :include-all-objects:
 
 .. automodapi:: gafaelfawr.services.token
+   :include-all-objects:
 
 .. automodapi:: gafaelfawr.services.token_cache
+   :include-all-objects:
 
 .. automodapi:: gafaelfawr.services.userinfo
+   :include-all-objects:
 
 .. automodapi:: gafaelfawr.storage.admin
+   :include-all-objects:
 
 .. automodapi:: gafaelfawr.storage.firestore
+   :include-all-objects:
 
 .. automodapi:: gafaelfawr.storage.forgerock
+   :include-all-objects:
 
 .. automodapi:: gafaelfawr.storage.history
+   :include-all-objects:
 
 .. automodapi:: gafaelfawr.storage.kubernetes
+   :include-all-objects:
 
 .. automodapi:: gafaelfawr.storage.ldap
+   :include-all-objects:
 
 .. automodapi:: gafaelfawr.storage.oidc
+   :include-all-objects:
 
 .. automodapi:: gafaelfawr.storage.token
+   :include-all-objects:
 
 .. automodapi:: gafaelfawr.templates
    :include-all-objects:
 
 .. automodapi:: gafaelfawr.util
+   :include-all-objects:

--- a/docs/documenteer.toml
+++ b/docs/documenteer.toml
@@ -61,13 +61,6 @@ nitpick_ignore = [
     # Bug in autodoc_pydantic.
     ["py:obj", "gafaelfawr.models.kubernetes.GafaelfawrIngressDelegate.all fields"],
     ["py:obj", "gafaelfawr.config.Settings.all fields"],
-    # TypeVar references that shouldn't be documented.
-    ["py:class", "gafaelfawr.cache.S"],
-    ["py:obj", "gafaelfawr.cache.S"],
-    ["py:class", "gafaelfawr.middleware.state.T"],
-    ["py:obj", "gafaelfawr.middleware.state.T"],
-    ["py:class", "gafaelfawr.models.history.E"],
-    ["py:obj", "gafaelfawr.models.history.E"],
 ]
 nitpick_ignore_regex = [
     ["py:class", "kubernetes_asyncio\\.client\\.models\\..*"],

--- a/docs/documenteer.toml
+++ b/docs/documenteer.toml
@@ -6,6 +6,11 @@ copyright = "2020-2022 Association of Universities for Research in Astronomy, In
 package = "gafaelfawr"
 
 [sphinx]
+disable_primary_sidebars = [
+    "**/index",
+    "changelog",
+    "dev/internals",
+]
 extensions = [
     "sphinx_click",
     "sphinx_diagrams",

--- a/docs/documenteer.toml
+++ b/docs/documenteer.toml
@@ -35,17 +35,13 @@ nitpick_ignore = [
     ["py:exc", "fastapi.exceptions.RequestValidationError"],
     ["py:exc", "httpx.HTTPError"],
     ["py:obj", "fastapi.routing.APIRoute"],
-    ["py:class", "kubernetes_asyncio.client.V1Ingress"],
-    ["py:class", "kubernetes_asyncio.client.V1Secret"],
     ["py:class", "kubernetes_asyncio.client.api_client.ApiClient"],
-    ["py:class", "pydantic.env_settings.BaseSettings"],
     ["py:class", "pydantic.error_wrappers.ValidationError"],
     ["py:class", "pydantic.main.BaseModel"],
     ["py:class", "pydantic.networks.AnyHttpUrl"],
     ["py:class", "pydantic.networks.IPvAnyNetwork"],
     ["py:class", "pydantic.types.SecretStr"],
     ["py:class", "pydantic.utils.Representation"],
-    ["py:class", "redis.asyncio.client.Redis"],
     ["py:obj", "safir.pydantic.validate_exactly_one_of.<locals>.validator"],
     ["py:class", "starlette.datastructures.URL"],
     ["py:class", "starlette.middleware.base.BaseHTTPMiddleware"],
@@ -58,11 +54,10 @@ nitpick_ignore = [
     ["py:class", "gafaelfawr.models.history.ConstrainedStrValue"],
     ["py:class", "gafaelfawr.models.token.ConstrainedIntValue"],
     ["py:class", "gafaelfawr.models.token.ConstrainedStrValue"],
-    # asyncio.Lock and asyncio.Queue are documented, and that's what all the
-    # code references, but the combination of Sphinx extensions we're using
-    # confuse themselves and there doesn't seem to be any way to fix this.
+    # asyncio.Lock is documented, and that's what all the code references, but
+    # the combination of Sphinx extensions we're using confuse themselves and
+    # there doesn't seem to be any way to fix this.
     ["py:class", "asyncio.locks.Lock"],
-    ["py:class", "asyncio.queues.Queue"],
     # Bug in autodoc_pydantic.
     ["py:obj", "gafaelfawr.models.kubernetes.GafaelfawrIngressDelegate.all fields"],
     ["py:obj", "gafaelfawr.config.Settings.all fields"],
@@ -73,8 +68,6 @@ nitpick_ignore = [
     ["py:obj", "gafaelfawr.middleware.state.T"],
     ["py:class", "gafaelfawr.models.history.E"],
     ["py:obj", "gafaelfawr.models.history.E"],
-    ["py:class", "gafaelfawr.storage.base.S"],
-    ["py:obj", "gafaelfawr.storage.base.S"],
 ]
 nitpick_ignore_regex = [
     ["py:class", "kubernetes_asyncio\\.client\\.models\\..*"],

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -21,11 +21,9 @@ Gafaelfawr is named for Glewlwyd Gafaelfawr, the knight who challenges King Arth
 Gafaelfawr is pronounced (very roughly) gah-VILE-vahwr.
 (If you speak Welsh and can provide a better pronunciation guide, please open an issue!)
 
-Usage
-=====
-
 .. toctree::
    :maxdepth: 2
+   :caption: Usage
 
    user-guide/index
    api
@@ -35,10 +33,8 @@ Usage
 
    changelog
 
-Development
-===========
-
 .. toctree::
    :maxdepth: 2
+   :caption: Development
 
    dev/index

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,6 +97,9 @@ add-ignore = [
     # Properties shouldn't be written in imperative mode. This will be fixed
     # post 6.1.1, see https://github.com/PyCQA/pydocstyle/pull/546
     "D401",
+    # Nested classes named Config are used by Pydantic for configuration, and
+    # don't have a meaningful docstring.
+    "D106",
 ]
 
 [tool.isort]

--- a/src/gafaelfawr/cache.py
+++ b/src/gafaelfawr/cache.py
@@ -28,6 +28,7 @@ from .constants import (
 from .models.token import Token, TokenData
 
 S = TypeVar("S")
+"""Type of content stored in a cache."""
 
 _LRUTokenCache = LRUCache[tuple[str, ...], Token]
 """Type for the underlying token cache."""
@@ -39,6 +40,7 @@ __all__ = [
     "PerUserCache",
     "LDAPCache",
     "NotebookTokenCache",
+    "S",
     "TokenCache",
     "UserLockManager",
 ]

--- a/src/gafaelfawr/middleware/state.py
+++ b/src/gafaelfawr/middleware/state.py
@@ -11,8 +11,13 @@ from fastapi import FastAPI, Request, Response
 from starlette.middleware.base import BaseHTTPMiddleware
 
 T = TypeVar("T", bound="BaseState")
+"""Type of data stored in the state cookie."""
 
-__all__ = ["BaseState", "StateMiddleware"]
+__all__ = [
+    "BaseState",
+    "StateMiddleware",
+    "T",
+]
 
 
 class BaseState(metaclass=ABCMeta):

--- a/src/gafaelfawr/models/admin.py
+++ b/src/gafaelfawr/models/admin.py
@@ -14,7 +14,5 @@ class Admin(BaseModel):
     """The username of the token administrator."""
 
     class Config:
-        """Additional Pydantic configuration."""
-
         orm_mode = True
         schema_extra = {"example": {"username": "adminuser"}}

--- a/src/gafaelfawr/models/history.py
+++ b/src/gafaelfawr/models/history.py
@@ -18,10 +18,12 @@ from ..util import normalize_ip_address, normalize_scopes
 from .token import TokenType
 
 E = TypeVar("E", bound="BaseModel")
+"""Type of a history entry in a paginated list."""
 
 __all__ = [
     "AdminChange",
     "AdminHistoryEntry",
+    "E",
     "HistoryCursor",
     "PaginatedHistory",
     "TokenChange",
@@ -75,8 +77,6 @@ class AdminHistoryEntry(BaseModel):
     )
 
     class Config:
-        """Additional Pydantic configuration."""
-
         orm_mode = True
 
     _normalize_event_time = validator(
@@ -353,8 +353,6 @@ class TokenChangeHistoryEntry(BaseModel):
     )
 
     class Config:
-        """Additional Pydantic configuration."""
-
         json_encoders = {datetime: lambda v: int(v.timestamp())}
         orm_mode = True
 

--- a/src/gafaelfawr/models/kubernetes.py
+++ b/src/gafaelfawr/models/kubernetes.py
@@ -181,8 +181,6 @@ class GafaelfawrIngressScopesBase(CamelCaseModel, metaclass=ABCMeta):
         """Whether this ingress is anonymous."""
 
     class Config:
-        """Pydantic configuration."""
-
         extra = Extra.forbid
 
 
@@ -334,8 +332,6 @@ class GafaelfawrServicePortName(CamelCaseModel):
     """Port name."""
 
     class Config:
-        """Pydantic configuration."""
-
         extra = Extra.forbid
 
     def to_kubernetes(self) -> V1ServiceBackendPort:
@@ -350,8 +346,6 @@ class GafaelfawrServicePortNumber(CamelCaseModel):
     """Port number."""
 
     class Config:
-        """Pydantic configuration."""
-
         extra = Extra.forbid
 
     def to_kubernetes(self) -> V1ServiceBackendPort:

--- a/src/gafaelfawr/models/oidc.py
+++ b/src/gafaelfawr/models/oidc.py
@@ -113,8 +113,6 @@ class OIDCAuthorization(BaseModel):
     )
 
     class Config:
-        """Additional Pydantic configuration."""
-
         json_encoders = {datetime: lambda v: int(v.timestamp())}
 
     _normalize_created_at = validator(

--- a/src/gafaelfawr/models/token.py
+++ b/src/gafaelfawr/models/token.py
@@ -227,7 +227,10 @@ class TokenBase(BaseModel):
     )
 
     scopes: list[str] = Field(
-        ..., title="Token scopes", example=["read:all", "user:token"]
+        ...,
+        title="Token scopes",
+        description="Scopes of the token",
+        example=["read:all", "user:token"],
     )
 
     created: datetime = Field(

--- a/src/gafaelfawr/models/token.py
+++ b/src/gafaelfawr/models/token.py
@@ -300,8 +300,6 @@ class TokenInfo(TokenBase):
     )
 
     class Config:
-        """Additional Pydantic configuration."""
-
         orm_mode = True
         json_encoders = {datetime: lambda v: int(v.timestamp())}
 
@@ -406,8 +404,6 @@ class TokenData(TokenBase, TokenUserInfo):
     token: Token = Field(..., title="Associated token")
 
     class Config:
-        """Additional Pydantic configuration."""
-
         json_encoders = {datetime: lambda v: int(v.timestamp())}
 
     @classmethod

--- a/src/gafaelfawr/storage/kubernetes.py
+++ b/src/gafaelfawr/storage/kubernetes.py
@@ -117,7 +117,7 @@ class KubernetesIngressStorage:
 
         Returns
         -------
-        kubernetes_asyncio.client.V1Ingress or None
+        kubernetes_asyncio.client.models.V1Ingress or None
             The Kubernetes ingress object, or `None` if it doesn't exist.
         """
         try:
@@ -240,7 +240,7 @@ class KubernetesTokenStorage:
 
         Returns
         -------
-        kubernetes_asyncio.client.V1Secret or None
+        kubernetes_asyncio.client.models.V1Secret or None
             The Kubernetes secret, or `None` if that secret does not exist.
         """
         try:

--- a/tox.ini
+++ b/tox.ini
@@ -53,7 +53,10 @@ commands = coverage report
 
 [testenv:docs]
 description = Build documentation (HTML) with Sphinx
+allowlist_externals =
+    rm
 commands =
+    rm -rf docs/dev/internals
     gafaelfawr openapi-schema --add-back-link --output docs/_static/openapi.json
     sphinx-build -W --keep-going -n -T -b html -d {envtmpdir}/doctrees docs docs/_build/html
 


### PR DESCRIPTION
- Remove the sidebars on some API documentation pages since they don't seem to add much value
- Remove now-unneeded nitpick exclusions
- Include TypeVar in the documentation but drop docstrings for nested Pydantic Config classes
- Add descriptions to more Pydantic model fields
- Delete automodapi files on doc generation to avoid errors from out-of-date code
- Support method and attribute documentation for exceptions
- Add missing API documentation for the ingress operator