### PR TITLE
DM-42384: Add support for database migrations with Alembic

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.2.0
+    rev: v0.2.1
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]

--- a/Dockerfile
+++ b/Dockerfile
@@ -60,6 +60,10 @@ RUN useradd --create-home appuser
 # Copy the virtualenv.
 COPY --from=install-image /opt/venv /opt/venv
 
+# Copy the Alembic configuration and migrations.
+COPY --from=install-image /workdir/alembic.ini /app/alembic.ini
+COPY --from=install-image /workdir/alembic /app/alembic
+
 # Copy in the built UI and tell Gafaelfawr where it is.
 COPY ui/public /app/ui/public
 ENV GAFAELFAWR_UI_PATH=/app/ui/public

--- a/alembic.ini
+++ b/alembic.ini
@@ -1,0 +1,22 @@
+# Alembic configuration for Gafaelfawr.
+#
+# This file does not retain the comments that are generated as part of the
+# default template, since they will get out of date with newer versions of
+# Alembic. See the Alembic documentation for details about each setting and
+# for settings that are not used here.
+
+[alembic]
+script_location = alembic
+file_template = %%(year)d%%(month).2d%%(day).2d_%%(hour).2d%%(minute).2d_%%(rev)s_%%(slug)s
+prepend_sys_path = .
+timezone = UTC
+version_path_separator = os
+
+[post_write_hooks]
+hooks = ruff ruff_format
+ruff.type = exec
+ruff.executable = ruff
+ruff.options = --fix REVISION_SCRIPT_FILENAME
+ruff_format.type = exec
+ruff_format.executable = ruff
+ruff_format.options = --format REVISION_SCRIPT_FILENAME

--- a/alembic/README
+++ b/alembic/README
@@ -1,0 +1,1 @@
+Generic single-database configuration with an async dbapi.

