### PR TITLE
DM-40495: Add better error reporting of linkcheck failures

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,41 @@
+.PHONY: help
+help:
+	@echo "Make targets for Gafaelfawr"
+	@echo "make init - Set up dev environment"
+	@echo "make linkcheck - Check for broken links in documentation"
+	@echo "make ui - Build the JavaScript frontend"
+	@echo "make update - Update pinned dependencies and run make init"
+	@echo "make update-deps - Update pinned dependencies"
+	@echo "make update-deps-no-hashes - Pin dependencies without hashes"
+
+# npm dependencies have to be installed for pre-commit eslint to work.
+.PHONY: init
+init:
+	pip install --editable .
+	pip install --upgrade -r requirements/main.txt -r requirements/dev.txt
+	rm -rf .tox
+	pip install --upgrade tox tox-docker
+	pre-commit install
+	cd ui && npm install --legacy-peer-deps
+
+# This is defined as a Makefile target instead of only a tox command because
+# if the command fails we want to cat output.txt, which contains the
+# actually useful linkcheck output. tox unfortunately doesn't support this
+# level of shell trickery after failed commands.
+.PHONY: linkcheck
+linkcheck:
+	sphinx-build --keep-going -n -W -T -b linkcheck docs	\
+	    docs/_build/linkcheck				\
+	    || (cat docs/_build/linkcheck/output.txt; exit 1)
+
+.PHONY: ui
+ui:
+	cd ui && npm run lint:fix
+	cd ui && npm run build
+
+.PHONY: update
+update: update-deps init
+
 # The dependencies need --allow-unsafe because kubernetes-asyncio and
 # (transitively) pre-commit depends on setuptools, which is normally not
 # allowed to appear in a hashed dependency file.
@@ -21,21 +59,3 @@ update-deps-no-hashes:
 	pip-compile --upgrade --resolver=backtracking --build-isolation	\
 	    --allow-unsafe						\
 	    --output-file requirements/dev.txt requirements/dev.in
-
-# npm dependencies have to be installed for pre-commit eslint to work.
-.PHONY: init
-init:
-	pip install --editable .
-	pip install --upgrade -r requirements/main.txt -r requirements/dev.txt
-	rm -rf .tox
-	pip install --upgrade tox tox-docker
-	pre-commit install
-	cd ui && npm install --legacy-peer-deps
-
-.PHONY: update
-update: update-deps init
-
-.PHONY: ui
-ui:
-	cd ui && npm run lint:fix
-	cd ui && npm run build

--- a/tox.ini
+++ b/tox.ini
@@ -62,9 +62,11 @@ commands =
 
 [testenv:docs-linkcheck]
 description = Check links in the documentation
+allowlist_externals =
+    make
 commands =
     gafaelfawr openapi-schema --add-back-link --output docs/_static/openapi.json
-    sphinx-build --keep-going -n -W -T -b linkcheck -d {envtmpdir}/doctrees docs docs/_build/linkcheck
+    make linkcheck
 
 [testenv:lint]
 description = Lint codebase by running pre-commit (Black, isort, Flake8)


### PR DESCRIPTION
Sphinx's linkcheck target does not summarize errors at the end of the run normally, but it does write the errors into an output.txt file. Move the linkcheck code into Makefile so that we can use shell trickery and display output.txt at the end of the run if the check failed.

Add a make help target as the default that displays the available Makefile targets.