### PR TITLE
DM-42384: Add support for data rights information

### DIFF
--- a/changelog.d/20240117_152943_rra_DM_42384.md
+++ b/changelog.d/20240117_152943_rra_DM_42384.md
@@ -1,0 +1,3 @@
+### New features
+
+- Add a new `rubin` scope for the OpenID Connect server that, if requested, provides a `data_rights` claim listing the data releases to which the user has rights. Add a new `config.oidcServer.dataRightsMapping` configuration option that is used to determine that list of data releases from a user's group memberships.

--- a/docs/user-guide/helm.rst
+++ b/docs/user-guide/helm.rst
@@ -753,10 +753,34 @@ Kubernetes also deletes completed and failed jobs as necessary to maintain a cap
 To change the time limit for maintenance jobs (if, for instance, you have a huge user database or your database is very slow), set ``config.maintenance.deadlineSeconds`` to the length of time jobs are allowed to run for.
 To change the retention time for completed jobs, set ``config.maintenance.cleanupSeconds`` to the maximum lifetime of a completed job.
 
+.. _helm-oidc-server:
+
 OpenID Connect server
 =====================
 
 Gafaelfawr can act as an OpenID Connect identity provider for relying parties inside the Kubernetes cluster.
 To enable this, set ``config.oidcServer.enabled`` to true.
 If this is set, ``oidc-server-secrets`` and ``signing-key`` must be set in the Gafaelfawr Vault secret.
+
+Gafaelfawr can provide an OpenID Connect ID token claim listing the data releases to which the user has access.
+To do so, it must be configured with a mapping of group names to data releases to which membership in that group grants access.
+This is done via the ``config.oidcServer.dataRightsMapping`` setting.
+For example:
+
+.. code-block:: yaml
+
+   config:
+     oidcServer:
+       dataRightsMapping:
+         g_users:
+           - dp0.1
+           - dp0.2
+           - dp0.3
+         g_preview:
+           - dp0.1
+
+This configuration indicates members of the ``g_preview`` group have access to the ``dp0.1`` release and members of the ``g_users`` group have access to all of ``dp0.1``, ``dp0.2``, and ``dp0.3``.
+Users have access to the union of data releases across all of their group memberships.
+
 See :ref:`openid-connect` for more information.
+See :dmtn:`253` for how this OpenID Connect support can be used by International Data Access Centers.

--- a/docs/user-guide/openid-connect.rst
+++ b/docs/user-guide/openid-connect.rst
@@ -51,6 +51,11 @@ The following OpenID Connect scopes are supported and influence what claims are 
 ``email``
     Adds the ``email`` claim if the user's email address is known.
 
+``rubin``
+    Adds the ``data_rights`` claim with a space-separated list of data releases the user has access to, if there are any.
+    See :ref:`helm-oidc-server` for details on how to configure a mapping from group memberships to data releases.
+    For more information about how this scope is used, see :dmtn:`253`.
+
 Examples
 ========
 

--- a/src/gafaelfawr/models/oidc.py
+++ b/src/gafaelfawr/models/oidc.py
@@ -39,6 +39,7 @@ class OIDCScope(StrEnum):
     openid = "openid"
     profile = "profile"
     email = "email"
+    rubin = "rubin"
 
     @classmethod
     def parse_scopes(cls, scopes: str) -> list[Self]:

--- a/tests/data/config/github-oidc-server.yaml.in
+++ b/tests/data/config/github-oidc-server.yaml.in
@@ -23,8 +23,10 @@ oidcServer:
   issuer: "https://test.example.com/"
   keyId: "some-kid"
   keyFile: "{issuer_key_file}"
-  audience: "https://example.com/"
   secretsFile: "{oidc_server_secrets_file}"
+  dataRightsMapping:
+    "admin": ["dp0.1"]
+    "foo": ["dp0.3", "dp0.2"]
 github:
   clientId: "some-github-client-id"
   clientSecretFile: "{github_secret_file}"


### PR DESCRIPTION
Add a rubin scope for the OpenID Connect server and a data_rights claim that it enables. This claim will contain a space-separated list of data releases to which the user has access rights, and is intended for use by IDACs (see DMTN-253).

Add a new config.oidcServer.dataRightsMapping configuration option that tells Gafaelfawr how to determine those data rights from the user's group memberships.