### PR TITLE
DM-43288: Don't check LDAP and Firestore from Kopf

### DIFF
--- a/changelog.d/20240313_102609_rra_DM_43288a.md
+++ b/changelog.d/20240313_102609_rra_DM_43288a.md
@@ -1,6 +1,6 @@
 ### New features
 
-- Add a health check for the Kubernetes operator that tests the Kopf infrastructure as well as the database, Redis, and (if configured) LDAP connections. Use that as a liveness check to restart the operator if the health check starts failing.
+- Add a health check for the Kubernetes operator that tests the Kopf infrastructure as well as the database and Redis connections. Use that as a liveness check to restart the operator if the health check starts failing.
 
 ### Bug fixes
 

--- a/src/gafaelfawr/models/health.py
+++ b/src/gafaelfawr/models/health.py
@@ -13,7 +13,7 @@ __all__ = [
 ]
 
 
-class HealthStatus(Enum):
+class HealthStatus(str, Enum):
     """Status of health check.
 
     Since errors are returned as HTTP 500 errors, currently the only status is

--- a/src/gafaelfawr/operator/health.py
+++ b/src/gafaelfawr/operator/health.py
@@ -27,5 +27,5 @@ async def get_health(memo: kopf.Memo, **_: Any) -> dict[str, Any]:
     factory: Factory = memo.factory
 
     health_check_service = factory.create_health_check_service()
-    await health_check_service.check()
+    await health_check_service.check(check_user_info=False)
     return HealthCheck(status=HealthStatus.HEALTHY).model_dump()


### PR DESCRIPTION
The Kubernetes operator doesn't need access to LDAP or Firestore, so checks that use that access will fail. Add a flag that allows the Kopf health checks to disable this.