### PR TITLE
DM-42384: Improve schema handling and testing

### DIFF
--- a/alembic/env.py
+++ b/alembic/env.py
@@ -5,11 +5,11 @@ import logging
 from urllib.parse import quote, urlparse
 
 import structlog
+from alembic import context
 from safir.database import create_database_engine
 from safir.logging import LogLevel, add_log_severity
 from sqlalchemy.engine import Connection
 
-from alembic import context
 from gafaelfawr.dependencies.config import config_dependency
 from gafaelfawr.schema import Base
 

--- a/alembic/versions/20240209_2310_2feb306dd1ee_add_oidc_token_type.py
+++ b/alembic/versions/20240209_2310_2feb306dd1ee_add_oidc_token_type.py
@@ -17,7 +17,7 @@ depends_on: str | Sequence[str] | None = None
 
 
 def upgrade() -> None:
-    op.execute("ALTER TYPE tokentype ADD VALUE 'oidc' IF NOT EXISTS")
+    op.execute("ALTER TYPE tokentype ADD VALUE IF NOT EXISTS 'oidc'")
 
 
 def downgrade() -> None:

--- a/changelog.d/20240214_185441_rra_DM_42384.md
+++ b/changelog.d/20240214_185441_rra_DM_42384.md
@@ -1,0 +1,4 @@
+### New features
+
+- Added new `gafaelfawr update-schema` command that creates the database if necessary and otherwise applies any needed Alembic migrations.
+- Added new `gafaelfawr validate-schema` command that exits non-zero if the database has not been initialized or if the schema is not up-to-date.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -232,6 +232,7 @@ select = ["ALL"]
 
 [tool.ruff.lint.isort]
 known-first-party = ["gafaelfawr", "tests"]
+known-third-party = ["alembic"]
 split-on-trailing-comma = false
 
 [tool.ruff.lint.flake8-bugbear]

