### PR TITLE
DM-40567: Diagnose invalid GafaelfawrIngress scopes

### DIFF
--- a/changelog.d/20230830_145513_rra_DM_40567b.md
+++ b/changelog.d/20230830_145513_rra_DM_40567b.md
@@ -1,0 +1,3 @@
+### Bug fixes
+
+- The Gafaelfawr Kubernetes operator now rejects `GafaelfawrIngress` resources with invalid scopes and sets an error status, rather than creating an `Ingress` resource that will always fail.

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -8,9 +8,9 @@ alabaster==0.7.13 \
     --hash=sha256:1ee19aca801bbabb5ba3f5f258e4422dfa86f82f3e9cefb0859b283cdd7f62a3 \
     --hash=sha256:a27a4a084d5e690e16e01e03ad2b2e552c61a65469419b907243193de1a84ae2
     # via sphinx
-anyio==3.7.1 \
-    --hash=sha256:44a3c9aba0f5defa43261a8b3efb97891f2bd7d804e0e1f56419befa1adfc780 \
-    --hash=sha256:91dee416e570e92c64041bd18b900d1d6fa78dff7048769ce5ac5ddad004fbb5
+anyio==4.0.0 \
+    --hash=sha256:cfdb2b588b9fc25ede96d8db56ed50848b0b649dca3dd1df0b11f683bb9e0b5f \
+    --hash=sha256:f7ed51751b2c2add651e5747c891b47e26d2a21be5d32d9311dfe9692f3e5d7a
     # via
     #   -c requirements/main.txt
     #   httpcore

--- a/requirements/main.txt
+++ b/requirements/main.txt
@@ -99,9 +99,9 @@ aiosignal==1.3.1 \
     --hash=sha256:54cd96e15e1649b75d6c87526a6ff0b6c1b0dd3459f43d9ca11d48c339b68cfc \
     --hash=sha256:f8376fb07dd1e86a584e4fcdec80b36b7f81aac666ebc724e2c090300dd83b17
     # via aiohttp
-anyio==3.7.1 \
-    --hash=sha256:44a3c9aba0f5defa43261a8b3efb97891f2bd7d804e0e1f56419befa1adfc780 \
-    --hash=sha256:91dee416e570e92c64041bd18b900d1d6fa78dff7048769ce5ac5ddad004fbb5
+anyio==4.0.0 \
+    --hash=sha256:cfdb2b588b9fc25ede96d8db56ed50848b0b649dca3dd1df0b11f683bb9e0b5f \
+    --hash=sha256:f7ed51751b2c2add651e5747c891b47e26d2a21be5d32d9311dfe9692f3e5d7a
     # via
     #   httpcore
     #   starlette

--- a/src/gafaelfawr/factory.py
+++ b/src/gafaelfawr/factory.py
@@ -366,7 +366,9 @@ class Factory:
             Newly-created Kubernetes service.
         """
         storage = KubernetesIngressStorage(api_client, self._logger)
-        return KubernetesIngressService(storage, self._logger)
+        return KubernetesIngressService(
+            self._context.config, storage, self._logger
+        )
 
     def create_kubernetes_token_service(
         self, api_client: ApiClient

--- a/tests/data/kubernetes/input/ingress-error-scope.yaml
+++ b/tests/data/kubernetes/input/ingress-error-scope.yaml
@@ -1,0 +1,24 @@
+apiVersion: gafaelfawr.lsst.io/v1alpha1
+kind: GafaelfawrIngress
+metadata:
+  name: small-ingress
+  namespace: {namespace}
+config:
+  baseUrl: "https://foo.example.com"
+  scopes:
+    all: ["invalid:scope"]
+template:
+  metadata:
+    name: small
+  spec:
+    rules:
+      - host: foo.example.com
+        http:
+          paths:
+            - path: /foo
+              pathType: Prefix
+              backend:
+                service:
+                  name: something
+                  port:
+                    name: http


### PR DESCRIPTION
Check the validity of scopes in a GafaelfawrIngress Kubernetes object and set an error status rather than creating an Ingress that will always fail.