### PR TITLE
DM-42384: Fix protocol issues in OpenID Connect server

### DIFF
--- a/changelog.d/20240110_125829_rra_DM_42384.md
+++ b/changelog.d/20240110_125829_rra_DM_42384.md
@@ -1,0 +1,11 @@
+### Backwards-incompatible changes
+
+- When acting as an OpenID Connect server, Gafaelfawr no longer exposes all claims by default. Instead, it now honors the `scope` parameter in the request, which must include `openid` and may include `profile` and `email`.
+- Require the `oidcServer.issuer` configuration setting use the `https` scheme, since this is required by the OpenID Connect 1.0 specification.
+- Set the `aud` claim in OpenID Connect ID tokens issued by Gafaelfawr to the client ID of the requesting client instead of a fixed audience used for all tokens.
+- OpenID Connect ID tokens issued by Gafaelfawr now inherit their expiration time from the underlying Gafaelfawr token used as the authentication basis for the ID token. Previously, OpenID Connect ID tokens would receive the full default lifetime even when issued on the basis of Gafaelfawr tokens that were about to expire.
+
+### Bug fixes
+
+- Include the scope used to issue the ID token in the reply from the OpenID Connect server token endpoint.
+- In the response from `/.well-known/openid-configuration`, declare that the only supported response mode of the OpenID Connect server is `query`.

--- a/examples/docker/gafaelfawr.yaml
+++ b/examples/docker/gafaelfawr.yaml
@@ -38,7 +38,7 @@ github:
 
 # Configuration for the Gafaelfawr OpenID Connect server.
 oidc_server:
-  issuer: "http://localhost:8080"
+  issuer: "https://localhost:8080"
   keyId: "localhost-key-id"
   audience: "http://localhost"
   keyFile: "/run/secrets/issuer-key"

--- a/examples/gafaelfawr-dev.yaml
+++ b/examples/gafaelfawr-dev.yaml
@@ -41,7 +41,7 @@ github:
 
 # Configuration for the Gafaelfawr OpenID Connect server.
 oidcServer:
-  issuer: "http://localhost:8080"
+  issuer: "https://localhost:8080"
   keyId: "localhost-key-id"
   audience: "http://localhost"
   keyFile: "examples/secrets/issuer-key"

--- a/src/gafaelfawr/factory.py
+++ b/src/gafaelfawr/factory.py
@@ -415,11 +415,13 @@ class Factory:
         )
         authorization_store = OIDCAuthorizationStore(storage)
         token_service = self.create_token_service()
+        user_info_service = self.create_user_info_service()
         slack_client = self.create_slack_client()
         return OIDCService(
             config=self._context.config.oidc_server,
             authorization_store=authorization_store,
             token_service=token_service,
+            user_info_service=user_info_service,
             slack_client=slack_client,
             logger=self._logger,
         )

--- a/src/gafaelfawr/services/token.py
+++ b/src/gafaelfawr/services/token.py
@@ -753,31 +753,6 @@ class TokenService:
             return None
         return info
 
-    async def get_user_info(self, token: Token) -> TokenUserInfo | None:
-        """Get user information associated with a token.
-
-        Parameters
-        ----------
-        token
-            Data from the authentication token.
-
-        Returns
-        -------
-        TokenUserInfo or None
-            User information for the holder of that token, or `None` if the
-            token is not valid.
-        """
-        data = await self.get_data(token)
-        if not data:
-            return None
-        return TokenUserInfo(
-            username=data.username,
-            name=data.name,
-            uid=data.uid,
-            email=data.email,
-            groups=data.groups,
-        )
-
     async def list_tokens(
         self, auth_data: TokenData, username: str | None = None
     ) -> list[TokenInfo]:

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -29,7 +29,7 @@ from gafaelfawr.exceptions import InvalidGrantError
 from gafaelfawr.factory import Factory
 from gafaelfawr.models.admin import Admin
 from gafaelfawr.models.history import TokenChange, TokenChangeHistoryEntry
-from gafaelfawr.models.oidc import OIDCAuthorizationCode
+from gafaelfawr.models.oidc import OIDCAuthorizationCode, OIDCScope
 from gafaelfawr.models.token import Token, TokenData, TokenType, TokenUserInfo
 from gafaelfawr.schema import Base
 from gafaelfawr.storage.history import TokenChangeHistoryStore
@@ -128,7 +128,10 @@ def test_delete_all_data(
             )
             oidc_service = factory.create_oidc_service()
             return await oidc_service.issue_code(
-                "some-id", "https://example.com/", token
+                client_id="some-id",
+                redirect_uri="https://example.com/",
+                token=token,
+                scopes=[OIDCScope.openid],
             )
 
     code = event_loop.run_until_complete(setup())


### PR DESCRIPTION
Stop exposing all known claims by default in the issued ID token and instead honor scopes requested by the client. Currently, the supported scopes include the profile and email scopes defined by OpenID Connect (insofar as Gafaelfawr has the data).

Set the aud claim on ID tokens to the client ID rather than a fixed audience value that matches the Gafaelfawr issuer, bringing the implementation in line with the intent of the specification.

Tie the expiration time of OpenID Connect ID tokens to the expiration of the underlying Gafaelfawr token used as an authentication basis.

Require the oidcServer.issuer configuration setting use the https scheme, since the protocol requires that. Include the scope that was used for ID token issuance in the response from the token endpoint, since the spec may require that if unknown scopes were requested.

Declare, in the OpenID configuration endpoint, that the only supported response mode is query.