--- a/src/gafaelfawr/database.py
+++ b/src/gafaelfawr/database.py
@@ -1,0 +1,157 @@
+"""Database utility functions for Gafaelfawr."""
+
+from __future__ import annotations
+
+import asyncio
+
+from alembic.config import Config as AlembicConfig
+from alembic.runtime.migration import MigrationContext
+from alembic.script import ScriptDirectory
+from safir.database import create_database_engine, initialize_database
+from sqlalchemy import Connection, select
+from sqlalchemy.exc import OperationalError, ProgrammingError
+from sqlalchemy.ext.asyncio import AsyncEngine
+from structlog.stdlib import BoundLogger
+
+from .config import Config
+from .factory import Factory
+from .schema import Base, Token
+
+__all__ = [
+    "initialize_gafaelfawr_database",
+    "is_database_current",
+    "is_database_initialized",
+]
+
+
+async def initialize_gafaelfawr_database(
+    config: Config, logger: BoundLogger, engine: AsyncEngine | None = None
+) -> None:
+    """Initialize the database.
+
+    This is the internal async implementation details of the ``init`` command,
+    except for the Alembic parts. Alembic has to run outside of a running
+    asyncio loop, hence this separation. Always stamp the database with
+    Alembic after calling this function.
+
+    Parameters
+    ----------
+    config
+        Gafaelfawr configuration.
+    logger
+        Logger to use for status reporting.
+    engine
+        If given, database engine to use, which avoids the need to create
+        another one.
+    """
+    if not engine:
+        engine = create_database_engine(
+            config.database_url, config.database_password
+        )
+    await initialize_database(engine, logger, schema=Base.metadata)
+    async with Factory.standalone(config, engine) as factory:
+        admin_service = factory.create_admin_service()
+        logger.debug("Adding initial administrators")
+        async with factory.session.begin():
+            await admin_service.add_initial_admins(config.initial_admins)
+        if config.firestore:
+            firestore = factory.create_firestore_storage()
+            logger.debug("Initializing Firestore")
+            await firestore.initialize()
+    await engine.dispose()
+
+
+async def is_database_current(
+    config: Config, logger: BoundLogger, engine: AsyncEngine | None = None
+) -> bool:
+    """Check whether the database schema is at the current version.
+
+    This must be called outside of any event loop, since Alembic doesn't work
+    well with async event loops. It expects :file:`alembic/versions` to
+    contain the migration scripts.
+
+    Parameters
+    ----------
+    config
+        Gafaelfawr configuration.
+    logger
+        Logger to use for status reporting.
+    engine
+        If given, database engine to use, which avoids the need to create
+        another one.
+
+    Returns
+    -------
+    bool
+        `True` if Alembic reports the database schema is current, false
+        otherwise.
+    """
+    if not engine:
+        engine = create_database_engine(
+            config.database_url, config.database_password
+        )
+
+    def get_current_heads(connection: Connection) -> set[str]:
+        context = MigrationContext.configure(connection)
+        return set(context.get_current_heads())
+
+    async with engine.begin() as connection:
+        current = await connection.run_sync(get_current_heads)
+    await engine.dispose()
+    alembic_config = AlembicConfig("alembic.ini")
+    alembic_scripts = ScriptDirectory.from_config(alembic_config)
+    expected = set(alembic_scripts.get_heads())
+    if current != expected:
+        logger.error(f"Schema mismatch: {current} != {expected}")
+        return False
+    else:
+        return True
+
+
+async def is_database_initialized(
+    config: Config, logger: BoundLogger, engine: AsyncEngine | None = None
+) -> bool:
+    """Check whether the database has been initialized.
+
+    Parameters
+    ----------
+    config
+        Gafaelfawr configuration.
+    logger
+        Logger to use for status reporting.
+    engine
+        If given, database engine to use, which avoids the need to create
+        another one.
+
+    Returns
+    -------
+    bool
+        `True` if some Gafaelfawr schema (possibly out of date) appears to
+        exist, `False` otherwise. This may misdetect partial schemas that
+        contain some tables and not others or that are missing indices.
+    """
+    if not engine:
+        engine = create_database_engine(
+            config.database_url, config.database_password
+        )
+    statement = select(Token).limit(1)
+    try:
+        for _ in range(5):
+            try:
+                async with engine.begin() as connection:
+                    await connection.execute(statement)
+                    return True
+            except (ConnectionRefusedError, OperationalError, OSError):
+                if logger:
+                    logger.info("database not ready, waiting two seconds")
+                await asyncio.sleep(2)
+                continue
+
+        # If we got here, we failed five times. Try one more time to generate
+        # a proper exception.
+        async with engine.begin() as connection:
+            await connection.execute(statement)
+            return True
+    except ProgrammingError:
+        logger.info("Database appears not to be initialized")
+        return False

