### PR TITLE
DM-42384: Add OpenID Connect return URL registration

### DIFF
--- a/changelog.d/20240123_163221_rra_DM_42384.md
+++ b/changelog.d/20240123_163221_rra_DM_42384.md
@@ -1,0 +1,3 @@
+### Backwards-incompatible changes
+
+- Clients of the Gafaelfawr OpenID Connect server now must have registered return URIs as well as client IDs and secrets. Each element of the `oidc-server-secrets` secret must, in addition to the previous `id` and `secret` keys, contain a `return_uri` key that matches the return URL of authentications from that client. Those return URLs are now allowed to be at any (matching) domain and are not constrained to the same domain as Gafaelfawr.

--- a/docs/user-guide/openid-connect.rst
+++ b/docs/user-guide/openid-connect.rst
@@ -11,9 +11,18 @@ To protect a service that uses OpenID Connect, first set ``oidcServer.enabled`` 
 Then, create (or add to, if already existing) an ``oidc-server-secrets`` secret for the ``gafaelfawr`` Phalanx application.
 
 The value of the secret must be a JSON list, with each list member representing one OpenID Connect client.
-Each list member must be an object with two keys: ``id`` and ``secret``.
-``id`` is the unique OpenID Connect client ID that the client will present during authentication.
-``secret`` should be a randomly-generated secret that the client will use to authenticate.
+Each list member must be an object with the following keys:
+
+``id``
+    The unique OpenID Connect client ID (the ``client_id`` parameter in the OpenID Connect protocol) that the client will present during authentication.
+
+``secret``
+    A randomly-generated secret that the client will use to authenticate via the ``client_secret`` POST parameter.
+
+``return_uri``
+    The acceptable return URL for this client.
+    The actual return URL (the ``redirect_uri`` parameter) of any authentication must exactly match this return URL except for query parameters and fragments.
+    The path portion of this URL may not contain semicolons (``;``) to avoid potentially confusing parsing as either part of the path or as path parameters.
 
 Configure the OpenID client
 ===========================

--- a/src/gafaelfawr/config.py
+++ b/src/gafaelfawr/config.py
@@ -753,6 +753,9 @@ class OIDCClient:
     client_secret: str
     """Secret used to authenticate this client."""
 
+    return_uri: str
+    """Acceptable return URL when authenticating users for this client."""
+
 
 @dataclass(frozen=True, slots=True)
 class OIDCServerConfig:
@@ -1021,7 +1024,11 @@ class Config:
             oidc_secrets_json = cls._load_secret(path).decode()
             oidc_secrets = json.loads(oidc_secrets_json)
             oidc_clients = tuple(
-                OIDCClient(client_id=c["id"], client_secret=c["secret"])
+                OIDCClient(
+                    client_id=c["id"],
+                    client_secret=c["secret"],
+                    return_uri=c["return_uri"],
+                )
                 for c in oidc_secrets
             )
             data_rights_mapping = {

--- a/src/gafaelfawr/exceptions.py
+++ b/src/gafaelfawr/exceptions.py
@@ -24,6 +24,7 @@ __all__ = [
     "InputValidationError",
     "InsufficientScopeError",
     "InvalidClientError",
+    "InvalidClientIdError",
     "InvalidCSRFError",
     "InvalidCursorError",
     "InvalidDelegateToError",
@@ -55,7 +56,7 @@ __all__ = [
     "PermissionDeniedError",
     "ProviderError",
     "ProviderWebError",
-    "UnauthorizedClientError",
+    "ReturnUriMismatchError",
     "UnknownAlgorithmError",
     "UnknownKeyIdError",
     "UnsupportedGrantTypeError",
@@ -78,6 +79,16 @@ class DuplicateTokenNameError(InputValidationError):
 
     def __init__(self, message: str) -> None:
         super().__init__(message, ErrorLocation.body, ["token_name"])
+
+
+class InvalidClientIdError(InputValidationError):
+    """Invalid client ID for OpenID Connect server."""
+
+    error = "invalid_client"
+    status_code = status.HTTP_403_FORBIDDEN
+
+    def __init__(self, message: str) -> None:
+        super().__init__(message, ErrorLocation.query, ["client_id"])
 
 
 class InvalidCSRFError(InputValidationError):
@@ -179,6 +190,16 @@ class PermissionDeniedError(InputValidationError):
 
     error = "permission_denied"
     status_code = status.HTTP_403_FORBIDDEN
+
+
+class ReturnUriMismatchError(InputValidationError):
+    """Specified return URI does not match return URI of registered client."""
+
+    error = "return_uri_mismatch"
+    status_code = status.HTTP_403_FORBIDDEN
+
+    def __init__(self, message: str) -> None:
+        super().__init__(message, ErrorLocation.query, ["return_uri"])
 
 
 class OAuthError(Exception):
@@ -388,13 +409,6 @@ class OIDCNotEnrolledError(OIDCError):
 
 class OIDCWebError(ProviderWebError):
     """A web request to the OpenID Connect provider failed."""
-
-
-class UnauthorizedClientError(Exception):
-    """The client is not authorized to request an authorization code.
-
-    This corresponds to the ``unauthorized_client`` error in RFC 6749.
-    """
 
 
 class VerifyTokenError(SlackException):

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -114,7 +114,14 @@ def test_delete_all_data(
     engine: AsyncEngine,
     event_loop: asyncio.AbstractEventLoop,
 ) -> None:
-    clients = [OIDCClient(client_id="some-id", client_secret="some-secret")]
+    redirect_uri = "https://example.com/"
+    clients = [
+        OIDCClient(
+            client_id="some-id",
+            client_secret="some-secret",
+            return_uri=redirect_uri,
+        )
+    ]
     config = configure(tmp_path, "github-oidc-server", oidc_clients=clients)
     logger = structlog.get_logger("gafaelfawr")
 
@@ -129,7 +136,7 @@ def test_delete_all_data(
             oidc_service = factory.create_oidc_service()
             return await oidc_service.issue_code(
                 client_id="some-id",
-                redirect_uri="https://example.com/",
+                redirect_uri=redirect_uri,
                 token=token,
                 scopes=[OIDCScope.openid],
             )

--- a/tests/support/config.py
+++ b/tests/support/config.py
@@ -118,7 +118,11 @@ def build_config(
     oidc_path = tmp_path / "oidc.json"
     if oidc_clients:
         clients_data = [
-            {"id": c.client_id, "secret": c.client_secret}
+            {
+                "id": c.client_id,
+                "secret": c.client_secret,
+                "return_uri": c.return_uri,
+            }
             for c in oidc_clients
         ]
         oidc_path.write_text(json.dumps(clients_data))


### PR DESCRIPTION
In order to allow OpenID Connect clients to be at any domain, not just one that matches Gafaelfawr's domain, require OpenID Connect clients to pre-register their return URL. This changes the format of the oidc-server-secrets secret, since this is now a mandatory parameter. Verify that it matches the registered client information in the OIDC routes.