--- a/alembic/env.py
+++ b/alembic/env.py
@@ -1,0 +1,191 @@
+"""Alembic migration environment."""
+
+import asyncio
+import logging
+from urllib.parse import quote, urlparse
+
+import structlog
+from safir.database import create_database_engine
+from safir.logging import LogLevel, add_log_severity
+from sqlalchemy.engine import Connection
+
+from alembic import context
+from gafaelfawr.dependencies.config import config_dependency
+from gafaelfawr.schema import Base
+
+# This is the Alembic Config object, which provides access to the values
+# within the .ini file in use.
+config = context.config
+
+# Load the Gafaelfawr configuration, which as a side effect also configures
+# logging using structlog.
+gafaelfawr_config = config_dependency.config()
+
+# Define the SQLAlchemy schema, which enables autogenerate support.
+target_metadata = Base.metadata
+
+
+def build_database_url(
+    url: str, password: str | None, *, is_async: bool
+) -> str:
+    """Build the authenticated URL for the database.
+
+    Parameters
+    ----------
+    url
+        Database connection URL, not including the password.
+    password
+        Database connection password.
+    is_async
+        Whether the resulting URL should be async or not.
+
+    Returns
+    -------
+    url
+        The URL including the password.
+
+    Raises
+    ------
+    ValueError
+        A password was provided but the connection URL has no username.
+
+    Notes
+    -----
+    This is duplicated from safir.database and should be replaced with an
+    exported Safir function once Safir provides one.
+    """
+    if is_async or password:
+        parsed_url = urlparse(url)
+        if is_async and parsed_url.scheme == "postgresql":
+            parsed_url = parsed_url._replace(scheme="postgresql+asyncpg")
+        if password:
+            if not parsed_url.username:
+                raise ValueError(f"No username in database URL {url}")
+            password = quote(password, safe="")
+
+            # The username portion of the parsed URL does not appear to decode
+            # URL escaping of the username, so we should not quote it again or
+            # we will get double-quoting.
+            netloc = f"{parsed_url.username}:{password}@{parsed_url.hostname}"
+            if parsed_url.port:
+                netloc = f"{netloc}:{parsed_url.port}"
+            parsed_url = parsed_url._replace(netloc=netloc)
+        url = parsed_url.geturl()
+    return url
+
+
+def configure_alembic_logging(
+    log_level: LogLevel | str = LogLevel.INFO,
+) -> None:
+    """Set up logging for Alembic.
+
+    This configures Alembic to use structlog for output formatting so that its
+    logs are also in JSON. This helps Google's Cloud Logging system understand
+    the logs.
+
+    Parameters
+    ----------
+    log_level
+        The Python log level. May be given as a `LogLevel` enum (preferred)
+        or a case-insensitive string.
+    """
+    if not isinstance(log_level, LogLevel):
+        log_level = LogLevel[log_level.upper()]
+
+    processors = [
+        structlog.stdlib.ProcessorFormatter.remove_processors_meta,
+        structlog.processors.format_exc_info,
+        structlog.processors.JSONRenderer(),
+    ]
+    logging.config.dictConfig(
+        {
+            "version": 1,
+            "disable_existing_loggers": False,
+            "formatters": {
+                "json": {
+                    "()": structlog.stdlib.ProcessorFormatter,
+                    "processors": processors,
+                    "foreign_pre_chain": [add_log_severity],
+                },
+            },
+            "handlers": {
+                "alembic": {
+                    "level": log_level.value,
+                    "class": "logging.StreamHandler",
+                    "formatter": "json",
+                    "stream": "ext://sys.stdout",
+                },
+            },
+            "loggers": {
+                "alembic": {
+                    "handlers": ["alembic"],
+                    "level": log_level.value,
+                    "propagate": False,
+                },
+            },
+        }
+    )
+
+
+def run_migrations_offline() -> None:
+    """Run migrations in offline mode.
+
+    This configures the context with just a URL and not an Engine, though an
+    Engine is acceptable here as well. By skipping the Engine creation we
+    don't even need a DBAPI to be available.
+
+    Calls to context.execute() here emit the given string to the script
+    output.
+    """
+    url = build_database_url(
+        gafaelfawr_config.database_url,
+        gafaelfawr_config.database_password,
+        is_async=False,
+    )
+    context.configure(
+        url=url,
+        target_metadata=target_metadata,
+        literal_binds=True,
+        dialect_opts={"paramstyle": "named"},
+    )
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def do_run_migrations(connection: Connection) -> None:
+    """Run database migrations with a connection."""
+    context.configure(connection=connection, target_metadata=target_metadata)
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+async def run_async_migrations() -> None:
+    """Run migrations in online mode with an async engine.
+
+    In this scenario we need to create an Engine and associate a connection
+    with the context.
+    """
+    engine = create_database_engine(
+        gafaelfawr_config.database_url, gafaelfawr_config.database_password
+    )
+
+    async with engine.connect() as connection:
+        await connection.run_sync(do_run_migrations)
+
+    await engine.dispose()
+
+
+def run_migrations_online() -> None:
+    """Run database migrations.
+
+    This must be called outside of an event loop.
+    """
+    asyncio.run(run_async_migrations())
+
+
+configure_alembic_logging()
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/alembic/gafaelfawr.yaml
+++ b/alembic/gafaelfawr.yaml
@@ -1,0 +1,40 @@
+# Settings used for local database creation for Alembic migrations. These
+# settings do not need to contain enough settings for Gafaelfawr to actually
+# work.
+#
+# WARNING: The session secret and PostgreSQL password included in this package
+# are published to the entire world and are therefore not secure in any way.
+# Use them ONLY for development on server limited to localhost. Anyone in the
+# world can decrypt and forge any identity information of any server that uses
+# these settings.
+
+realm: "localhost"
+logLevel: "DEBUG"
+sessionSecretFile: "examples/secrets/session-secret"
+databaseUrl: "postgresql://gafaelfawr:INSECURE@localhost/gafaelfawr"
+
+# This Redis will be started by the docker-compose.yaml file at the top
+# level of the repository.
+redisUrl: "redis://localhost:6379/0"
+redisPasswordFile: "examples/secrets/redis-password"
+
+# Where to send the user after logging out.
+afterLogoutUrl: "http://localhost:8080"
+
+# These values are fake and exist only to ensure Gafaelfawr can start, since
+# this configuration is intended only for database schema management.
+github:
+  clientId: "<github-client-id>"
+  clientSecretFile: "examples/secrets/session-secret"
+
+# Add a random administrator because the code doesn't like this to be empty.
+initialAdmins:
+  - "example"
+
+# Only the built-in scopes.
+knownScopes:
+  "admin:token": "Can create and modify tokens for any user"
+  "user:token": "Can create and modify user tokens"
+
+# A minimal mapping sufficient for Gafaelfawr to start.
+groupMapping: {}

