### PR TITLE
DM-42384: Verify the database schema on startup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,9 +60,12 @@ RUN useradd --create-home appuser
 # Copy the virtualenv.
 COPY --from=install-image /opt/venv /opt/venv
 
-# Copy the Alembic configuration and migrations.
+# Copy the Alembic configuration and migrations, and set that path as the
+# working directory so that Alembic can be run with a simple entry command
+# and no extra configuration.
 COPY --from=install-image /workdir/alembic.ini /app/alembic.ini
 COPY --from=install-image /workdir/alembic /app/alembic
+WORKDIR /app
 
 # Copy in the built UI and tell Gafaelfawr where it is.
 COPY ui/public /app/ui/public

--- a/changelog.d/20240214_133634_rra_DM_42384.md
+++ b/changelog.d/20240214_133634_rra_DM_42384.md
@@ -1,0 +1,3 @@
+### New features
+
+- Check the database schema at startup to ensure that it is current, and refuse to start if the schema is out of date.

--- a/src/gafaelfawr/cli.py
+++ b/src/gafaelfawr/cli.py
@@ -263,7 +263,7 @@ async def maintenance(*, config_path: Path | None) -> None:
 )
 def openapi_schema(*, add_back_link: bool, output: Path | None) -> None:
     """Generate the OpenAPI schema."""
-    app = create_app(load_config=False)
+    app = create_app(load_config=False, validate_schema=False)
     description = app.description
     if add_back_link:
         description += "\n\n[Return to Gafaelfawr documentation](api.html)."

--- a/src/gafaelfawr/exceptions.py
+++ b/src/gafaelfawr/exceptions.py
@@ -12,6 +12,7 @@ from safir.models import ErrorLocation
 from safir.slack.blockkit import SlackException, SlackWebException
 
 __all__ = [
+    "DatabaseSchemaError",
     "DuplicateTokenNameError",
     "ExternalUserInfoError",
     "FetchKeysError",
@@ -306,6 +307,14 @@ class InsufficientScopeError(OAuthBearerError):
     error = "insufficient_scope"
     message = "Permission denied"
     status_code = status.HTTP_403_FORBIDDEN
+
+
+class DatabaseSchemaError(SlackException):
+    """Gafaelfawr database schema is invalid.
+
+    Raised during startup if schema checking is requested and Alembic reports
+    that the database schema is not current.
+    """
 
 
 class ExternalUserInfoError(SlackException):


### PR DESCRIPTION
Unless it is explicitly disabled (such as by the test suite), check the schema with Alembic during startup to see if it's current and refuse to start if it isn't. Test this by keeping schema validation enabled during Selenium testing, which runs via uvicorn and thus simulates how Gafaelfawr is run in production.

This required changing the Selenium fixtures to not be async, since Alembic doesn't like async for some things. They turned out to have no reason to be async, so this was painless.

At present, this only handles web application startup, not the Kubernetes operator or the audit or maintenance cron jobs.