### PR TITLE
DM-41075: Log OIDC exceptions properly

### DIFF
--- a/changelog.d/20231006_082903_rra_DM_41075.md
+++ b/changelog.d/20231006_082903_rra_DM_41075.md
@@ -1,0 +1,3 @@
+### Bug fixes
+
+- Log exceptions encountered while parsing OpenID Connect responses from upstream providers, not just the deduced error message. Include the body of the response from the token endpoint if it could not be parsed as JSON.

--- a/changelog.d/20231006_083302_rra_DM_41075.md
+++ b/changelog.d/20231006_083302_rra_DM_41075.md
@@ -1,0 +1,3 @@
+### Other changes
+
+- Include curl in the Gafaelfawr container for manual debugging of web request problems.

--- a/scripts/install-base-packages.sh
+++ b/scripts/install-base-packages.sh
@@ -26,11 +26,11 @@ apt-get update
 # Install security updates:
 apt-get -y upgrade
 
-# git is required by setuptools-scm. libpq-dev is required by psycopg2. The
-# other packages are required by bonsai for LDAP binds or to manage the
-# Kerberos ticket cache. (krb5-user is not strictly needed, but it's useful
-# for debugging.)
-apt-get -y install --no-install-recommends git krb5-user kstart         \
+# git is required by setuptools-scm. libpq-dev is required by psycopg2. Most
+# of the other packages are required by bonsai for LDAP binds or to manage the
+# Kerberos ticket cache. curl and krb5-user are not strictly needed, but are
+# useful for debugging.
+apt-get -y install --no-install-recommends curl git krb5-user kstart    \
         libldap2-dev libldap-common libsasl2-dev libsasl2-modules       \
         libsasl2-modules-gssapi-mit libpq-dev
 


### PR DESCRIPTION
Rather than just raising exceptions during various OIDC provider parse errors, also log those exceptions. Include the body of the response from the token URL if we cannot parse it as valid JSON, since hopefully the chances that it contains secure information are low in that case.