--- a/alembic/script.py.mako
+++ b/alembic/script.py.mako
@@ -1,0 +1,26 @@
+"""${message}
+
+Revision ID: ${up_revision}
+Revises: ${down_revision | comma,n}
+Create Date: ${create_date}
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+${imports if imports else ""}
+
+# revision identifiers, used by Alembic.
+revision: str = ${repr(up_revision)}
+down_revision: Union[str, None] = ${repr(down_revision)}
+branch_labels: Union[str, Sequence[str], None] = ${repr(branch_labels)}
+depends_on: Union[str, Sequence[str], None] = ${repr(depends_on)}
+
+
+def upgrade() -> None:
+    ${upgrades if upgrades else "pass"}
+
+
+def downgrade() -> None:
+    ${downgrades if downgrades else "pass"}

--- a/alembic/versions/20240209_2310_2feb306dd1ee_add_oidc_token_type.py
+++ b/alembic/versions/20240209_2310_2feb306dd1ee_add_oidc_token_type.py
@@ -1,0 +1,25 @@
+"""Add oidc token type.
+
+Revision ID: 2feb306dd1ee
+Revises: d2a7f04de565
+Create Date: 2024-02-09 23:10:43.229238+00:00
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "2feb306dd1ee"
+down_revision: str | None = None
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.execute("ALTER TYPE tokentype ADD VALUE 'oidc' IF NOT EXISTS")
+
+
+def downgrade() -> None:
+    # PostgreSQL does not appear to support removing values from enums.
+    pass

