### PR TITLE
DM-39989: Use tox to run neophile

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -119,7 +119,7 @@ jobs:
           python-version: ${{ matrix.python }}
           tox-envs: "typing,py-full,coverage-report"
           tox-plugins: tox-docker
-          cache-key-prefix: "test"
+          cache-key-prefix: test
 
   dependencies:
     runs-on: ubuntu-latest
@@ -128,16 +128,13 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Set up Python
-        uses: actions/setup-python@v4
+      - name: Run neophile
+        uses: lsst-sqre/run-tox@v1
         with:
           python-version: "3.11"
-
-      - name: Install neophile
-        run: pip install neophile
-
-      - name: Run neophile
-        run: neophile check python
+          tox-envs: neophile-check
+          tox-posargs: python
+          cache-key-prefix: neophile
 
   docs:
     runs-on: ubuntu-latest

--- a/.github/workflows/dependencies.yaml
+++ b/.github/workflows/dependencies.yaml
@@ -13,16 +13,12 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Set up Python
-        uses: actions/setup-python@v4
+      - name: Run neophile
+        uses: lsst-sqre/run-tox@v1
         with:
           python-version: "3.11"
-
-      - name: Install neophile
-        run: pip install neophile
-
-      - name: Run neophile
-        run: neophile update --pr pre-commit
+          tox-envs: "neophile-update"
+          tox-posargs: "--pr pre-commit"
         env:
           NEOPHILE_GITHUB_APP_ID: ${{ secrets.NEOPHILE_APP_ID }}
           NEOPHILE_GITHUB_PRIVATE_KEY: ${{ secrets.NEOPHILE_PRIVATE_KEY }}

--- a/.github/workflows/periodic.yaml
+++ b/.github/workflows/periodic.yaml
@@ -42,11 +42,20 @@ jobs:
       - name: Install extra packages
         run: sudo apt install -y graphviz libpq-dev libldap2-dev libsasl2-dev
 
+      - name: Run neophile
+        uses: lsst-sqre/run-tox@v1
+        with:
+          python-version: "3.11"
+          tox-envs: "neophile-update"
+          tox-posargs: "python"
+          cache-key-prefix: "neophile"
+
       - name: Run tox
         uses: lsst-sqre/run-tox@v1
         with:
           python-version: ${{ matrix.python }}
           tox-envs: "lint,typing,py,docs,docs-linkcheck"
+          use-cache: false
 
       - name: Report status
         if: always()

--- a/tox.ini
+++ b/tox.ini
@@ -73,6 +73,20 @@ deps =
     pre-commit
 commands = pre-commit run --all-files
 
+[testenv:neophile-check]
+description = Run neophile to check dependencies
+skip_install = true
+deps =
+    neophile
+commands = neophile check {posargs}
+
+[testenv:neophile-update]
+description = Run neophile to update dependencies
+skip_install = true
+deps =
+    neophile
+commands = neophile update {posargs}
+
 [testenv:py]
 description = Run pytest with Docker prerequisites
 docker =


### PR DESCRIPTION
Add neophile-check and neophile-update tox targets, and use the run-tox GitHub Action to run them instead of manually setting up Python and installing neophile manually.