### PR TITLE
DM-43288: Use user info service for health check

### DIFF
--- a/changelog.d/20240312_180104_rra_DM_43288.md
+++ b/changelog.d/20240312_180104_rra_DM_43288.md
@@ -1,3 +1,3 @@
 ### New features
 
-- Add a health check internal route, `/health`, which is available only inside the Kubernetes cluster. Check that the database, Redis, and (if configured) LDAP connections are all working. Use that as a liveness check so that Kubernetes will restart Gafaelfawr if any of those connection pools are no longer working.
+- Add a health check internal route, `/health`, which is available only inside the Kubernetes cluster. Check that the database, Redis, and (if configured) LDAP and Firestore connections are all working. Use that as a liveness check so that Kubernetes will restart Gafaelfawr if any of those connection pools are no longer working.

--- a/src/gafaelfawr/services/firestore.py
+++ b/src/gafaelfawr/services/firestore.py
@@ -45,13 +45,15 @@ class FirestoreService:
         self._storage = storage
         self._logger = logger
 
-    async def get_gid(self, group: str) -> int:
+    async def get_gid(self, group: str, *, uncached: bool = False) -> int:
         """Get the GID for a given user from Firestore.
 
         Parameters
         ----------
         group
             Group of the user.
+        uncached
+            Bypass the cache, used for health checks.
 
         Returns
         -------
@@ -63,6 +65,8 @@ class FirestoreService:
         NoAvailableGidError
             No more GIDs are available in that range.
         """
+        if uncached:
+            return await self._storage.get_gid(group)
         gid = self._gid_cache.get(group)
         if gid:
             return gid
@@ -74,13 +78,15 @@ class FirestoreService:
             self._gid_cache.store(group, gid)
             return gid
 
-    async def get_uid(self, username: str) -> int:
+    async def get_uid(self, username: str, *, uncached: bool = False) -> int:
         """Get the UID for a given user.
 
         Parameters
         ----------
         username
             Username of the user.
+        uncached
+            Bypass the cache, used for health checks.
 
         Returns
         -------
@@ -92,6 +98,9 @@ class FirestoreService:
         NoAvailableUidError
             No more UIDs are available in that range.
         """
+        bot = is_bot_user(username)
+        if uncached:
+            return await self._storage.get_uid(username, bot=bot)
         uid = self._uid_cache.get(username)
         if uid:
             return uid

--- a/src/gafaelfawr/services/ldap.py
+++ b/src/gafaelfawr/services/ldap.py
@@ -48,7 +48,7 @@ class LDAPService:
         self._logger = logger
 
     async def get_group_names(
-        self, username: str, gid: int | None
+        self, username: str, gid: int | None, *, uncached: bool = False
     ) -> list[str]:
         """Get the names of user groups from LDAP.
 
@@ -61,12 +61,16 @@ class LDAPService:
             GID and add it to the user's group memberships.  This handles LDAP
             configurations where the user's primary group is represented only
             by their GID and not their group memberships.
+        uncached
+            Bypass the cache, used for health checks.
 
         Returns
         -------
         list of str
             The names of the user's groups according to LDAP.
         """
+        if uncached:
+            return await self._ldap.get_group_names(username, gid)
         groups = self._group_name_cache.get(username)
         if groups is not None:
             return groups
@@ -79,7 +83,7 @@ class LDAPService:
             return groups
 
     async def get_groups(
-        self, username: str, gid: int | None
+        self, username: str, gid: int | None, *, uncached: bool = False
     ) -> list[TokenGroup]:
         """Get user group membership and GIDs from LDAP.
 
@@ -93,6 +97,8 @@ class LDAPService:
             with this GID and add it to the user's group memberships.  This
             handles LDAP configurations where the user's primary group is
             represented only by their GID and not their group memberships.
+        uncached
+            Bypass the cache, used for health checks.
 
         Returns
         -------
@@ -104,6 +110,8 @@ class LDAPService:
         LDAPError
             An error occurred when retrieving user information from LDAP.
         """
+        if uncached:
+            return await self._ldap.get_groups(username, gid)
         groups = self._group_cache.get(username)
         if groups is not None:
             return groups
@@ -115,7 +123,9 @@ class LDAPService:
             self._group_cache.store(username, groups)
             return groups
 
-    async def get_data(self, username: str) -> LDAPUserData:
+    async def get_data(
+        self, username: str, *, uncached: bool = False
+    ) -> LDAPUserData:
         """Get configured data from LDAP.
 
         Returns all data configured to be retrieved from LDAP.
@@ -124,12 +134,16 @@ class LDAPService:
         ----------
         username
             Username of the user.
+        uncached
+            Bypass the cache, used for health checks.
 
         Returns
         -------
         LDAPUserData
             The retrieved data.
         """
+        if uncached:
+            return await self._ldap.get_data(username)
         data = self._user_cache.get(username)
         if data:
             return data


### PR DESCRIPTION
The health check tried to bypass the user info service, but that would require recreating all of the logic that the user info service already had and bypassed checking connectivity to Firestore. Instead, add uncached flags to the user info service and its underlying LDAP and Firestore services that make uncached requests for a proper health check, and use it.