### PR TITLE
Increase the timeout for periodic CI

### DIFF
--- a/.github/workflows/periodic-ci.yaml
+++ b/.github/workflows/periodic-ci.yaml
@@ -12,7 +12,7 @@ name: Periodic CI
 jobs:
   test:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 20
 
     strategy:
       matrix:


### PR DESCRIPTION
Running every tox CI environment in serial can take a while, so increase the timeout to 20 minutes from 10 minutes.