### PR TITLE
DM-39519: Add newline back to Gafaelfawr CI output

### DIFF
--- a/changelog.d/20230605_084645_rra_DM_39519.md
+++ b/changelog.d/20230605_084645_rra_DM_39519.md
@@ -1,0 +1,3 @@
+### Bug fixes
+
+- Restore the newline after the output from `gafaelfawr generate-session-secret` and `gafaelfawr generate-token`, accidentally dropped in 9.2.1.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -177,7 +177,7 @@ select = ["ALL"]
 target-version = "py311"
 
 [tool.ruff.per-file-ignores]
-"src/mobu/handlers/**" = [
+"src/gafaelfawr/handlers/**" = [
     "D103",    # FastAPI handlers should not have docstrings
 ]
 "tests/**" = [

--- a/src/gafaelfawr/cli.py
+++ b/src/gafaelfawr/cli.py
@@ -158,13 +158,13 @@ def generate_key() -> None:
 @main.command()
 def generate_session_secret() -> None:
     """Generate a new Gafaelfawr session secret."""
-    sys.stdout.write(Fernet.generate_key().decode())
+    sys.stdout.write(Fernet.generate_key().decode() + "\n")
 
 
 @main.command()
 def generate_token() -> None:
     """Generate an encoded token (such as the bootstrap token)."""
-    sys.stdout.write(str(Token()))
+    sys.stdout.write(str(Token()) + "\n")
 
 
 @main.command()


### PR DESCRIPTION
When switching to the Ruff linter, output from the CLI changed to use sys.stdout.write instead of print. That caused the newline after generated session secrets and tokens to accidentally be dropped. Restore it.