### PR TITLE
DM-23878: Allow the LDAP group search to be configured

### DIFF
--- a/changelog.d/20231002_161626_rra_DM_23878.md
+++ b/changelog.d/20231002_161626_rra_DM_23878.md
@@ -1,0 +1,7 @@
+### New features
+
+- Gafaelfawr now supports the common LDAP configuration of recording group membership by full user DN rather than only username. Set `group_search_by_dn` to search for the user by full DN in the group tree. This requires LDAP also be used for user metadata.
+
+### Other changes
+
+- Log the full contents of the upstream OIDC token before token verification if debug logging is enabled.

--- a/docs/documenteer.toml
+++ b/docs/documenteer.toml
@@ -50,21 +50,15 @@ nitpick_ignore = [
     ["py:class", "starlette.routing.Route"],
     ["py:class", "starlette.routing.BaseRoute"],
     ["py:exc", "starlette.exceptions.HTTPException"],
-    # Special Pydantic magic that Sphinx doesn't understand.
-    ["py:class", "gafaelfawr.models.history.ConstrainedStrValue"],
-    ["py:class", "gafaelfawr.models.token.ConstrainedIntValue"],
-    ["py:class", "gafaelfawr.models.token.ConstrainedStrValue"],
     # asyncio.Lock is documented, and that's what all the code references, but
     # the combination of Sphinx extensions we're using confuse themselves and
     # there doesn't seem to be any way to fix this.
     ["py:class", "asyncio.locks.Lock"],
-    # Bug in autodoc_pydantic.
-    ["py:obj", "gafaelfawr.models.kubernetes.GafaelfawrIngressConfig.all fields"],
-    ["py:obj", "gafaelfawr.models.kubernetes.GafaelfawrIngressDelegate.all fields"],
-    ["py:obj", "gafaelfawr.config.Settings.all fields"],
 ]
 nitpick_ignore_regex = [
     ["py:class", "kubernetes_asyncio\\.client\\.models\\..*"],
+    # Bug in autodoc_pydantic.
+    ["py:obj", ".*\\.all fields"],
 ]
 python_api_dir = "dev/internals"
 rst_epilog_file = "_rst_epilog.rst"

--- a/src/gafaelfawr/config.py
+++ b/src/gafaelfawr/config.py
@@ -163,6 +163,23 @@ class LDAPSettings(CamelCaseModel):
     group_base_dn: str
     """Base DN to use when executing an LDAP search for user groups."""
 
+    group_search_template: str = (
+        "(&(objectClass={group_object_class})({group_member_attr}={username}))"
+    )
+    """Search template for locating a user's group membership.
+
+    The Python `format` template used to construct the LDAP search for the
+    user's group memberships. ``group_object_class`` and ``group_member_attr``
+    will be replaced with those settings, and ``username`` will be replaced
+    with the username of the authenticated user.
+
+    The default will work with LDAP servers that have an attribute containing
+    the simple usernames of the members in the group's LDAP entry. LDAP
+    servers that only contain DNs in the group LDAP entry may need to
+    customize this setting to search for the user's DN (constructed from their
+    username in the format string) instead of the simple username.
+    """
+
     group_object_class: str = "posixGroup"
     """LDAP group object class.
 
@@ -593,6 +610,21 @@ class LDAPConfig:
     group_base_dn: str
     """Base DN to use when executing LDAP search for group membership."""
 
+    group_search_template: str
+    """Search template for locating a user's group membership.
+
+    The Python `format` template used to construct the LDAP search for the
+    user's group memberships. ``group_object_class`` and ``group_member_attr``
+    will be replaced with those settings, and ``username`` will be replaced
+    with the username of the authenticated user.
+
+    The default will work with LDAP servers that have an attribute containing
+    the simple usernames of the members in the group's LDAP entry. LDAP
+    servers that only contain DNs in the group LDAP entry may need to
+    customize this setting to search for the user's DN (constructed from their
+    username in the format string) instead of the simple username.
+    """
+
     group_object_class: str = "posixGroup"
     """LDAP group object class.
 
