### PR TITLE
Update Python dependencies

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -598,15 +598,15 @@ hpack==4.0.0 \
     --hash=sha256:84a076fad3dc9a9f8063ccb8041ef100867b1878b25ef0ee63847a5d53818a6c \
     --hash=sha256:fc41de0c63e687ebffde81187a948221294896f6bdc0ae2312708df339430095
     # via h2
-httpcore==0.17.3 \
-    --hash=sha256:a6f30213335e34c1ade7be6ec7c47f19f50c56db36abef1a9dfa3815b1cb3888 \
-    --hash=sha256:c2789b767ddddfa2a5782e3199b2b7f6894540b17b16ec26b2c4d8e103510b87
+httpcore==0.18.0 \
+    --hash=sha256:13b5e5cd1dca1a6636a6aaea212b19f4f85cd88c366a2b82304181b769aab3c9 \
+    --hash=sha256:adc5398ee0a476567bf87467063ee63584a8bce86078bf748e48754f60202ced
     # via
     #   -c requirements/main.txt
     #   httpx
-httpx==0.24.1 \
-    --hash=sha256:06781eb9ac53cde990577af654bd990a4949de37a28bdb4a230d434f3a30b9bd \
-    --hash=sha256:5853a43053df830c20f8110c5e69fe44d035d850b2dfe795e196f00fdb774bdd
+httpx==0.25.0 \
+    --hash=sha256:181ea7f8ba3a82578be86ef4171554dd45fec26a02556a744db029a0a27b7100 \
+    --hash=sha256:47ecda285389cb32bb2691cc6e069e3ab0205956f681c5b2ad2325719751d875
     # via
     #   -c requirements/main.txt
     #   respx
@@ -1348,24 +1348,24 @@ rpds-py==0.10.2 \
     # via
     #   jsonschema
     #   referencing
-ruff==0.0.287 \
-    --hash=sha256:00d579a011949108c4b4fa04c4f1ee066dab536a9ba94114e8e580c96be2aeb4 \
-    --hash=sha256:022f8bed2dcb5e5429339b7c326155e968a06c42825912481e10be15dafb424b \
-    --hash=sha256:02dc4f5bf53ef136e459d467f3ce3e04844d509bc46c025a05b018feb37bbc39 \
-    --hash=sha256:06ac5df7dd3ba8bf83bba1490a72f97f1b9b21c7cbcba8406a09de1a83f36083 \
-    --hash=sha256:150007028ad4976ce9a7704f635ead6d0e767f73354ce0137e3e44f3a6c0963b \
-    --hash=sha256:1cf4d5ad3073af10f186ea22ce24bc5a8afa46151f6896f35c586e40148ba20b \
-    --hash=sha256:1e0f9ee4c3191444eefeda97d7084721d9b8e29017f67997a20c153457f2eafd \
-    --hash=sha256:26bd0041d135a883bd6ab3e0b29c42470781fb504cf514e4c17e970e33411d90 \
-    --hash=sha256:2918cb7885fa1611d542de1530bea3fbd63762da793751cc8c8d6e4ba234c3d8 \
-    --hash=sha256:2bfb478e1146a60aa740ab9ebe448b1f9e3c0dfb54be3cc58713310eef059c30 \
-    --hash=sha256:33d7b251afb60bec02a64572b0fd56594b1923ee77585bee1e7e1daf675e7ae7 \
-    --hash=sha256:44bceb3310ac04f0e59d4851e6227f7b1404f753997c7859192e41dbee9f5c8d \
-    --hash=sha256:66d9d58bcb29afd72d2afe67120afcc7d240efc69a235853813ad556443dc922 \
-    --hash=sha256:8ca1ed11d759a29695aed2bfc7f914b39bcadfe2ef08d98ff69c873f639ad3a8 \
-    --hash=sha256:a24a280db71b0fa2e0de0312b4aecb8e6d08081d1b0b3c641846a9af8e35b4a7 \
-    --hash=sha256:d3a810a79b8029cc92d06c36ea1f10be5298d2323d9024e1d21aedbf0a1a13e5 \
-    --hash=sha256:e9843e5704d4fb44e1a8161b0d31c1a38819723f0942639dfeb53d553be9bfb5
+ruff==0.0.288 \
+    --hash=sha256:0496556da7b413279370cae7de001a0415279e9318dc1fabd447a3ca7b398bce \
+    --hash=sha256:10feeabd15e2c6e06bce75aa97e806009cf909261cd124f24ef832385914aae9 \
+    --hash=sha256:13d1e6cef389dc0238ef0e97e25561c925bf255d0f59f70ed2d6bd0a13fdd7b0 \
+    --hash=sha256:28ee03358e4eb89e843cb4fd9cf0406eb603a7e060436ffc623b29544e374c2b \
+    --hash=sha256:2d5df4a49eaa11536776b1efcc4e88e373b205a958712185de8e4ae287397614 \
+    --hash=sha256:64c01615b8640c703a56a1eac3114a653166eafa5d416ffc9e6cafbfb86ab927 \
+    --hash=sha256:6ca84861bf046e4365e20f4d664dc0aa02b377a6896a393dad716e033ac47a65 \
+    --hash=sha256:71eb3e09cb47cc02c13c6dc5561055b913572995cf5fa8286948f938bc464621 \
+    --hash=sha256:73066b1da66b3d4942cce8c90fd6e09108851e0867a5f7071255d1b99aee3e75 \
+    --hash=sha256:7534da2f1e724b87a5041615652bca7c6e721f90ae3a01d1d8e965d08a615038 \
+    --hash=sha256:84691fd3c8edd705c27eb7ccf745a3530c31e4c83010f9ce20e0b9eb0578f099 \
+    --hash=sha256:bd9977eee17d7f29beca74b478f6930c7dd006d486bac615c849a3436384fc28 \
+    --hash=sha256:db1de2ac1de219f29c12940b429fe365974c3d9f69464c4660c06e4b4b284dba \
+    --hash=sha256:e08c81394ae272b1595580dad1bfc62de72d9356c51e76b5c2fdd546f84e6168 \
+    --hash=sha256:e450e50a936409439bf4e28e85412622693350cf4da89c69e1f14af21ddbc467 \
+    --hash=sha256:ea0535d48f674d6a6bf1e6fb1a18c40622cb6496b0994cfdcd7aec763ef8b589 \
+    --hash=sha256:ef9a6563bbacfc7afdba04722d742db4f1961ab6f398a2e305b43c21d418c149
     # via -r requirements/dev.in
 scriv[toml]==1.3.1 \
     --hash=sha256:4df597ee0a7b3dcc0d5315d7649df091efcb1b3ff08f0b51a698340727d17118 \
