### PR TITLE
DM-38414: Use allowlist_externals

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -103,7 +103,7 @@ setenv =
 [testenv:run]
 description = Run the development server with auto-reload for code changes
 usedevelop = true
-whitelist_externals =
+allowlist_externals =
     docker-compose
 commands_pre =
     docker-compose up -d


### PR DESCRIPTION
tox v4 appears to prefer allowlist_externals instead of whitelist_externals.