@@ -924,6 +956,7 @@ class Config:
                 password=ldap_password,
                 use_kerberos=settings.ldap.use_kerberos,
                 group_base_dn=settings.ldap.group_base_dn,
+                group_search_template=settings.ldap.group_search_template,
                 group_object_class=settings.ldap.group_object_class,
                 group_member_attr=settings.ldap.group_member_attr,
                 user_base_dn=settings.ldap.user_base_dn,

--- a/src/gafaelfawr/providers/oidc.py
+++ b/src/gafaelfawr/providers/oidc.py
@@ -137,7 +137,7 @@ class OIDCProvider(Provider):
             "code": code,
             "redirect_uri": self._config.redirect_url,
         }
-        self._logger.info("Retrieving ID token from %s", token_url)
+        self._logger.info("Retrieving ID token", token_url=token_url)
 
         # If the call failed, try to extract an error from the reply.  If that
         # fails, just raise an exception for the HTTP status.
@@ -246,15 +246,7 @@ class OIDCTokenVerifier:
             raise UnknownKeyIdError("No kid in token header")
         key_id = unverified_header["kid"]
 
-        if "jti" in unverified_token:
-            self._logger.debug(
-                "Verifying token %s from issuer %s",
-                unverified_token["jti"],
-                issuer_url,
-            )
-        else:
-            self._logger.debug("Verifying token from issuer %s", issuer_url)
-
+        self._logger.debug("Verifying OIDC token", token_data=unverified_token)
         if issuer_url != self._config.issuer:
             raise jwt.InvalidIssuerError(f"Unknown issuer: {issuer_url}")
 

--- a/src/gafaelfawr/storage/ldap.py
+++ b/src/gafaelfawr/storage/ldap.py
@@ -49,8 +49,8 @@ class LDAPStorage:
         username
             Username of the user.
         primary_gid
-            Primary GID if set.  If not `None`, search for the group with this
-            GID and add it to the user's group memberships.  This handles LDAP
+            Primary GID if set. If not `None`, search for the group with this
+            GID and add it to the user's group memberships. This handles LDAP
             configurations where the user's primary group is represented only
             by their GID and not their group memberships.
 
@@ -64,9 +64,11 @@ class LDAPStorage:
         LDAPError
             Raised if some error occurred while doing the LDAP search.
         """
-        group_class = self._config.group_object_class
-        member_attr = self._config.group_member_attr
-        search = f"(&(objectClass={group_class})({member_attr}={username}))"
+        search = self._config.group_search_template.format(
+            group_object_class=self._config.group_object_class,
+            group_member_attr=self._config.group_member_attr,
+            username=username,
+        )
         logger = self._logger.bind(ldap_search=search, user=username)
         results = await self._query(
             self._config.group_base_dn,
@@ -97,6 +99,7 @@ class LDAPStorage:
 
         # Check that the primary group is included, and if not, try to add it.
         if primary_gid:
+            group_class = self._config.group_object_class
             search = f"(&(objectClass={group_class})(gidNumber={primary_gid}))"
             logger = self._logger.bind(ldap_search=search)
             results = await self._query(
@@ -150,9 +153,11 @@ class LDAPStorage:
         LDAPError
             Raised if some error occurred when searching LDAP.
         """