@@ -1648,9 +1648,9 @@ urllib3[socks]==1.26.16 \
     #   -c requirements/main.txt
     #   requests
     #   selenium
-virtualenv==20.24.4 \
-    --hash=sha256:29c70bb9b88510f6414ac3e55c8b413a1f96239b6b789ca123437d5e892190cb \
-    --hash=sha256:772b05bfda7ed3b8ecd16021ca9716273ad9f4467c801f27e83ac73430246dca
+virtualenv==20.24.5 \
+    --hash=sha256:b80039f280f4919c77b30f1c23294ae357c4c8701042086e3fc005963e4e537b \
+    --hash=sha256:e8361967f6da6fbdf1426483bfe9fca8287c242ac0bc30429905721cefbff752
     # via pre-commit
 wsproto==1.2.0 \
     --hash=sha256:ad565f26ecb92588a3e43bc3d96164de84cd9902482b130d0ddbaa9664a85065 \
@@ -1705,9 +1705,9 @@ zstandard==0.21.0 \
     # via selenium-wire
 
 # The following packages are considered to be unsafe in a requirements file:
-setuptools==68.2.0 \
-    --hash=sha256:00478ca80aeebeecb2f288d3206b0de568df5cd2b8fada1209843cc9a8d88a48 \
-    --hash=sha256:af3d5949030c3f493f550876b2fd1dd5ec66689c4ee5d5344f009746f71fd5a8
+setuptools==68.2.1 \
+    --hash=sha256:56ee14884fd8d0cd015411f4a13f40b4356775a0aefd9ebc1d3bfb9a1acb32f1 \
+    --hash=sha256:eff96148eb336377ab11beee0c73ed84f1709a40c0b870298b0d058828761bae
     # via
     #   -c requirements/main.txt
     #   nodeenv

--- a/requirements/main.txt
+++ b/requirements/main.txt
@@ -451,9 +451,9 @@ google-api-core[grpc]==2.11.1 \
     # via
     #   google-cloud-core
     #   google-cloud-firestore
