### PR TITLE
DM-42627: Remove uses of sqlalchemy.future

### DIFF
--- a/src/gafaelfawr/factory.py
+++ b/src/gafaelfawr/factory.py
@@ -19,8 +19,8 @@ from safir.database import create_async_session
 from safir.dependencies.http_client import http_client_dependency
 from safir.redis import EncryptedPydanticRedisStorage
 from safir.slack.webhook import SlackWebhookClient
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncEngine, async_scoped_session
-from sqlalchemy.future import select
 from structlog.stdlib import BoundLogger
 
 from .cache import IdCache, InternalTokenCache, LDAPCache, NotebookTokenCache

--- a/src/gafaelfawr/storage/admin.py
+++ b/src/gafaelfawr/storage/admin.py
@@ -2,9 +2,8 @@
 
 from __future__ import annotations
 
-from sqlalchemy import delete
+from sqlalchemy import delete, select
 from sqlalchemy.ext.asyncio import async_scoped_session
-from sqlalchemy.future import select
 
 from ..models.admin import Admin
 from ..schema import Admin as SQLAdmin

--- a/src/gafaelfawr/storage/history.py
+++ b/src/gafaelfawr/storage/history.py
@@ -5,9 +5,8 @@ from __future__ import annotations
 from datetime import datetime
 
 from safir.database import datetime_from_db, datetime_to_db
-from sqlalchemy import and_, delete, func, or_
+from sqlalchemy import and_, delete, func, or_, select
 from sqlalchemy.ext.asyncio import async_scoped_session
-from sqlalchemy.future import select
 from sqlalchemy.sql import Select, text
 
 from ..models.history import (

--- a/src/gafaelfawr/storage/token.py
+++ b/src/gafaelfawr/storage/token.py
@@ -8,9 +8,8 @@ from safir.database import datetime_to_db
 from safir.datetime import current_datetime
 from safir.redis import DeserializeError, EncryptedPydanticRedisStorage
 from safir.slack.webhook import SlackWebhookClient
-from sqlalchemy import delete
+from sqlalchemy import delete, select
 from sqlalchemy.ext.asyncio import async_scoped_session
-from sqlalchemy.future import select
 from structlog.stdlib import BoundLogger
 
 from ..exceptions import DuplicateTokenNameError

--- a/tests/handlers/api_history_test.py
+++ b/tests/handlers/api_history_test.py
@@ -14,7 +14,7 @@ from httpx import AsyncClient
 from safir.database import datetime_to_db
 from safir.datetime import current_datetime
 from safir.testing.slack import MockSlackWebhook
-from sqlalchemy.future import select
+from sqlalchemy import select
 
 from gafaelfawr.factory import Factory
 from gafaelfawr.models.history import TokenChangeHistoryEntry


### PR DESCRIPTION
Now that SQLAlchemy 2.x has been released, we no longer need to import some things from sqlalchemy.future and can simplify imports.