--- a/tests/data/schemas/9.6.1
+++ b/tests/data/schemas/9.6.1
@@ -1,0 +1,410 @@
+--
+-- PostgreSQL database dump
+--
+
+-- Dumped from database version 13.1 (Debian 13.1-1.pgdg100+1)
+-- Dumped by pg_dump version 16.2 (Debian 16.2-1)
+
+SET statement_timeout = 0;
+SET lock_timeout = 0;
+SET idle_in_transaction_session_timeout = 0;
+SET client_encoding = 'UTF8';
+SET standard_conforming_strings = on;
+SELECT pg_catalog.set_config('search_path', '', false);
+SET check_function_bodies = false;
+SET xmloption = content;
+SET client_min_messages = warning;
+SET row_security = off;
+
+--
+-- Name: public; Type: SCHEMA; Schema: -; Owner: gafaelfawr
+--
+
+-- *not* creating schema, since initdb creates it
+
+
+ALTER SCHEMA public OWNER TO gafaelfawr;
+
+--
+-- Name: adminchange; Type: TYPE; Schema: public; Owner: gafaelfawr
+--
+
+CREATE TYPE public.adminchange AS ENUM (
+    'add',
+    'remove'
+);
+
+
+ALTER TYPE public.adminchange OWNER TO gafaelfawr;
+
+--
+-- Name: tokenchange; Type: TYPE; Schema: public; Owner: gafaelfawr
+--
+
+CREATE TYPE public.tokenchange AS ENUM (
+    'create',
+    'revoke',
+    'expire',
+    'edit'
+);
+
+
+ALTER TYPE public.tokenchange OWNER TO gafaelfawr;
+
+--
+-- Name: tokentype; Type: TYPE; Schema: public; Owner: gafaelfawr
+--
+
+CREATE TYPE public.tokentype AS ENUM (
+    'session',
+    'user',
+    'notebook',
+    'internal',
+    'service'
+);
+
+
+ALTER TYPE public.tokentype OWNER TO gafaelfawr;
+
+SET default_tablespace = '';
+
+SET default_table_access_method = heap;
+
+--
+-- Name: admin; Type: TABLE; Schema: public; Owner: gafaelfawr
+--
+
+CREATE TABLE public.admin (
+    username character varying(64) NOT NULL
+);
+
+
+ALTER TABLE public.admin OWNER TO gafaelfawr;
+
+--
+-- Name: admin_history; Type: TABLE; Schema: public; Owner: gafaelfawr
+--
+
+CREATE TABLE public.admin_history (
+    id integer NOT NULL,
+    username character varying(64) NOT NULL,
+    action public.adminchange NOT NULL,
+    actor character varying(64) NOT NULL,
+    ip_address inet NOT NULL,
+    event_time timestamp without time zone NOT NULL
+);
+
+
+ALTER TABLE public.admin_history OWNER TO gafaelfawr;
+
+--
+-- Name: admin_history_id_seq; Type: SEQUENCE; Schema: public; Owner: gafaelfawr
+--
+
+CREATE SEQUENCE public.admin_history_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER SEQUENCE public.admin_history_id_seq OWNER TO gafaelfawr;
+
+--
+-- Name: admin_history_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: gafaelfawr
+--
+
+ALTER SEQUENCE public.admin_history_id_seq OWNED BY public.admin_history.id;
+
+
+--
+-- Name: subtoken; Type: TABLE; Schema: public; Owner: gafaelfawr
+--
+
+CREATE TABLE public.subtoken (
+    child character varying(64) NOT NULL,
+    parent character varying(64)
+);
+
+
+ALTER TABLE public.subtoken OWNER TO gafaelfawr;
+
+--
+-- Name: token; Type: TABLE; Schema: public; Owner: gafaelfawr
+--
+
+CREATE TABLE public.token (
+    token character varying(64) NOT NULL COLLATE pg_catalog."C",
+    username character varying(64) NOT NULL,
+    token_type public.tokentype NOT NULL,
+    token_name character varying(64),
+    scopes character varying(512) NOT NULL,
+    service character varying(64),
+    created timestamp without time zone NOT NULL,
+    last_used timestamp without time zone,
+    expires timestamp without time zone
+);
+
+
+ALTER TABLE public.token OWNER TO gafaelfawr;
+
+--
+-- Name: token_auth_history; Type: TABLE; Schema: public; Owner: gafaelfawr
+--
+
+CREATE TABLE public.token_auth_history (
+    id integer NOT NULL,
+    token character varying(64) NOT NULL,
+    username character varying(64) NOT NULL,
+    token_type public.tokentype NOT NULL,
+    token_name character varying(64),
+    parent character varying(64),
+    scopes character varying(512),
+    service character varying(64),
+    ip_address inet,
+    event_time timestamp without time zone NOT NULL
+);
+
+
+ALTER TABLE public.token_auth_history OWNER TO gafaelfawr;
+
+--
+-- Name: token_auth_history_id_seq; Type: SEQUENCE; Schema: public; Owner: gafaelfawr
+--
+
+CREATE SEQUENCE public.token_auth_history_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER SEQUENCE public.token_auth_history_id_seq OWNER TO gafaelfawr;
+
+--
+-- Name: token_auth_history_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: gafaelfawr
+--
+
+ALTER SEQUENCE public.token_auth_history_id_seq OWNED BY public.token_auth_history.id;
+
+
+--
+-- Name: token_change_history; Type: TABLE; Schema: public; Owner: gafaelfawr
+--
+
+CREATE TABLE public.token_change_history (
+    id integer NOT NULL,
+    token character varying(64) NOT NULL,
+    username character varying(64) NOT NULL,
+    token_type public.tokentype NOT NULL,
+    token_name character varying(64),
+    parent character varying(64),
+    scopes character varying(512) NOT NULL,
+    service character varying(64),
+    expires timestamp without time zone,
+    actor character varying(64),
+    action public.tokenchange NOT NULL,
+    old_token_name character varying(64),
+    old_scopes character varying(512),
+    old_expires timestamp without time zone,
+    ip_address inet,
+    event_time timestamp without time zone NOT NULL
+);
+
+
+ALTER TABLE public.token_change_history OWNER TO gafaelfawr;
+
+--
+-- Name: token_change_history_id_seq; Type: SEQUENCE; Schema: public; Owner: gafaelfawr
+--
+
+CREATE SEQUENCE public.token_change_history_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER SEQUENCE public.token_change_history_id_seq OWNER TO gafaelfawr;
+
+--
+-- Name: token_change_history_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: gafaelfawr
+--
+
+ALTER SEQUENCE public.token_change_history_id_seq OWNED BY public.token_change_history.id;
+
+
+--
+-- Name: admin_history id; Type: DEFAULT; Schema: public; Owner: gafaelfawr
+--
+
+ALTER TABLE ONLY public.admin_history ALTER COLUMN id SET DEFAULT nextval('public.admin_history_id_seq'::regclass);
+
+
+--
+-- Name: token_auth_history id; Type: DEFAULT; Schema: public; Owner: gafaelfawr
+--
+
+ALTER TABLE ONLY public.token_auth_history ALTER COLUMN id SET DEFAULT nextval('public.token_auth_history_id_seq'::regclass);
+
+
+--
+-- Name: token_change_history id; Type: DEFAULT; Schema: public; Owner: gafaelfawr
+--
+
+ALTER TABLE ONLY public.token_change_history ALTER COLUMN id SET DEFAULT nextval('public.token_change_history_id_seq'::regclass);
+
+
+--
+-- Name: admin_history admin_history_pkey; Type: CONSTRAINT; Schema: public; Owner: gafaelfawr
+--
+
+ALTER TABLE ONLY public.admin_history
+    ADD CONSTRAINT admin_history_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: admin admin_pkey; Type: CONSTRAINT; Schema: public; Owner: gafaelfawr
+--
+
+ALTER TABLE ONLY public.admin
+    ADD CONSTRAINT admin_pkey PRIMARY KEY (username);
+
+
+--
+-- Name: subtoken subtoken_pkey; Type: CONSTRAINT; Schema: public; Owner: gafaelfawr
+--
+
+ALTER TABLE ONLY public.subtoken
+    ADD CONSTRAINT subtoken_pkey PRIMARY KEY (child);
+
+
+--
+-- Name: token_auth_history token_auth_history_pkey; Type: CONSTRAINT; Schema: public; Owner: gafaelfawr
+--
+
+ALTER TABLE ONLY public.token_auth_history
+    ADD CONSTRAINT token_auth_history_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: token_change_history token_change_history_pkey; Type: CONSTRAINT; Schema: public; Owner: gafaelfawr
+--
+
+ALTER TABLE ONLY public.token_change_history
+    ADD CONSTRAINT token_change_history_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: token token_pkey; Type: CONSTRAINT; Schema: public; Owner: gafaelfawr
+--
+
+ALTER TABLE ONLY public.token
+    ADD CONSTRAINT token_pkey PRIMARY KEY (token);
+
+
+--
+-- Name: token token_username_token_name_key; Type: CONSTRAINT; Schema: public; Owner: gafaelfawr
+--
+
+ALTER TABLE ONLY public.token
+    ADD CONSTRAINT token_username_token_name_key UNIQUE (username, token_name);
+
+
+--
+-- Name: admin_history_by_time; Type: INDEX; Schema: public; Owner: gafaelfawr
+--
+
+CREATE INDEX admin_history_by_time ON public.admin_history USING btree (event_time, id);
+
+
+--
+-- Name: subtoken_by_parent; Type: INDEX; Schema: public; Owner: gafaelfawr
+--
+
+CREATE INDEX subtoken_by_parent ON public.subtoken USING btree (parent);
+
+
+--
+-- Name: token_auth_history_by_time; Type: INDEX; Schema: public; Owner: gafaelfawr
+--
+
+CREATE INDEX token_auth_history_by_time ON public.token_auth_history USING btree (event_time, id);
+
+
+--
+-- Name: token_auth_history_by_token; Type: INDEX; Schema: public; Owner: gafaelfawr
+--
+
+CREATE INDEX token_auth_history_by_token ON public.token_auth_history USING btree (token, event_time, id);
+
+
+--
+-- Name: token_auth_history_by_username; Type: INDEX; Schema: public; Owner: gafaelfawr
+--
+
+CREATE INDEX token_auth_history_by_username ON public.token_auth_history USING btree (username, event_time, id);
+
+
+--
+-- Name: token_by_username; Type: INDEX; Schema: public; Owner: gafaelfawr
+--
+
+CREATE INDEX token_by_username ON public.token USING btree (username, token_type);
+
+
+--
+-- Name: token_change_history_by_time; Type: INDEX; Schema: public; Owner: gafaelfawr
+--
+
+CREATE INDEX token_change_history_by_time ON public.token_change_history USING btree (event_time, id);
+
+
+--
+-- Name: token_change_history_by_token; Type: INDEX; Schema: public; Owner: gafaelfawr
+--
+
+CREATE INDEX token_change_history_by_token ON public.token_change_history USING btree (token, event_time, id);
+
+
+--
+-- Name: token_change_history_by_username; Type: INDEX; Schema: public; Owner: gafaelfawr
+--
+
+CREATE INDEX token_change_history_by_username ON public.token_change_history USING btree (username, event_time, id);
+
+
+--
+-- Name: subtoken subtoken_child_fkey; Type: FK CONSTRAINT; Schema: public; Owner: gafaelfawr
+--
+
+ALTER TABLE ONLY public.subtoken
+    ADD CONSTRAINT subtoken_child_fkey FOREIGN KEY (child) REFERENCES public.token(token) ON DELETE CASCADE;
+
+
+--
+-- Name: subtoken subtoken_parent_fkey; Type: FK CONSTRAINT; Schema: public; Owner: gafaelfawr
+--
+
+ALTER TABLE ONLY public.subtoken
+    ADD CONSTRAINT subtoken_parent_fkey FOREIGN KEY (parent) REFERENCES public.token(token) ON DELETE SET NULL;
+
+
+--
+-- Name: SCHEMA public; Type: ACL; Schema: -; Owner: gafaelfawr
+--
+
+REVOKE USAGE ON SCHEMA public FROM PUBLIC;
+GRANT ALL ON SCHEMA public TO PUBLIC;
+
+
+--
+-- PostgreSQL database dump complete
+--
+


### PR DESCRIPTION
Check whether the schema is current at all entry points, not just the FastAPI application startup, so that the other aspects of Gafaelfawr will also not start with an outdated database.

Fix the existing schema migration to use valid SQL. Add proper tests for schema updates, confirming the ability to upgrade from the last pre-Alembic schema version.

Add new gafaelfawr update-schema command to initialize the database if needed and then apply any missing Alembic migrations. Add new gafaelfawr validate-schema command that exits non-zero if the database has not been initialized or if the schema is not up to date.