### PR TITLE
DM-42384: Fix database schema check during startup

### DIFF
--- a/changelog.d/20240222_115317_rra_DM_42384.md
+++ b/changelog.d/20240222_115317_rra_DM_42384.md
@@ -1,0 +1,3 @@
+### Bug fixes
+
+- Fix check for current database schema when starting the web application.

--- a/src/gafaelfawr/main.py
+++ b/src/gafaelfawr/main.py
@@ -74,7 +74,7 @@ def create_app(
         config = config_dependency.config()
         if validate_schema:
             logger = structlog.get_logger("gafaelfawr")
-            if not is_database_current(config, logger):
+            if not await is_database_current(config, logger):
                 raise DatabaseSchemaError("Database schema out of date")
         await context_dependency.initialize(config)
         await db_session_dependency.initialize(

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -1,0 +1,70 @@
+"""Tests for web application startup."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from asgi_lifespan import LifespanManager
+from safir.database import create_database_engine
+from safir.dependencies.db_session import db_session_dependency
+from sqlalchemy import text
+from sqlalchemy.exc import ProgrammingError
+from sqlalchemy.ext.asyncio import AsyncEngine
+
+from gafaelfawr.config import Config
+from gafaelfawr.exceptions import DatabaseSchemaError
+from gafaelfawr.factory import Factory
+from gafaelfawr.main import create_app
+from gafaelfawr.schema import Base
+
+from .support.constants import TEST_DATABASE_URL
+
+
+# Initialize the database from an old schema. This was the database schema
+# before Alembic was introduced, so it should run all migrations.
+async def create_old_database(config: Config, engine: AsyncEngine) -> None:
+    """Initialize the database from an old schema.
+
+    Used to test whether the application refuses to start if the schema is out
+    of date.
+
+    Parameters
+    ----------
+    config
+        Gafaelfawr configuration.
+    engine
+        Database engine.
+    """
+    old_schema = Path(__file__).parent / "data" / "schemas" / "9.6.1"
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.drop_all)
+    async with Factory.standalone(config, engine) as factory:
+        async with factory.session.begin():
+            try:
+                sql = "DROP TABLE alembic_version"
+                await factory.session.execute(text(sql))
+            except ProgrammingError:
+                pass
+        async with factory.session.begin():
+            with old_schema.open() as f:
+                statement = ""
+                for line in f:
+                    if not line.startswith("--") and line.strip("\n"):
+                        statement += line.strip("\n")
+                    if statement.endswith(";"):
+                        await factory.session.execute(text(statement))
+                        statement = ""
+
+
+@pytest.mark.asyncio
+async def test_out_of_date_schema(config: Config) -> None:
+    engine = create_database_engine(TEST_DATABASE_URL, None)
+    await create_old_database(config, engine)
+
+    db_session_dependency.override_engine(engine)
+    app = create_app()
+    with pytest.raises(DatabaseSchemaError):
+        async with LifespanManager(app):
+            pass

--- a/tests/operator/ingress_test.py
+++ b/tests/operator/ingress_test.py
@@ -27,7 +27,7 @@ from ..support.kubernetes import (
 @requires_kubernetes
 @pytest.mark.asyncio
 async def test_create(
-    config: Config, api_client: ApiClient, namespace: str
+    config: Config, empty_database: None, api_client: ApiClient, namespace: str
 ) -> None:
     ingresses = operator_test_input("ingresses", namespace)
     await create_custom_resources(api_client, ingresses)
@@ -49,7 +49,7 @@ async def test_create(
 @requires_kubernetes
 @pytest.mark.asyncio
 async def test_replace(
-    config: Config, api_client: ApiClient, namespace: str
+    config: Config, empty_database: None, api_client: ApiClient, namespace: str
 ) -> None:
     ingress = operator_test_input("ingresses", namespace)[0]
     expected = operator_test_output("ingresses", namespace)[0]
@@ -117,7 +117,7 @@ async def test_replace(
 @requires_kubernetes
 @pytest.mark.asyncio
 async def test_resume(
-    config: Config, api_client: ApiClient, namespace: str
+    config: Config, empty_database: None, api_client: ApiClient, namespace: str
 ) -> None:
     """Test periodic rechecking of Ingress resources."""
     ingress = operator_test_input("ingresses", namespace)[0]
@@ -145,7 +145,7 @@ async def test_resume(
 @requires_kubernetes
 @pytest.mark.asyncio
 async def test_errors_scope(
-    config: Config, api_client: ApiClient, namespace: str
+    config: Config, empty_database: None, api_client: ApiClient, namespace: str
 ) -> None:
     networking_api = client.NetworkingV1Api(api_client)
     ingress = operator_test_input("ingress-error-scope", namespace)[0]


### PR DESCRIPTION
The check for whether the database schema was current during startup of the web application was never run because it was missing an await. Fix that and add a test.