### PR TITLE
DM-39486: Suppress warnings about CO: groups

### DIFF
--- a/changelog.d/20230601_142330_rra_DM_39486.md
+++ b/changelog.d/20230601_142330_rra_DM_39486.md
@@ -1,0 +1,3 @@
+### Other changes
+
+- Suppress logged warnings about invalid groups if they match the pattern of COmanage internal groups (start with `CO:`).

--- a/src/gafaelfawr/storage/ldap.py
+++ b/src/gafaelfawr/storage/ldap.py
@@ -88,6 +88,10 @@ class LDAPStorage:
                 logger.warning(msg, error=str(e), ldap_result=result)
             if valid_group_regex.match(name):
                 groups.append(name)
+            elif name.startswith("CO:"):
+                # COmanage populates internal groups that start with CO:. We
+                # always ignore these, so they don't warrant a warning.
+                logger.debug(f"Ignoring COmanage group {name}")
             else:
                 logger.warning(f"LDAP group {name} invalid, ignoring")
 


### PR DESCRIPTION
We know we have lots of internal COmanage internal groups that start with CO: that aren't worth warning about. Turn warnings about groups with that name pattern into debug messages.