### PR TITLE
DM-42384: Add support for OpenID Connect nonces in server

### DIFF
--- a/changelog.d/20240111_164048_rra_DM_42384.md
+++ b/changelog.d/20240111_164048_rra_DM_42384.md
@@ -1,0 +1,3 @@
+### New features
+
+- Add support for a client-supplied nonce in OpenID Connect authentication with Gafaelfawr as a server. The provided nonce is passed through to the ID token following the OpenID Connect specification.

--- a/src/gafaelfawr/handlers/oidc.py
+++ b/src/gafaelfawr/handlers/oidc.py
@@ -112,6 +112,17 @@ async def get_login(
             examples=["omeKJ7MNv_9dKSKnVNjxMQ"],
         ),
     ] = None,
+    nonce: Annotated[
+        str | None,
+        Query(
+            title="ID token nonce",
+            description=(
+                "Nonce to include in ID tokens to mitigate replay attacks or"
+                " associate an ID token with a client session"
+            ),
+            examples=["5Ndm2AFSZ6dN6Gt-Iu6lng"],
+        ),
+    ] = None,
 ) -> str:
     oidc_service = context.factory.create_oidc_service()
 
@@ -153,6 +164,7 @@ async def get_login(
         redirect_uri=parsed_redirect_uri.geturl(),
         token=token_data.token,
         scopes=scopes,
+        nonce=nonce,
     )
     return_url = build_return_url(
         parsed_redirect_uri, state=state, code=str(code)

--- a/src/gafaelfawr/models/oidc.py
+++ b/src/gafaelfawr/models/oidc.py
@@ -156,6 +156,15 @@ class OIDCAuthorization(BaseModel):
         [OIDCScope.openid], title="Requested scopes"
     )
 
+    nonce: str | None = Field(
+        None,
+        title="Client-provided nonce",
+        description=(
+            "Nonce to include in the issued ID token for either replay"
+            " protection or to bind the ID token to a client session"
+        ),
+    )
+
     @field_serializer("created_at")
     def _serialize_datetime(self, time: datetime | None) -> int | None:
         return int(time.timestamp()) if time is not None else None

--- a/src/gafaelfawr/services/oidc.py
+++ b/src/gafaelfawr/services/oidc.py
@@ -38,7 +38,7 @@ __all__ = ["OIDCService"]
 
 _SCOPE_CLAIMS = {
     OIDCScope.openid: frozenset(
-        ["aud", "iat", "iss", "exp", "jti", "scope", "sub"]
+        ["aud", "iat", "iss", "exp", "jti", "nonce", "scope", "sub"]
     ),
     OIDCScope.profile: frozenset(["name", "preferred_username"]),
     OIDCScope.email: frozenset(["email"]),
@@ -138,6 +138,7 @@ class OIDCService:
         redirect_uri: str,
         token: Token,
         scopes: list[OIDCScope],
+        nonce: str | None = None,
     ) -> OIDCAuthorizationCode:
         """Issue a new authorization code.
 
@@ -151,6 +152,8 @@ class OIDCService:
             Underlying authentication token.
         scopes
             Requested scopes.
+        nonce
+            Client-provided nonce.
 
         Returns
         -------
@@ -170,6 +173,7 @@ class OIDCService:
             redirect_uri=redirect_uri,
             token=token,
             scopes=scopes,
+            nonce=nonce,
         )
         await self._authorization_store.create(authorization)
         return authorization.code
@@ -217,10 +221,10 @@ class OIDCService:
             "exp": int(token_data.expires.timestamp()),
             "jti": authorization.code.key,
             "name": user_info.name,
+            "nonce": authorization.nonce,
             "preferred_username": token_data.username,
             "scope": " ".join(s.value for s in authorization.scopes),
             "sub": token_data.username,
-            "uid_number": user_info.uid,
         }
         payload = self._filter_claims(payload, authorization)
 

--- a/tests/services/oidc_test.py
+++ b/tests/services/oidc_test.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 import time
 from datetime import timedelta
 from pathlib import Path
@@ -76,6 +77,7 @@ async def test_issue_code(tmp_path: Path, factory: Factory) -> None:
         },
         "created_at": ANY,
         "scopes": ["openid", "profile"],
+        "nonce": None,
     }
     now = time.time()
     assert now - 2 < serialized_code["created_at"] < now
@@ -283,6 +285,7 @@ async def test_issue_id_token(tmp_path: Path, factory: Factory) -> None:
         redirect_uri="https://example.com/",
         token=token_data.token,
         scopes=[OIDCScope.openid, OIDCScope.profile],
+        nonce=os.urandom(16).hex(),
     )
     oidc_token = await oidc_service.issue_id_token(authorization)
 
@@ -293,6 +296,7 @@ async def test_issue_id_token(tmp_path: Path, factory: Factory) -> None:
         "iss": config.oidc_server.issuer,
         "jti": authorization.code.key,
         "name": token_data.name,
+        "nonce": authorization.nonce,
         "preferred_username": token_data.username,
         "scope": "openid profile",
         "sub": token_data.username,


### PR DESCRIPTION
The OpenID Connect specification requires support for a client-provided nonce, which if given must be included vertabim in the nonce claim of the issued ID token. This value is used to protect against replay attacks and tie the ID token to a local session.