--- a/changelog.d/20240209_160742_rra_DM_42384.md
+++ b/changelog.d/20240209_160742_rra_DM_42384.md
@@ -1,0 +1,3 @@
+### Other changes
+
+- Gafaelfawr now uses [Alembic](https://alembic.sqlalchemy.org/en/latest/index.html) to perform database migrations as needed.

--- a/docs/_rst_epilog.rst
+++ b/docs/_rst_epilog.rst
@@ -1,3 +1,4 @@
+.. _Alembic: https://alembic.sqlalchemy.org/en/latest/index.html
 .. _ingress-nginx: https://kubernetes.github.io/ingress-nginx/
 .. _Kopf: https://kopf.readthedocs.io/en/stable/
 .. _mypy: https://mypy.readthedocs.io/en/stable/

--- a/examples/secrets/oidc-clients.json
+++ b/examples/secrets/oidc-clients.json
@@ -1,6 +1,7 @@
 [
   {
     "id": "some-client",
-    "secret": "some-oidc-client-secret"
+    "secret": "some-oidc-client-secret",
+    "return_uri": "https://example.com/some-app/login"
   }
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -209,11 +209,15 @@ ignore = [
 select = ["ALL"]
 
 [tool.ruff.lint.per-file-ignores]
-"src/gafaelfawr/handlers/**" = [
-    "D103",    # FastAPI handlers should not have docstrings
+"alembic/**" = [
+    "INP001",  # Alembic files are magical
+    "D103",    # no docstrings for Alembic migrations
 ]
 "docs/**" = [
     "INP001",  # Python files are embedded diagrams
+]
+"src/gafaelfawr/handlers/**" = [
+    "D103",    # FastAPI handlers should not have docstrings
 ]
 "tests/**" = [
     "C901",    # tests are allowed to be complex, sometimes that's convenient

--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -7,7 +7,7 @@
 
 -c main.txt
 
-# Testing
+# Testing and linting
 asgi-lifespan
 coverage[toml]
 mypy
@@ -16,6 +16,7 @@ pytest-asyncio
 pytest-cov
 pytest-sugar
 respx
+ruff
 selenium-wire
 sqlalchemy[mypy]
 types-cachetools
@@ -26,7 +27,7 @@ holdup
 
 # Documentation
 autodoc_pydantic
-documenteer[guide]>=1.0.0a7
+documenteer[guide]>=1.0.0
 scriv[toml]
 sphinx-click
 sphinx-diagrams

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -854,17 +854,17 @@ pysocks==1.7.1 \
     # via
     #   selenium-wire
     #   urllib3
-pytest==7.4.4 \
-    --hash=sha256:2cf0005922c6ace4a3e2ec8b4080eb0d9753fdc93107415332f50ce9e7994280 \
-    --hash=sha256:b090cdf5ed60bf4c45261be03239c2c1c22df034fbffe691abe93cd80cea01d8
+pytest==8.0.0 \
+    --hash=sha256:249b1b0864530ba251b7438274c4d251c58d868edaaec8762893ad4a0d71c36c \
+    --hash=sha256:50fb9cbe836c3f20f0dfa99c565201fb75dc54c8d76373cd1bde06b06657bdb6
     # via
     #   -r requirements/dev.in
     #   pytest-asyncio
     #   pytest-cov
     #   pytest-sugar
-pytest-asyncio==0.23.4 \
-    --hash=sha256:2143d9d9375bf372a73260e4114541485e84fca350b0b6b92674ca56ff5f7ea2 \
-    --hash=sha256:b0079dfac14b60cd1ce4691fbfb1748fe939db7d0234b5aba97197d10fbe0fef
+pytest-asyncio==0.23.5 \
+    --hash=sha256:3a048872a9c4ba14c3e90cc1aa20cbc2def7d01c7c8db3777ec281ba9c057675 \
+    --hash=sha256:4e7093259ba018d58ede7d5315131d21923a60f8a6e9ee266ce1589685c89eac
     # via -r requirements/dev.in
 pytest-cov==4.1.0 \
     --hash=sha256:3904b13dfbfec47f003b8e77fd5b589cd11904a21ddf1ab38a64f204d6a10ef6 \
@@ -1059,6 +1059,25 @@ rpds-py==0.17.1 \
     # via
     #   jsonschema
     #   referencing
+ruff==0.2.1 \
+    --hash=sha256:0034d5b6323e6e8fe91b2a1e55b02d92d0b582d2953a2b37a67a2d7dedbb7acc \
+    --hash=sha256:00a818e2db63659570403e44383ab03c529c2b9678ba4ba6c105af7854008105 \
+    --hash=sha256:0a725823cb2a3f08ee743a534cb6935727d9e47409e4ad72c10a3faf042ad5ba \
+    --hash=sha256:13471684694d41ae0f1e8e3a7497e14cd57ccb7dd72ae08d56a159d6c9c3e30e \
+    --hash=sha256:3b42b5d8677cd0c72b99fcaf068ffc62abb5a19e71b4a3b9cfa50658a0af02f1 \
+    --hash=sha256:6b95ac9ce49b4fb390634d46d6ece32ace3acdd52814671ccaf20b7f60adb232 \
+    --hash=sha256:7022d66366d6fded4ba3889f73cd791c2d5621b2ccf34befc752cb0df70f5fad \
+    --hash=sha256:a11567e20ea39d1f51aebd778685582d4c56ccb082c1161ffc10f79bebe6df35 \
+    --hash=sha256:be60592f9d218b52f03384d1325efa9d3b41e4c4d55ea022cd548547cc42cd2b \
+    --hash=sha256:c92db7101ef5bfc18e96777ed7bc7c822d545fa5977e90a585accac43d22f18a \
+    --hash=sha256:dc586724a95b7d980aa17f671e173df00f0a2eef23f8babbeee663229a938fec \
+    --hash=sha256:dd81b911d28925e7e8b323e8d06951554655021df8dd4ac3045d7212ac4ba080 \
+    --hash=sha256:e3affdcbc2afb6f5bd0eb3130139ceedc5e3f28d206fe49f63073cb9e65988e0 \
+    --hash=sha256:e5cb5526d69bb9143c2e4d2a115d08ffca3d8e0fddc84925a7b54931c96f5c02 \
+    --hash=sha256:efababa8e12330aa94a53e90a81eb6e2d55f348bc2e71adbf17d9cad23c03ee6 \
+    --hash=sha256:f3ef052283da7dec1987bba8d8733051c2325654641dfe5877a4022108098683 \
+    --hash=sha256:fbd2288890b88e8aab4499e55148805b58ec711053588cc2f0196a44f6e3d855
+    # via -r requirements/dev.in
 scriv[toml]==1.5.1 \
     --hash=sha256:30ae9ff8d144f8e0cf394c4e1d379542f1b3823767642955b54ec40dc00b32b6 \
     --hash=sha256:a3adc657733b4124fcb54527a5f3daab0d3c300de82d0fd2b9b297b243151b78
@@ -1124,9 +1143,9 @@ sphinx==7.2.6 \
     #   sphinxcontrib-redoc
     #   sphinxext-opengraph
     #   sphinxext-rediraffe
-sphinx-autodoc-typehints==1.25.3 \
-    --hash=sha256:70db10b391acf4e772019765991d2de0ff30ec0899b9ba137706dc0b3c4835e0 \
-    --hash=sha256:d3da7fa9a9761eff6ff09f8b1956ae3090a2d4f4ad54aebcade8e458d6340835
+sphinx-autodoc-typehints==2.0.0 \
+    --hash=sha256:12c0e161f6fe191c2cdfd8fa3caea271f5387d9fbc67ebcd6f4f1f24ce880993 \
+    --hash=sha256:7f2cdac2e70fd9787926b6e9e541cd4ded1e838d2b46fda2a1bb0a75ec5b7f3a
     # via documenteer
 sphinx-automodapi==0.16.0 \
     --hash=sha256:68fc47064804604b90aa27c047016e86aaf970981d90a0082d5b5dd2e9d38afd \
@@ -1337,9 +1356,9 @@ typing-extensions==4.9.0 \
     #   pydantic-core
     #   selenium
     #   sqlalchemy
-uc-micro-py==1.0.2 \
-    --hash=sha256:30ae2ac9c49f39ac6dce743bd187fcd2b574b16ca095fa74cd9396795c954c54 \
-    --hash=sha256:8c9110c309db9d9e87302e2f4ad2c3152770930d88ab385cd544e7a7e75f3de0
+uc-micro-py==1.0.3 \
+    --hash=sha256:d321b92cff673ec58027c04015fcaa8bb1e005478643ff4a500882eaab88c48a \
+    --hash=sha256:db1dffff340817673d7b466ec86114a9dc0e9d4d9b5ba229d9d60e5c12600cd5
     # via linkify-it-py
 urllib3[socks]==2.2.0 \
     --hash=sha256:051d961ad0c62a94e50ecf1af379c3aba230c66c710493493560c0c223c49f20 \

--- a/requirements/main.in
+++ b/requirements/main.in
@@ -12,6 +12,7 @@ starlette
 uvicorn[standard]
 
 # Other dependencies.
+alembic[tz]
 asyncpg
 bonsai>=1.5.0
 cachetools
@@ -26,7 +27,7 @@ pydantic>2
 PyJWT
 pyyaml
 redis>=4.2.0
-safir[db,kubernetes]>=5.0.0a1
+safir[db,kubernetes]>=5.0.0
 sqlalchemy
 structlog
 

--- a/requirements/main.txt
+++ b/requirements/main.txt
@@ -88,6 +88,10 @@ aiosignal==1.3.1 \
     --hash=sha256:54cd96e15e1649b75d6c87526a6ff0b6c1b0dd3459f43d9ca11d48c339b68cfc \
     --hash=sha256:f8376fb07dd1e86a584e4fcdec80b36b7f81aac666ebc724e2c090300dd83b17
     # via aiohttp
+alembic[tz]==1.13.1 \
+    --hash=sha256:2edcc97bed0bd3272611ce3a98d98279e9c209e7186e43e75bbb1b2bdfdbcc43 \
+    --hash=sha256:4932c8558bf68f2ee92b9bbcb8218671c627064d5b08939437af6d77dc05e595
+    # via -r requirements/main.in
 annotated-types==0.6.0 \
     --hash=sha256:0641064de18ba7a25dee8f96403ebc39113d0cb953a01429249d5c7564666a43 \
     --hash=sha256:563339e807e53ffd9c267e99fc6d9ea23eb8443c08f112651963e24e22f84a5d
@@ -451,9 +455,9 @@ gidgethub==5.3.0 \
     --hash=sha256:4dd92f2252d12756b13f9dd15cde322bfb0d625b6fb5d680da1567ec74b462c0 \
     --hash=sha256:9ece7d37fbceb819b80560e7ed58f936e48a65d37ec5f56db79145156b426a25
     # via safir
-google-api-core[grpc]==2.16.2 \
-    --hash=sha256:032d37b45d1d6bdaf68fb11ff621e2593263a239fa9246e2e94325f9c47876d2 \
-    --hash=sha256:449ca0e3f14c179b4165b664256066c7861610f70b6ffe54bb01a04e9b466929
+google-api-core[grpc]==2.17.0 \
+    --hash=sha256:08ed79ed8e93e329de5e3e7452746b734e6bf8438d8d64dd3319d21d3164890c \
+    --hash=sha256:de7ef0450faec7c75e0aea313f29ac870fdc44cfaec9d6499a9a17305980ef66
     # via
     #   google-api-core
     #   google-cloud-core
@@ -680,6 +684,10 @@ kubernetes-asyncio==28.2.1 \
     # via
     #   -r requirements/main.in
     #   safir
+mako==1.3.2 \
+    --hash=sha256:2a0c8ad7f6274271b3bb7467dd37cf9cc6dab4bc19cb69a4ef10669402de698e \
+    --hash=sha256:32a99d70754dfce237019d17ffe4a282d2d3351b9c476e90d8a60e63f133b80c
+    # via alembic
 markupsafe==2.1.5 \
     --hash=sha256:00e046b6dd71aa03a41079792f8473dc494d564611a8f89bbbd7cb93295ebdcf \
     --hash=sha256:075202fa5b72c86ad32dc7d0b56024ebdbcf2048c0ba09f1cde31bfdd57bcfff \
@@ -741,7 +749,9 @@ markupsafe==2.1.5 \
     --hash=sha256:fa9db3f79de01457b03d4f01b34cf91bc0048eb2c3846ff26f66687c2f6d16ab \
     --hash=sha256:fce659a462a1be54d2ffcacea5e3ba2d74daa74f30f5f143fe0c58636e355fdd \
     --hash=sha256:ffee1f21e5ef0d712f9033568f8344d5da8cc2869dbd08d87c84656e6a2d2f68
-    # via jinja2
+    # via
+    #   jinja2
+    #   mako
 multidict==6.0.5 \
     --hash=sha256:01265f5e40f5a17f8241d52656ed27192be03bfa8764d88e8220141d1e4b3556 \
     --hash=sha256:0275e35209c27a3f7951e1ce7aaf93ce0d163b28948444bec61dd7badc6d3f8c \
@@ -1121,6 +1131,7 @@ sqlalchemy[asyncio]==2.0.25 \
     --hash=sha256:f5693145220517b5f42393e07a6898acdfe820e136c98663b971906120549da5
     # via
     #   -r requirements/main.in
+    #   alembic
     #   safir
 starlette==0.36.3 \
     --hash=sha256:13d429aa93a61dc40bf503e8c801db1f1bca3dc706b10ef2434a36123568f044 \
@@ -1139,6 +1150,7 @@ typing-extensions==4.9.0 \
     --hash=sha256:23478f88c37f27d76ac8aee6c905017a143b0b1b886c3c9f66bc2fd94f9f5783 \
     --hash=sha256:af72aea155e91adfc61c3ae9e0e342dbc0cba726d6cba4b6c72c1f34e47291cd
     # via
+    #   alembic
     #   fastapi
     #   kopf
     #   pydantic

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -1,14 +1,16 @@
 #!/bin/bash
 #
-# Start the Gafaelfawr application inside the Docker image.  Currently creates
-# the database.  Eventually, this will call Alembic to handle database
-# migrations.
+# Set up the database and then start the Gafaelfawr application.
 
 set -eu
 
 # Always initialize the database if needed. This shouldn't require LDAP access
 # and thus isn't run with Kerberos tickets.
 gafaelfawr init
+
+# Perform any Alembic migrations that are needed.
+cd /app
+alembic upgrade head
 
 # Start the server under k5start if Kerberos is configured.
 cmd="uvicorn --factory gafaelfawr.main:create_app --host 0.0.0.0 --port 8080"

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -4,14 +4,6 @@
 
 set -eu
 
-# Always initialize the database if needed. This shouldn't require LDAP access
-# and thus isn't run with Kerberos tickets.
-gafaelfawr init
-
-# Perform any Alembic migrations that are needed.
-cd /app
-alembic upgrade head
-
 # Start the server under k5start if Kerberos is configured.
 cmd="uvicorn --factory gafaelfawr.main:create_app --host 0.0.0.0 --port 8080"
 if [ -f "/etc/krb5.conf" ] && [ -f "/etc/krb5.keytab" ]; then

--- a/src/gafaelfawr/config.py
+++ b/src/gafaelfawr/config.py
@@ -30,7 +30,7 @@ from pydantic import (
     model_validator,
 )
 from pydantic_core import Url
-from safir.logging import LogLevel, Profile, configure_logging
+from safir.logging import LogLevel, configure_logging
 from safir.pydantic import CamelCaseModel, validate_exactly_one_of
 
 from .constants import SCOPE_REGEX, USERNAME_REGEX
@@ -1128,16 +1128,12 @@ class Config:
 
     def configure_logging(self) -> None:
         """Configure logging based on the Gafaelfawr configuration."""
-        configure_logging(
-            profile=Profile.production,
-            log_level=self.log_level,
-            name="gafaelfawr",
-        )
+        configure_logging(name="gafaelfawr", log_level=self.log_level)
 
     @staticmethod
     def _load_secret(path: Path) -> bytes:
         """Load a secret from a file."""
-        secret = path.read_bytes()
+        secret = path.read_bytes().rstrip(b"\n")
         if len(secret) == 0:
             raise ValueError(f"Secret file {path} is empty")
         return secret

--- a/src/gafaelfawr/models/token.py
+++ b/src/gafaelfawr/models/token.py
@@ -145,6 +145,9 @@ class TokenType(Enum):
     services, unrelated to a user request.
     """
 
+    oidc = "oidc"
+    """Access token for an OpenID Connect client."""
+
 
 class TokenGroup(BaseModel):
     """Information about a single group."""
@@ -234,6 +237,7 @@ class TokenBase(BaseModel):
             " sub-calls made as part of processing a user request\n"
             "* `service`: A service-to-service token used for internal calls"
             " initiated by services, unrelated to a user request\n"
+            "* `oidc`: Access token for an OpenID Connect client\n"
         ),
         title="Token type",
         examples=["session"],

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -44,6 +44,12 @@ def test_config_examples() -> None:
             parse_config(path, fix_token=True)
 
 
+def test_config_alembic() -> None:
+    """Check the configuration used for Alembic operations."""
+    path = Path(__file__).parent.parent / "alembic" / "gafaelfawr.yaml"
+    parse_config(path)
+
+
 def test_config_no_provider() -> None:
     with pytest.raises(ValidationError):
         parse_config(config_path("no-provider.yaml"))

--- a/tox.ini
+++ b/tox.ini
@@ -41,7 +41,15 @@ deps =
     -r{toxinidir}/requirements/main.txt
     -r{toxinidir}/requirements/dev.txt
 setenv =
+    GAFAELFAWR_ALEMBIC_CONFIG_PATH = {toxinidir}/alembic.ini
     GAFAELFAWR_UI_PATH = {toxinidir}/ui/public
+
+[testenv:alembic]
+description = Run Alembic against a test database
+commands =
+    alembic {posargs}
+setenv =
+    GAFAELFAWR_CONFIG_PATH = {toxinidir}/alembic/gafaelfawr.yaml
 
 [testenv:coverage-report]
 description = Compile coverage from each test run.
@@ -67,6 +75,14 @@ allowlist_externals =
 commands =
     gafaelfawr openapi-schema --add-back-link --output docs/_static/openapi.json
     make linkcheck
+
+[testenv:gafaelfawr]
+description = Run Gafaelfawr command-line tool against a test database
+commands =
+    gafaelfawr {posargs}
+setenv =
+    GAFAELFAWR_ALEMBIC_CONFIG_PATH = {toxinidir}/alembic.ini
+    GAFAELFAWR_CONFIG_PATH = {toxinidir}/alembic/gafaelfawr.yaml
 
 [testenv:lint]
 description = Lint codebase by running pre-commit (Black, isort, Flake8)
@@ -99,6 +115,7 @@ docker =
 commands =
     pytest -vv --cov=gafaelfawr --cov-branch --cov-report= {posargs}
 setenv =
+    GAFAELFAWR_ALEMBIC_CONFIG_PATH = {toxinidir}/alembic.ini
     GAFAELFAWR_UI_PATH = {toxinidir}/ui/public
     TEST_KUBERNETES = 1
 
@@ -117,6 +134,7 @@ commands =
 commands_post =
     docker-compose down
 setenv =
+    GAFAELFAWR_ALEMBIC_CONFIG_PATH = {toxinidir}/alembic.ini
     GAFAELFAWR_CONFIG_PATH = {toxinidir}/examples/gafaelfawr-dev.yaml
 
 [testenv:typing]


### PR DESCRIPTION
Add a new oidc token type as an initial migration, which is not yet used but will be used in a subsequent change.

Use an async engine for Alembic, since that avoids needing to also install psycopg2 alongside asyncpg only for Alembic to use it. Since Alembic only sort-of supports async via asyncio.run, this requires moving the body of gafaelfawr init into a separate coroutine and running that with asyncio.run so that Alembic can be run outside of the running async loop.

The Alembic environment is a bit complicated at the moment and duplicates a bit of Safir code. A lot of this can be lifted into Safir in the future.

Fix a few problems with secret loading uncovered by loading the example configuration: the example OIDC client secrets were missing the new return_uri field, and newlines weren't removed from the end of secrets.