### PR TITLE
DM-42384: Issue oidc tokens for OIDC access tokens

### DIFF
--- a/changelog.d/20240213_170118_rra_DM_42384a.md
+++ b/changelog.d/20240213_170118_rra_DM_42384a.md
@@ -1,0 +1,5 @@
+### Backwards-incompatible changes
+
+- In the reply to a successful OpenID Connect authentication, return a Gafaelfawr token of a new `oidc` type as the access token instead of a copy of the ID token. This `oidc` token will be marked as a child token of the underlying Gafaelfawr token used to authenticate the OpenID Connect login, which means it will automatically be revoked if the user logs out.
+- Only accept Gafaelfawr tokens of the `oidc` type for the OpenID Connect server userinfo endpoint.
+- Return only userinfo claims from the OpenID Connect server userinfo endpoint instead of the full set of claims that would go into an ID token. Currently, the userinfo claims are not filtered based on the requested scopes; all available userinfo claims are returned.

--- a/docs/dev/glossary.rst
+++ b/docs/dev/glossary.rst
@@ -45,10 +45,14 @@ protected service
     Gafaelfawr will run as an NGINX auth subrequest handler and return headers that NGINX will in turn pass to the protected service, which it can use for further authorization and identity decisions.
 
 scope
-    A permission that a user holding a token has in some system.
-    When requesting authentication from an OpenID Connect provider, the requested scopes control what information is returned about the user in the ID token.
+    The term "scope" is unfortunately overloaded.
+    It is used both for a set of permissions granted to a Gafaelfawr token and for a set of claims requested from an OpenID Connect server.
+
     For a token issued by Gafaelfawr, a scope represents a general class of permissions on systems protected by Gafaelfawr.
     Services can be protected by authorization rules that require specific scopes.
+
+    When requesting authentication from an OpenID Connect provider, including the Gafaelfawr OpenID Connect provider, the requested scopes control what information is returned about the user in the ID token.
+    These scopes are (partly) standardized by the OpenID Connect standard and are entirely unrelated to (and have a different naming convention than) Gafaelfawr scopes.
 
 session
     A stored authentication token for a user that expires after some set length of time.
@@ -64,8 +68,8 @@ subject
 
 token
     There are two types of authentication tokens used by Gafaelfawr.
-    When authenticating the user to an external OpenID Connect service, or when acting as an OpenID Connect service to a protected service, tokens are JWTs.
-    For all other operations, tokens are opaque strings starting with ``gt-``.
+    When authenticating the user to an external OpenID Connect service, or when acting as an OpenID Connect service to a protected service, the ID token is a JWT.
+    For all other operations, including the access token returned when acting as an OpenID Connect service, tokens are opaque strings starting with ``gt-``.
     These opaque tokens consist of two parts: a key and a secret.
     The key is the Redis key for the stored session.
     The secret proves that the client has the right to use that stored session.

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -162,6 +162,7 @@ def test_delete_all_data(
                     client_secret="some-secret",
                     redirect_uri="https://example.com/",
                     code=str(code),
+                    ip_address="127.0.0.1",
                 )
 
     event_loop.run_until_complete(check_data())


### PR DESCRIPTION
Instead of setting the access token for OpenID Connect authentications to the same as the ID token, issue a new Gafaelfawr token of the oidc type with no scopes. Change the userinfo endpoint to expect that token instead.

This means that the access token will be automatically revoked if the authentication token used to authenticate the OpenID Connect login is revoked.