### PR TITLE
DM-43288: Add Kopf health check

### DIFF
--- a/changelog.d/20240313_102609_rra_DM_43288a.md
+++ b/changelog.d/20240313_102609_rra_DM_43288a.md
@@ -1,0 +1,8 @@
+### New features
+
+- Add a health check for the Kubernetes operator that tests the Kopf infrastructure as well as the database, Redis, and (if configured) LDAP connections. Use that as a liveness check to restart the operator if the health check starts failing.
+
+### Bug fixes
+
+- Ensure that only one Gafaelfawr operator pod is running at a time.
+- Add Kubernetes resource requests and limits for the Cloud SQL Auth Proxy sidecar container.

--- a/docs/dev/internals.rst
+++ b/docs/dev/internals.rst
@@ -80,6 +80,9 @@ Python internal API
 .. automodapi:: gafaelfawr.operator
    :include-all-objects:
 
+.. automodapi:: gafaelfawr.operator.health
+   :include-all-objects:
+
 .. automodapi:: gafaelfawr.operator.ingress
    :include-all-objects:
 

--- a/src/gafaelfawr/operator/__init__.py
+++ b/src/gafaelfawr/operator/__init__.py
@@ -4,6 +4,6 @@ This module imports all of the handlers for Gafaelfawr's Kubernetes operator
 and serves as an entry point for Kopf_.
 """
 
-from . import ingress, startup, tokens
+from . import health, ingress, startup, tokens
 
-__all__ = ["ingress", "startup", "tokens"]
+__all__ = ["health", "ingress", "startup", "tokens"]

--- a/src/gafaelfawr/operator/health.py
+++ b/src/gafaelfawr/operator/health.py
@@ -1,0 +1,23 @@
+"""Kubernetes operator health checks."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import kopf
+
+
+@kopf.on.probe(id="health")
+async def get_health(memo: kopf.Memo, **_: Any) -> dict[str, Any]:
+    """Health check for Gafaelfawr data stores.
+
+    Check the health of the Gafaelfawr database, Redis, and (if configured)
+    LDAP connections and raise an exception if any of them do not work.
+
+    Parameters
+    ----------
+    memo
+        Holds global state.
+    """
+    health_check_service = memo.factory.create_health_check_service()
+    return await health_check_service.health().model_dump()


### PR DESCRIPTION
Run the health check service as a Kopf probe. Mention other Phalanx improvements to Gafaelfawr's Helm chart in the change log.