-google-auth==2.22.0 \
-    --hash=sha256:164cba9af4e6e4e40c3a4f90a1a6c12ee56f14c0b4868d1ca91b32826ab334ce \
-    --hash=sha256:d61d1b40897407b574da67da1a833bdc10d5a11642566e506565d1b1a46ba873
+google-auth==2.23.0 \
+    --hash=sha256:2cec41407bd1e207f5b802638e32bb837df968bb5c05f413d0fa526fac4cf7a7 \
+    --hash=sha256:753a26312e6f1eaeec20bc6f2644a10926697da93446e1f8e24d6d32d45a922a
     # via
     #   google-api-core
     #   google-cloud-core
@@ -596,9 +596,9 @@ h11==0.14.0 \
     # via
     #   httpcore
     #   uvicorn
-httpcore==0.17.3 \
-    --hash=sha256:a6f30213335e34c1ade7be6ec7c47f19f50c56db36abef1a9dfa3815b1cb3888 \
-    --hash=sha256:c2789b767ddddfa2a5782e3199b2b7f6894540b17b16ec26b2c4d8e103510b87
+httpcore==0.18.0 \
+    --hash=sha256:13b5e5cd1dca1a6636a6aaea212b19f4f85cd88c366a2b82304181b769aab3c9 \
+    --hash=sha256:adc5398ee0a476567bf87467063ee63584a8bce86078bf748e48754f60202ced
     # via httpx
 httptools==0.6.0 \
     --hash=sha256:03bfd2ae8a2d532952ac54445a2fb2504c804135ed28b53fefaf03d3a93eb1fd \
@@ -637,9 +637,9 @@ httptools==0.6.0 \
     --hash=sha256:e41ccac9e77cd045f3e4ee0fc62cbf3d54d7d4b375431eb855561f26ee7a9ec4 \
     --hash=sha256:f959e4770b3fc8ee4dbc3578fd910fab9003e093f20ac8c621452c4d62e517cb
     # via uvicorn
-httpx==0.24.1 \
-    --hash=sha256:06781eb9ac53cde990577af654bd990a4949de37a28bdb4a230d434f3a30b9bd \
-    --hash=sha256:5853a43053df830c20f8110c5e69fe44d035d850b2dfe795e196f00fdb774bdd
+httpx==0.25.0 \
+    --hash=sha256:181ea7f8ba3a82578be86ef4171554dd45fec26a02556a744db029a0a27b7100 \
+    --hash=sha256:47ecda285389cb32bb2691cc6e069e3ab0205956f681c5b2ad2325719751d875
     # via
     #   -r requirements/main.in
     #   safir
@@ -986,7 +986,6 @@ six==1.16.0 \
     --hash=sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926 \
     --hash=sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254
     # via
-    #   google-auth
     #   kubernetes-asyncio
     #   python-dateutil
 sniffio==1.3.0 \
@@ -1283,7 +1282,7 @@ yarl==1.9.2 \
     # via aiohttp
 
 # The following packages are considered to be unsafe in a requirements file:
-setuptools==68.2.0 \
-    --hash=sha256:00478ca80aeebeecb2f288d3206b0de568df5cd2b8fada1209843cc9a8d88a48 \
-    --hash=sha256:af3d5949030c3f493f550876b2fd1dd5ec66689c4ee5d5344f009746f71fd5a8
+setuptools==68.2.1 \
+    --hash=sha256:56ee14884fd8d0cd015411f4a13f40b4356775a0aefd9ebc1d3bfb9a1acb32f1 \
+    --hash=sha256:eff96148eb336377ab11beee0c73ed84f1709a40c0b870298b0d058828761bae
     # via kubernetes-asyncio

--- a/tests/handlers/oidc_test.py
+++ b/tests/handlers/oidc_test.py
@@ -185,9 +185,9 @@ async def test_unauthenticated(
     assert not url.scheme
     assert not url.netloc
     assert url.path == "/login"
-    params = urlencode(login_params, safe="/")
+    params = urlencode(login_params)
     expected_url = f"https://{TEST_HOSTNAME}/auth/openid/login?{params}"
-    assert query_from_url(r.headers["Location"]) == {"rd": [str(expected_url)]}
+    assert query_from_url(r.headers["Location"]) == {"rd": [expected_url]}
 
     assert parse_log(caplog) == [
         {


### PR DESCRIPTION
Fix a test that failed because the redirect URL parameter in the redirect returned by OpenID Connect login now encodes the slashes, whereas before it doesn't. Some change in dependencies must have done that.