### PR TITLE
DM-39486: Hopefully fix Redis connection pooling

### DIFF
--- a/changelog.d/20230601_104058_rra_DM_39486.md
+++ b/changelog.d/20230601_104058_rra_DM_39486.md
@@ -1,0 +1,4 @@
+### Bug fixes
+
+- Limit the number of connections opened by the Redis connection pool, and wait for a connection to become available if all of them are in use.
+- Use the asyncio version of Redis request retrying instead of (in conflict with everything else Gafaelfawr does) the sync version.

--- a/src/gafaelfawr/constants.py
+++ b/src/gafaelfawr/constants.py
@@ -26,6 +26,8 @@ __all__ = [
     "OIDC_AUTHORIZATION_LIFETIME",
     "REDIS_BACKOFF_START",
     "REDIS_BACKOFF_MAX",
+    "REDIS_POOL_SIZE",
+    "REDIS_POOL_TIMEOUT",
     "REDIS_RETRIES",
     "SCOPE_REGEX",
     "TOKEN_CACHE_SIZE",
@@ -110,6 +112,12 @@ REDIS_BACKOFF_MAX = 1.0
 
 REDIS_RETRIES = 10
 """How many times to try to connect to Redis before giving up."""
+
+REDIS_POOL_SIZE = 10
+"""Size of the Redis connection pool."""
+
+REDIS_POOL_TIMEOUT = 10
+"""How long to wait for a connection from the pool before giving up."""
 
 # The following constants define per-process cache sizes.
 


### PR DESCRIPTION
Gafaelfawr was incorrectly using the sync version of Retry. Use the asyncio one instead so that we call the correct sleep.

Create the connection pool explicitly so that we can cap its size (by default, Redis has an unbounded connection pool size) and use the BlockingConnectionPool variant so that requests wait for a connection to become available.