### PR TITLE
DM-42627: Add more pointers to the Phalanx documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ Find changes for the upcoming release in the project's [changelog.d directory](h
 <a id='changelog-10.0.0'></a>
 ## 10.0.0 (2024-02-22)
 
+Upgrading to this version requires a [database schema migration](https://phalanx.lsst.io/applications/gafaelfawr/manage-schema.html).
+
 ### Backwards-incompatible changes
 
 - Clients of the Gafaelfawr OpenID Connect server now must have registered return URIs as well as client IDs and secrets. Each element of the `oidc-server-secrets` secret must, in addition to the previous `id` and `secret` keys, contain a `return_uri` key that matches the return URL of authentications from that client. Those return URLs are now allowed to be at any (matching) domain and are not constrained to the same domain as Gafaelfawr.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -17,10 +17,6 @@ Its design is documented in :dmtn:`234`, and its implementation in :dmtn:`224`.
 History and decisions made during its development are documented in :sqr:`069`.
 Read those documents for a more complete picture of how Gafaelfawr fits into a larger identity management system.
 
-Gafaelfawr is named for Glewlwyd Gafaelfawr, the knight who challenges King Arthur in *Pa gur yv y porthaur?* and, in later stories, is a member of his court and acts as gatekeeper.
-Gafaelfawr is pronounced (very roughly) gah-VILE-vahwr.
-(If you speak Welsh and can provide a better pronunciation guide, please open an issue!)
-
 .. toctree::
    :maxdepth: 2
    :caption: Usage
@@ -38,3 +34,7 @@ Gafaelfawr is pronounced (very roughly) gah-VILE-vahwr.
    :caption: Development
 
    dev/index
+
+Gafaelfawr is named for Glewlwyd Gafaelfawr, the knight who challenges King Arthur in *Pa gur yv y porthaur?* and, in later stories, is a member of his court and acts as gatekeeper.
+Gafaelfawr is pronounced (very roughly) gah-VILE-vahwr.
+(If you speak Welsh and can provide a better pronunciation guide, please open an issue!)

--- a/docs/user-guide/helm.rst
+++ b/docs/user-guide/helm.rst
@@ -5,11 +5,8 @@ Helm configuration
 ##################
 
 Gafaelfawr is configured as a Phalanx_ application, using the Helm chart in `the Phalanx repository <https://github.com/lsst-sqre/phalanx/tree/main/applications/gafaelfawr/>`__.
-You will need to provide a ``values-<environment>.yaml`` file for your Phalanx environment.
-Below are the most-commonly-used settings.
-
-For a complete reference, see the `Gafaelfawr application documentation <https://phalanx.lsst.io/applications/gafaelfawr/index.html>`__.
-For examples, see the other ``values-<environment>.yaml`` files in that directory.
+You will need to provide a :file:`values-{environment}.yaml` file for your Phalanx environment.
+For examples, see the other :file:`values-{environment}.yaml` files in that directory.
 
 In the below examples, the full key hierarchy is shown for each setting.
 For example:
@@ -20,8 +17,11 @@ For example:
      cilogon:
        test: true
 
-When writing a ``values-<environment>.yaml`` chart, you should coalesce all settings so that each level of the hierarchy appears only once.
+When writing a :file:`values-{environment}.yaml` chart, you should coalesce all settings so that each level of the hierarchy appears only once.
 For example, there should be one top-level ``config:`` key and all parameters that start with ``config.`` should go under that key.
+
+You should also read the `Gafaelfawr application documentation <https://phalanx.lsst.io/applications/gafaelfawr/index.html>`__.
+In particular, when bootstrapping a new Phalanx environment, see the `Gafaelfawr bootstrapping instructions <https://phalanx.lsst.io/applications/gafaelfawr/bootstrap.html>`__.
 
 .. _basic-settings:
 
@@ -49,6 +49,18 @@ Alternately, if Gafaelfawr should use the cluster-internal PostgreSQL service, o
      internalDatabase: true
 
 This option is primarily for test and development deployments and is not recommended for production use.
+
+To enable database schema creation or upgrades, add:
+
+.. code-block:: yaml
+
+   config:
+     upgradeSchema: true
+
+This will enable a Helm pre-install and pre-upgrade hook that will initialize or update the database schema before the rest of Gafaelfawr is installed or updated.
+This setting should be left off by default and only enabled when you know you want to initialize the database from scratch or update the schema.
+When updating the schema of an existing installation, all Gafaelfawr components should be stopped before syncing Gafaelfawr.
+See `the Phalanx documentation <https://phalanx.lsst.io/applications/gafaelfawr/manage-schema.html>`__ for step-by-step instructions.
 
 Error pages
 -----------

--- a/docs/user-guide/index.rst
+++ b/docs/user-guide/index.rst
@@ -5,6 +5,8 @@ User guide
 Gafaelfawr was written to run within the Vera C. Rubin Science Platform.
 While there is nothing intrinsic in Gafaelfawr that would prevent it from working in some other environment, only installation via `Phalanx <https://github.com/lsst-sqre/phalanx>`__ is supported or has been tested.
 
+Also see the `Phalanx Gafaelfawr application documentation <https://phalanx.lsst.io/applications/gafaelfawr/index.html>`__ for more operational documentation and procedures.
+
 .. toctree::
    :caption: Configuration
 


### PR DESCRIPTION
Some operational documentation that is heavy on Argo CD actions or is closely entangled with Phalanx updates is documented on the Phalanx site. Add pointers to that documentation in multiple places.