### PR TITLE
DM-40041: Switch minikube setup actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -108,13 +108,11 @@ jobs:
         run: sudo apt install -y libpq-dev libldap2-dev libsasl2-dev
 
       - name: Set up Minikube
-        uses: manusa/actions-setup-minikube@v2.7.2
+        uses: medyagh/setup-minikube@v0.0.13
         with:
-          minikube version: "v1.28.0"
-          kubernetes version: "v1.25.4"
+          kubernetes-version: "v1.27.3"
 
-      - name: Run tox
-        uses: lsst-sqre/run-tox@v1
+      - uses: lsst-sqre/run-tox@v1
         with:
           python-version: ${{ matrix.python }}
           tox-envs: "typing,py-full,coverage-report"
@@ -128,8 +126,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Run neophile
-        uses: lsst-sqre/run-neophile@v1
+      - uses: lsst-sqre/run-neophile@v1
         with:
           python-version: "3.11"
           mode: check
@@ -151,8 +148,7 @@ jobs:
       - name: Install extra packages
         run: sudo apt install -y graphviz libpq-dev libldap2-dev libsasl2-dev
 
-      - name: Run tox
-        uses: lsst-sqre/run-tox@v1
+      - uses: lsst-sqre/run-tox@v1
         with:
           python-version: "3.11"
           tox-envs: "docs"
@@ -162,8 +158,7 @@ jobs:
       # releases, and pull requests from ticket branches.  This avoids version
       # clutter in the docs and failures when a PR doesn't have access to
       # secrets.
-      - name: Upload to LSST the Docs
-        uses: lsst-sqre/ltd-upload@v1
+      - uses: lsst-sqre/ltd-upload@v1
         with:
           project: gafaelfawr
           dir: "docs/_build/html"
@@ -179,8 +174,7 @@ jobs:
     timeout-minutes: 15
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v3
+      - uses: actions/checkout@v3
 
       - name: Update package lists
         run: sudo apt-get update

--- a/.github/workflows/dependencies.yaml
+++ b/.github/workflows/dependencies.yaml
@@ -13,8 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Run neophile
-        uses: lsst-sqre/run-neophile@v1
+      - uses: lsst-sqre/run-neophile@v1
         with:
           python-version: "3.11"
           mode: pr

--- a/.github/workflows/periodic-ci.yaml
+++ b/.github/workflows/periodic-ci.yaml
@@ -25,8 +25,7 @@ jobs:
       # Use the oldest supported version of Python to update dependencies,
       # not the matrixed Python version, since this accurately reflects
       # how dependencies should later be updated.
-      - name: Run neophile
-        uses: lsst-sqre/run-neophile@v1
+      - uses: lsst-sqre/run-neophile@v1
         with:
           python-version: "3.11"
           mode: update
@@ -37,8 +36,7 @@ jobs:
       - name: Install extra packages
         run: sudo apt install -y graphviz libpq-dev libldap2-dev libsasl2-dev
 
-      - name: Run tox
-        uses: lsst-sqre/run-tox@v1
+      - uses: lsst-sqre/run-tox@v1
         with:
           python-version: ${{ matrix.python }}
           tox-envs: "lint,typing,py,docs,docs-linkcheck"


### PR DESCRIPTION
The GitHub Action to set up minikube that the test suite was using is apparently no longer supported, so switch to the one that's recommended by the minikube documentation and is now used in Phalanx.

Remove some unnecessary name settings for action steps, and rename the periodic workflow file to periodic-ci, matching the current templates.