### PR TITLE
DM-42093: Adjust the Redis connection pool parameters

### DIFF
--- a/changelog.d/20231208_105820_rra_DM_42093.md
+++ b/changelog.d/20231208_105820_rra_DM_42093.md
@@ -1,0 +1,3 @@
+### Bug fixes
+
+- Adjust the Redis connection pool parameters to hopefully improve recovery after a Redis server restart.

--- a/src/gafaelfawr/constants.py
+++ b/src/gafaelfawr/constants.py
@@ -128,10 +128,10 @@ REDIS_BACKOFF_MAX = 1.0
 REDIS_RETRIES = 10
 """How many times to try to connect to Redis before giving up."""
 
-REDIS_POOL_SIZE = 10
+REDIS_POOL_SIZE = 25
 """Size of the Redis connection pool."""
 
-REDIS_POOL_TIMEOUT = 10
+REDIS_POOL_TIMEOUT = 30
 """Seconds to wait for a connection from the pool before giving up."""
 
 REDIS_TIMEOUT = 5


### PR DESCRIPTION
Gafaelfawr is struggling to recover after a Redis server restart, such as from Kubernetes cluster upgrades. Enable retries on timeout, which is apparently not enabled by default. Increase the connection pool size since we've seen one case of pool exhaustion in production. Increase the length of time Gafaelfawr is willing to wait for a pool connection to become available.

Use from_pool to construct the Redis object so that we don't have to separately close the connection pool.