-        group_class = self._config.group_object_class
-        member_attr = self._config.group_member_attr
-        search = f"(&(objectClass={group_class})({member_attr}={username}))"
+        search = self._config.group_search_template.format(
+            group_object_class=self._config.group_object_class,
+            group_member_attr=self._config.group_member_attr,
+            username=username,
+        )
         logger = self._logger.bind(ldap_search=search, user=username)
         results = await self._query(
             self._config.group_base_dn,
@@ -177,6 +182,7 @@ class LDAPStorage:
 
         # Check that the primary group is included, and if not, try to add it.
         if primary_gid and not any(g.id == primary_gid for g in groups):
+            group_class = self._config.group_object_class
             search = f"(&(objectClass={group_class})(gidNumber={primary_gid}))"
             logger = self._logger.bind(ldap_search=search)
             results = await self._query(

--- a/src/gafaelfawr/storage/ldap.py
+++ b/src/gafaelfawr/storage/ldap.py
@@ -64,11 +64,7 @@ class LDAPStorage:
         LDAPError
             Raised if some error occurred while doing the LDAP search.
         """
-        search = self._config.group_search_template.format(
-            group_object_class=self._config.group_object_class,
-            group_member_attr=self._config.group_member_attr,
-            username=username,
-        )
+        search = self._build_group_member_search(username)
         logger = self._logger.bind(ldap_search=search, user=username)
         results = await self._query(
             self._config.group_base_dn,
@@ -153,11 +149,7 @@ class LDAPStorage:
         LDAPError
             Raised if some error occurred when searching LDAP.
         """
-        search = self._config.group_search_template.format(
-            group_object_class=self._config.group_object_class,
-            group_member_attr=self._config.group_member_attr,
-            username=username,
-        )
+        search = self._build_group_member_search(username)
         logger = self._logger.bind(ldap_search=search, user=username)
         results = await self._query(
             self._config.group_base_dn,
@@ -279,6 +271,32 @@ class LDAPStorage:
             msg = "LDAP user entry invalid"
             logger.exception(msg, error=str(e))
             raise LDAPError(msg, username) from e
+
+    def _build_group_member_search(self, username: str) -> str:
+        """Build the LDAP search to find group memberships for a user.
+
+        Parameters
+        ----------
+        username
+            Username of the user.
+
+        Returns
+        -------
+        str
+            LDAP search to find their group memberships.
+        """
+        group_class = self._config.group_object_class
+        member_attr = self._config.group_member_attr
+        if self._config.group_search_by_dn:
+            if not self._config.user_base_dn:
+                # Checked in Settings model so should be impossible.
+                raise ValueError("user_base_dn not set")
+            base_dn = self._config.user_base_dn
+            attr = self._config.user_search_attr
+            target = f"{attr}={username},{base_dn}"
+        else:
+            target = username
+        return f"(&(objectClass={group_class})({member_attr}={target}))"
 
     async def _query(
         self,

--- a/tests/data/config/oidc-ldap-memberdn.yaml.in
+++ b/tests/data/config/oidc-ldap-memberdn.yaml.in
@@ -1,0 +1,38 @@
+realm: "example.com"
+logLevel: "DEBUG"
+sessionSecretFile: "{session_secret_file}"
+databaseUrl: "{database_url}"
+redisUrl: "redis://localhost:6379/0"
+initialAdmins: ["admin"]
+afterLogoutUrl: "https://example.com/landing"
+groupMapping:
+  "exec:admin": ["admin"]
+  "exec:test": ["test"]
+  "read:all": ["foo", "admin", "org-a-team"]
+knownScopes:
+  "admin:token": "Can create and modify tokens for any user"
+  "exec:admin": "admin description"
+  "exec:test": "test description"
+  "read:all": "can read everything"
+  "user:token": "Can create and modify user tokens"
+ldap:
+  url: "ldaps://ldap.example.com/"
+  groupBaseDn: "dc=example,dc=com"
+  groupSearchByDn: true
+  userBaseDn: "ou=people,dc=example,dc=com"
+  uidAttr: "uidNumber"
+  gidAttr: "gidNumber"
+oidc:
+  clientId: "some-oidc-client-id"
+  clientSecretFile: "{oidc_secret_file}"
+  loginUrl: "https://upstream.example.com/oidc/login"
+  loginParams:
+    skin: "test"
+  redirectUrl: "https://upstream.example.com/login"
+  tokenUrl: "https://upstream.example.com/token"
+  enrollmentUrl: "https://upstream.example.com/enroll"
+  scopes:
+    - "email"
+    - "voPerson"
+  issuer: "https://upstream.example.com/"
+  audience: "https://test.example.com/"

--- a/tests/handlers/login_oidc_ldap_test.py
+++ b/tests/handlers/login_oidc_ldap_test.py
@@ -469,3 +469,58 @@ async def test_double_username(
             ]
         },
     ]
+
+
+@pytest.mark.asyncio
+async def test_ldap_member_dn(
+    tmp_path: Path,
+    client: AsyncClient,
+    respx_mock: respx.Router,
+    mock_ldap: MockLDAP,
+) -> None:
+    """Test group membership attributes containing full user DNs."""
+    config = await reconfigure(tmp_path, "oidc-ldap-memberdn")
+    assert config.ldap
+    assert config.ldap.user_base_dn
+    token = create_upstream_oidc_jwt(uid="ldap-user", groups=["admin"])
+    mock_ldap.add_entries_for_test(
+        config.ldap.user_base_dn,
+        config.ldap.user_search_attr,
+        "ldap-user",
+        [
+            {
+                "displayName": ["LDAP User"],
+                "mail": ["ldap-user@example.com"],
+                "uidNumber": ["2000"],
+                "gidNumber": ["1222"],
+            }
+        ],
+    )
+    mock_ldap.add_entries_for_test(
+        config.ldap.group_base_dn,
+        "member",
+        f"{config.ldap.user_search_attr}=ldap-user,{config.ldap.user_base_dn}",
+        [
+            {"cn": ["foo"], "gidNumber": ["1222"]},
+            {"cn": ["group-1"], "gidNumber": ["123123"]},
+            {"cn": ["group-2"], "gidNumber": ["123442"]},
+        ],
+    )
+    r = await simulate_oidc_login(client, respx_mock, token)
+    assert r.status_code == 307
+
+    # Check that the data returned from the user-info API is correct.
+    r = await client.get("/auth/api/v1/user-info")
+    assert r.status_code == 200
+    assert r.json() == {
+        "username": "ldap-user",
+        "name": "LDAP User",
+        "email": "ldap-user@example.com",
+        "uid": 2000,
+        "gid": 1222,
+        "groups": [
+            {"name": "foo", "id": 1222},
+            {"name": "group-1", "id": 123123},
+            {"name": "group-2", "id": 123442},
+        ],
+    }

--- a/tests/handlers/login_oidc_test.py
+++ b/tests/handlers/login_oidc_test.py
@@ -62,7 +62,7 @@ async def test_login(
             "severity": "info",
         },
         {
-            "event": f"Retrieving ID token from {config.oidc.token_url}",
+            "event": "Retrieving ID token",
             "httpRequest": {
                 "requestMethod": "GET",
                 "requestUrl": ANY,
@@ -70,6 +70,7 @@ async def test_login(
             },
             "return_url": return_url,
             "severity": "info",
+            "token_url": config.oidc.token_url,
         },
         {
             "event": f"Successfully authenticated user {username}",
@@ -200,7 +201,7 @@ async def test_callback_error(
     assert "error_code: description" in r.text
     assert parse_log(caplog) == [
         {
-            "event": f"Retrieving ID token from {config.oidc.token_url}",
+            "event": "Retrieving ID token",
             "httpRequest": {
                 "requestMethod": "GET",
                 "requestUrl": ANY,
@@ -208,6 +209,7 @@ async def test_callback_error(
             },
             "return_url": return_url,
             "severity": "info",
+            "token_url": config.oidc.token_url,
         },
         {
             "error": "Error retrieving ID token: error_code: description",


### PR DESCRIPTION
Most LDAP servers put the full user DN in the membership attribute of the group tree. Add a boolean configuration option to specify this search behavior, constructing the DNs using the user base DN and search attribute. This requires that user LDAP information also be enabled, but I'm hoping to drop support for getting only groups from LDAP and not also users, so this isn't a major drawback and it allows simplification of the configuration and avoids supporting too many degrees of freedom.

Log more debugging information about upstream OIDC tokens.

Restructure the validation of the LDAP settings object to take more advantage of Pydantic v2 validators by using model validators instead of field validators where more appropriate. Remove all of the defaults from the frozen config, since that should be determined entirely by the settings models.