### PR TITLE
DM-39186: Drop aiofiles dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ Dependencies are updated to the latest available version during each release. Th
 
 <!-- scriv-insert-here -->
 
+<a id='changelog-9.2.1'></a>
+## 9.2.1 (2023-05-15)
+
+### Bug fixes
+
+- TCP keepalive for Redis connections apparently caused problems with holding connections open that the Redis server wanted to close. The TCP keepalive setting has been removed, which appears to increase the stability of the Redis connections.
+- Connections to Redis are now retried longer (about eight seconds instead of three seconds) in the hope of surviving a Redis restart without failures.
+
+### Other changes
+
+- Gafaelfawr now uses the [Ruff](https://beta.ruff.rs/docs/) linter instead of flake8, isort, and pydocstyle.
+
 <a id='changelog-9.2.0'></a>
 ## 9.2.0 (2023-04-19)
 

--- a/changelog.d/20230515_120829_rra_DM_39186.md
+++ b/changelog.d/20230515_120829_rra_DM_39186.md
@@ -1,4 +1,0 @@
-### Bug fixes
-
-- TCP keepalive for Redis connections apparently caused problems with holding connections open that the Redis server wanted to close. The TCP keepalive setting has been removed, which appears to increase the stability of the Redis connections.
-- Connections to Redis are now retried longer (about eight seconds instead of three seconds) in the hope of surviving a Redis restart without failures.

--- a/changelog.d/20230515_152805_rra_DM_39186.md
+++ b/changelog.d/20230515_152805_rra_DM_39186.md
@@ -1,3 +1,0 @@
-### Other changes
-
-- Gafaelfawr now uses the [Ruff](https://beta.ruff.rs/docs/) linter instead of flake8, isort, and pydocstyle.

--- a/requirements/main.in
+++ b/requirements/main.in
@@ -6,7 +6,6 @@
 #     make update-deps
 
 # These dependencies are for fastapi including some optional features.
-aiofiles
 fastapi
 python-multipart
 starlette

--- a/requirements/main.txt
+++ b/requirements/main.txt
@@ -4,10 +4,6 @@
 #
 #    pip-compile --allow-unsafe --generate-hashes --output-file=requirements/main.txt --resolver=backtracking requirements/main.in
 #
-aiofiles==23.1.0 \
-    --hash=sha256:9312414ae06472eb6f1d163f555e466a23aed1c8f60c30cccf7121dba2e53eb2 \
-    --hash=sha256:edd247df9a19e0db16534d4baaf536d6609a43e1de5401d7a4c1c148753a1635
-    # via -r requirements/main.in
 aiohttp==3.8.4 \
     --hash=sha256:03543dcf98a6619254b409be2d22b51f21ec66272be4ebda7b04e6412e4b2e14 \
     --hash=sha256:03baa76b730e4e15a45f81dfe29a8d910314143414e528737f8589ec60cf7391 \


### PR DESCRIPTION
This is no longer required for static web service in FastAPI.