### PR TITLE
DM-39486: Use PackageLoader to load templates

### DIFF
--- a/src/gafaelfawr/templates.py
+++ b/src/gafaelfawr/templates.py
@@ -6,14 +6,15 @@ for error messages.
 
 from __future__ import annotations
 
-from pathlib import Path
-
 from fastapi.templating import Jinja2Templates
+from jinja2 import PackageLoader
 
 __all__ = ["templates"]
 
-# Starlette forces use of the FileSystemLoader and FastAPI re-exports the
-# Starlette Jinja2Templates object, so we unfortunately cannot use
-# importlib.resources or the equivalent here.
-templates = Jinja2Templates(directory=str(Path(__file__).parent / "templates"))
+# Starlette requires a directory argument, but since we override the loader so
+# that the templates are retrieved from the Python package, it's unused.
+templates = Jinja2Templates(
+    loader=PackageLoader("gafaelfawr", package_path="templates"),
+    directory="templates",
+)
 """The template manager."""

--- a/tests/handlers/login_oidc_test.py
+++ b/tests/handlers/login_oidc_test.py
@@ -705,10 +705,11 @@ async def test_no_valid_groups(
     r = await simulate_oidc_login(client, respx_mock, token)
     assert r.status_code == 403
     assert r.headers["Cache-Control"] == "no-cache, no-store"
+    assert r.headers["Content-Type"] == "text/html; charset=utf-8"
     username = token.claims[config.oidc.username_claim]
-    expected = f"{username} is not a member of any authorized groups"
-    assert expected in r.text
-    assert "Some <strong>error instructions</strong> with HTML." in r.text
+    assert f"{username} is not a member of any authorized groups" in r.text
+    assert config.error_footer
+    assert config.error_footer in r.text
 
     # The user should not be logged in.
     r = await client.get("/auth", params={"scope": "user:token"})


### PR DESCRIPTION
Override the loader for the Starlette Jinja environment to use PackageLoader instead of FileSystemLoader. Our templates are included in the package, so this is technically more correct.