### PR TITLE
DM-39186: Redo Redis connection configuration

### DIFF
--- a/changelog.d/20230515_120829_rra_DM_39186.md
+++ b/changelog.d/20230515_120829_rra_DM_39186.md
@@ -1,0 +1,4 @@
+### Bug fixes
+
+- TCP keepalive for Redis connections apparently caused problems with holding connections open that the Redis server wanted to close. The TCP keepalive setting has been removed, which appears to increase the stability of the Redis connections.
+- Connections to Redis are now retried longer (about eight seconds instead of three seconds) in the hope of surviving a Redis restart without failures.

--- a/src/gafaelfawr/constants.py
+++ b/src/gafaelfawr/constants.py
@@ -108,7 +108,7 @@ Exponential backoff will be used for subsequent retries, up to
 REDIS_BACKOFF_MAX = 1.0
 """Maximum delay (in seconds) to wait after a Redis failure."""
 
-REDIS_RETRIES = 5
+REDIS_RETRIES = 10
 """How many times to try to connect to Redis before giving up."""
 
 # The following constants define per-process cache sizes.

--- a/src/gafaelfawr/factory.py
+++ b/src/gafaelfawr/factory.py
@@ -140,11 +140,6 @@ class ProcessContext:
                 ),
                 REDIS_RETRIES,
             ),
-            retry_on_error=[
-                redis.exceptions.ConnectionError,
-                redis.exceptions.TimeoutError,
-            ],
-            socket_keepalive=True,
         )
 
         return cls(

--- a/tests/support/selenium.py
+++ b/tests/support/selenium.py
@@ -166,6 +166,7 @@ async def run_app(
     uvicorn = spawn_uvicorn(
         working_directory=tmp_path,
         factory="tests.support.selenium:selenium_create_app",
+        timeout=10.0,
         env={
             "GAFAELFAWR_CONFIG_PATH": str(config_path),
             "GAFAELFAWR_TEST_TOKEN_PATH": str(token_path),


### PR DESCRIPTION
Since adding more connection retry configuration, we have been seeing periodic "Connection closed by server" errors in all environments. One hypothesis is that setting socket_keepalive is keeping the connection open longer than the Redis server permits, and it's changing the error in a way that's causing this problem. Try dropping that configuration.

Stop setting an explicit list of exceptions on which to retry, since the default seems to be fine.