### PR TITLE
DM-43714: Switch to tox-uv, fix docs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -116,7 +116,7 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
           tox-envs: "typing,py-full,coverage-report"
-          tox-plugins: tox-docker
+          tox-plugins: "tox-docker tox-uv"
           cache-key-prefix: test
 
   docs:
@@ -138,8 +138,9 @@ jobs:
       - uses: lsst-sqre/run-tox@v1
         with:
           python-version: "3.12"
-          tox-envs: "docs"
-          cache-key-prefix: "docs"
+          tox-envs: docs
+          tox-plugins: "tox-docker tox-uv"
+          cache-key-prefix: docs
 
       # Only attempt documentation uploads for long-lived branches, tagged
       # releases, and pull requests from ticket branches.  This avoids version
@@ -173,7 +174,8 @@ jobs:
         uses: lsst-sqre/run-tox@v1
         with:
           python-version: "3.12"
-          tox-envs: "docs-linkcheck"
+          tox-envs: docs-linkcheck
+          tox-plugins: tox-uv
 
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/periodic-ci.yaml
+++ b/.github/workflows/periodic-ci.yaml
@@ -79,7 +79,7 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
           tox-envs: "lint,typing,py-full,docs,docs-linkcheck"
-          tox-plugins: tox-docker
+          tox-plugins: "tox-docker tox-uv"
           use-cache: false
 
       - name: Report status

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,7 @@ repos:
         args: [-l, '79', -t, py312]
 
   - repo: https://github.com/pre-commit/mirrors-eslint
-    rev: v8.56.0
+    rev: v9.0.0-rc.0
     hooks:
       - id: eslint
         additional_dependencies:

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ init:
 # level of shell trickery after failed commands.
 .PHONY: linkcheck
 linkcheck:
-	sphinx-build --keep-going -n -T -b linkcheck docs	\
+	sphinx-build -W --keep-going -n -T -b linkcheck docs	\
 	    docs/_build/linkcheck				\
 	    || (cat docs/_build/linkcheck/output.txt; exit 1)
 

--- a/docs/dev/development.rst
+++ b/docs/dev/development.rst
@@ -143,7 +143,7 @@ To set up Minikube:
 
    .. prompt:: bash
 
-   minikube addons enable ingress
+      minikube addons enable ingress
 
 To run all of the tests including Kubernetes tests, first check that your default Kubernetes environment is the one in which you want to run tests:
 

--- a/docs/user-guide/helm.rst
+++ b/docs/user-guide/helm.rst
@@ -741,7 +741,7 @@ Maintenance
 ===========
 
 Timing
-^^^^^^
+------
 
 Gafaelfawr uses two Kubernetes ``CronJob`` resources to perform periodic maintenance and consistency checks on its data stores.
 
@@ -757,7 +757,7 @@ Its schedule can be set with ``config.maintenance.auditSchedule`` (a `cron sched
 .. _cron schedule expression: https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/#schedule-syntax
 
 Time limits
-^^^^^^^^^^^
+-----------
 
 By default, Gafaelfawr allows its maintenance and audit jobs five minutes to run, and cleans up any completed jobs older than one day.
 Kubernetes also deletes completed and failed jobs as necessary to maintain a cap on the number retained, which normally overrides the cleanup timing for the maintenance job that runs hourly.

--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -22,6 +22,7 @@ selenium-wire
 sqlalchemy[mypy]
 tox
 tox-docker
+tox-uv
 types-cachetools
 types-PyYAML
 

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -833,9 +833,10 @@ packaging==24.0 \
     #   sphinx
     #   tox
     #   tox-docker
-parso==0.8.3 \
-    --hash=sha256:8c07be290bb59f03588915921e29e8a50002acaf2cdc5fa0e0114f91709fafa0 \
-    --hash=sha256:c001d4636cd3aecdaf33cbb40aebb59b094be2a74c556778ef5576c175e19e75
+    #   tox-uv
+parso==0.8.4 \
+    --hash=sha256:a418670a20291dacd2dddc80c377c5c3791378ee1e8d12bffc35420643d43f18 \
+    --hash=sha256:eb3a7b58240fb99099a345571deecc0f9540ea5f4dd2fe14c2a99d6b281ab92d
     # via jedi
 pexpect==4.9.0 \
     --hash=sha256:7236d1e080e4936be2dc3e326cec0af72acf9212a7e1d060210e70a47e253523 \
@@ -1581,10 +1582,15 @@ tornado==6.4 \
 tox==4.14.2 \
     --hash=sha256:0defb44f6dafd911b61788325741cc6b2e12ea71f987ac025ad4d649f1f1a104 \
     --hash=sha256:2900c4eb7b716af4a928a7fdc2ed248ad6575294ed7cfae2ea41203937422847
-    # via tox-docker
+    # via
+    #   tox-docker
+    #   tox-uv
 tox-docker==4.1.0 \
     --hash=sha256:0317e692dc80f2197eaf9c905dcb8d1d1f9d5bf2686ecfd83c22a1da9d23fb24 \
     --hash=sha256:444c72192a2443d2b4db5766545d4413ea683cc488523d770e2e216f15fa3086
+tox-uv==1.7.0 \
+    --hash=sha256:0278f38f305ad0515f4d2620c70a848ef4d135a3d9eb778878d1ac8cbdd8528e \
+    --hash=sha256:2915128b487ac720e27f8a6dc9597aa6925b62235c6041553055ced710943ea7
 traitlets==5.14.2 \
     --hash=sha256:8cdd83c040dab7d1dee822678e5f5d100b514f7b72b01615b26fc5718916fdf9 \
     --hash=sha256:fcdf85684a772ddeba87db2f398ce00b40ff550d1528c03c14dbf6a02003cd80
@@ -1656,9 +1662,9 @@ types-cachetools==5.3.0.7 \
 types-pyyaml==6.0.12.20240311 \
     --hash=sha256:a9e0f0f88dc835739b0c1ca51ee90d04ca2a897a71af79de9aec5f38cb0a5342 \
     --hash=sha256:b845b06a1c7e54b8e5b4c683043de0d9caf205e7434b3edc678ff2411979b8f6
-typing-extensions==4.10.0 \
-    --hash=sha256:69b1a937c3a517342112fb4c6df7e72fc39a38e7891a5730ed4985b5214b5475 \
-    --hash=sha256:b0abd7c89e8fb96f98db18d86106ff1d90ab692004eb746cf6eda2682f91b3cb
+typing-extensions==4.11.0 \
+    --hash=sha256:83f085bd5ca59c80295fc2a82ab5dac679cbe02b9f33f7d83af68e241bea51b0 \
+    --hash=sha256:c1f94d72897edaf4ce775bb7558d5b79d8126906a14ea5ed1635921406c0387a
     # via
     #   mypy
     #   myst-nb
@@ -1678,6 +1684,25 @@ urllib3==2.2.1 \
     #   documenteer
     #   requests
     #   selenium
+uv==0.1.29 \
+    --hash=sha256:1c84b20e89dd807dc414c630ecf837c8d0764d7b1e23eddde01ea7781b44b0e8 \
+    --hash=sha256:341783e6db18fdf1b3f179168c4c3ab6b87b36091603473a9a6ffc1dacee4e35 \
+    --hash=sha256:4e677435abdc7a74c0a3eb8f5732a620815203886d8fda5f4e29724dd5e68e5a \
+    --hash=sha256:5e18e9db7dde120c736880a91a414d83e42057cbf0c5205003cfd1c4758d4e59 \
+    --hash=sha256:686b813030096942921180029d5c4cf6223f01d72514a34cf1816d10e7845a59 \
+    --hash=sha256:718ea9b5815a0fe7e9c244298b1b1a844c8f8b2f12dec8b024aef8efb3cf543f \
+    --hash=sha256:76fef8934e03f6b0b699265be8d3a2b26ecec76e5fcb277ebc5d5a2c4ff32a66 \
+    --hash=sha256:79d25e384abab5207b1b3e29daee2a5c2e76c98519ffef6dc6686d63584ff687 \
+    --hash=sha256:a8f58fcb2c8aeccd1295d271ba7388cfa5328be29f5ce91cfbb8161eff123b72 \
+    --hash=sha256:aa8d00ee623a598c4486f40f005059d73b4d74ecd647a4303bb740ac7f269b1b \
+    --hash=sha256:ad1a4da6213fac5f76289ee91cb2f6900f0a924e411220641ec33c0a552df947 \
+    --hash=sha256:bb8f3f2d398dbeee3f9288e7ae590b79979247793d0dbb1dab806c55df3b0cca \
+    --hash=sha256:ca8b16dc6ce8157409ea42ec7d7f68bd237fe7819c17690c4a7aee686569068f \
+    --hash=sha256:e154fdd4624b7ccbb94f3e0c350f29730f93562b1ab3e7a281b6ff5e652b0d3d \
+    --hash=sha256:ed5decffebca6041ce489cec0bfbc30141ff3c6e43e8685321f2553e716e5457 \
+    --hash=sha256:f60da529d5cbc8fd4ab22e5fb7d899d800d7170a8ab42e193fc4403d583d9170 \
+    --hash=sha256:f9a6023fb1863830dd1fe9a5d656fa11f18cde156f671e736904be282b2427be
+    # via tox-uv
 virtualenv==20.25.1 \
     --hash=sha256:961c026ac520bac5f69acb8ea063e8a4f071bcc9457b9c1f28f6b085c511583a \
     --hash=sha256:e08e13ecdca7a0bd53798f356d5831434afa5b07b93f0abdf0797b7a06ffe197

--- a/requirements/main.txt
+++ b/requirements/main.txt
@@ -1127,9 +1127,9 @@ structlog==24.1.0 \
     --hash=sha256:3f6efe7d25fab6e86f277713c218044669906537bb717c1807a09d46bca0714d \
     --hash=sha256:41a09886e4d55df25bdcb9b5c9674bccfab723ff43e0a86a1b7b236be8e57b16
     # via safir
-typing-extensions==4.10.0 \
-    --hash=sha256:69b1a937c3a517342112fb4c6df7e72fc39a38e7891a5730ed4985b5214b5475 \
-    --hash=sha256:b0abd7c89e8fb96f98db18d86106ff1d90ab692004eb746cf6eda2682f91b3cb
+typing-extensions==4.11.0 \
+    --hash=sha256:83f085bd5ca59c80295fc2a82ab5dac679cbe02b9f33f7d83af68e241bea51b0 \
+    --hash=sha256:c1f94d72897edaf4ce775bb7558d5b79d8126906a14ea5ed1635921406c0387a
     # via
     #   alembic
     #   fastapi

--- a/src/gafaelfawr/config.py
+++ b/src/gafaelfawr/config.py
@@ -123,7 +123,7 @@ class OIDCSettings(CamelCaseModel):
         title="Scopes to request",
         description=(
             "Scopes to request from the authentication provider. The"
-            " `openid` scope will always be added and does not need to be"
+            " ``openid`` scope will always be added and does not need to be"
             " specified."
         ),
     )
@@ -327,8 +327,8 @@ class OIDCServerSettings(CamelCaseModel):
         description=(
             "Mapping of group names to keywords for data releases, indicating"
             " membership in that group grants access to that data release."
-            " Used to construct the `data_rights` claim, which can be"
-            " requested by asking for the `rubin` scope."
+            " Used to construct the ``data_rights`` claim, which can be"
+            " requested by asking for the ``rubin`` scope."
         ),
         examples=[{"g_users": ["dp0.1", "dp0.2", "dp0.3"]}],
     )

--- a/src/gafaelfawr/models/auth.py
+++ b/src/gafaelfawr/models/auth.py
@@ -153,7 +153,7 @@ class APILoginResponse(BaseModel):
         title="CSRF token",
         description=(
             "This token must be included in any non-GET request using cookie"
-            " authentication as the value of the `X-CSRF-Token` header"
+            " authentication as the value of the ``X-CSRF-Token`` header"
         ),
         examples=["OmNdVTtKKuK_VuJsGFdrqg"],
     )

--- a/src/gafaelfawr/models/history.py
+++ b/src/gafaelfawr/models/history.py
@@ -237,18 +237,6 @@ class TokenChangeHistoryEntry(BaseModel):
     token_type: TokenType = Field(
         ...,
         title="Type of the token",
-        description=(
-            "Class of token, chosen from:\n\n"
-            "* `session`: An interactive user web session\n"
-            "* `user`: A user-generated token that may be used"
-            " programmatically\n"
-            "* `notebook`: The token delegated to a Jupyter notebook for"
-            " the user\n"
-            "* `internal`: A service-to-service token used for internal"
-            " sub-calls made as part of processing a user request\n"
-            "* `service`: A service-to-service token used for internal calls"
-            " initiated by services, unrelated to a user request\n"
-        ),
         examples=["user"],
     )
 

--- a/src/gafaelfawr/models/oidc.py
+++ b/src/gafaelfawr/models/oidc.py
@@ -24,6 +24,7 @@ __all__ = [
     "OIDCConfig",
     "OIDCScope",
     "OIDCToken",
+    "OIDCTokenReply",
     "OIDCVerifiedToken",
 ]
 
@@ -32,7 +33,7 @@ class OIDCScope(StrEnum):
     """A recognized OpenID Connect scope.
 
     This should not be directly exposed in the model of any endpoint. Instead,
-    the `str` scope parameter should be parsed with the `parse_scopes` class
+    the `str` scope parameter should be parsed with the ``parse_scopes`` class
     method to yield a list of `OIDCScope` objects.
     """
 
@@ -287,7 +288,7 @@ class OIDCTokenReply(BaseModel):
     token_type: str = Field(
         "Bearer",
         title="Type of token",
-        description="Will always be `Bearer`",
+        description="Will always be ``Bearer``",
         examples=["Bearer"],
     )
 
@@ -318,21 +319,21 @@ class JWK(BaseModel):
     alg: str = Field(
         ...,
         title="Algorithm",
-        description=f"Will always be `{ALGORITHM}`",
+        description=f"Will always be ``{ALGORITHM}``",
         examples=[ALGORITHM],
     )
 
     kty: str = Field(
         ...,
         title="Key type",
-        description="Will always be `RSA`",
+        description="Will always be ``RSA``",
         examples=["RSA"],
     )
 
     use: str = Field(
         ...,
         title="Key usage",
-        description="Will always be `sig` (signatures)",
+        description="Will always be ``sig`` (signatures)",
         examples=["sig"],
     )
 
@@ -431,41 +432,41 @@ class OIDCConfig(BaseModel):
     response_types_supported: list[str] = Field(
         ["code"],
         title="Supported response types",
-        description="`code` is the only supported response type",
+        description="``code`` is the only supported response type",
         examples=[["code"]],
     )
 
     response_modes_supported: list[str] = Field(
         ["query"],
         title="Supported response modes",
-        description="`query` is the only supported response mode",
+        description="``query`` is the only supported response mode",
         examples=[["query"]],
     )
 
     grant_types_supported: list[str] = Field(
         ["authorization_code"],
         title="Supported grant types",
-        description="`authorization_code` is the only supported grant type",
+        description="``authorization_code`` is the only supported grant type",
         examples=[["authorization_code"]],
     )
 
     subject_types_supported: list[str] = Field(
         ["public"],
         title="Supported subject types",
-        description="`public` is the only supported subject type",
+        description="``public`` is the only supported subject type",
         examples=[["public"]],
     )
 
     id_token_signing_alg_values_supported: list[str] = Field(
         [ALGORITHM],
         title="Supported JWT signing algorithms",
-        description=f"`{ALGORITHM}` is the only supported signing algorithm",
+        description=f"``{ALGORITHM}`` is the only supported signing algorithm",
         examples=[[ALGORITHM]],
     )
 
     token_endpoint_auth_methods_supported: list[str] = Field(
         ["client_secret_post"],
         title="Supported client auth methods",
-        description="`client_secret_post` is the only supported auth method",
+        description="``client_secret_post`` is the only supported auth method",
         examples=[["client_secret_post"]],
     )

--- a/src/gafaelfawr/models/token.py
+++ b/src/gafaelfawr/models/token.py
@@ -226,19 +226,6 @@ class TokenBase(BaseModel):
 
     token_type: TokenType = Field(
         ...,
-        description=(
-            "Class of token, chosen from:\n\n"
-            "* `session`: An interactive user web session\n"
-            "* `user`: A user-generated token that may be used"
-            " programmatically\n"
-            "* `notebook`: The token delegated to a Jupyter notebook for"
-            " the user\n"
-            "* `internal`: A service-to-service token used for internal"
-            " sub-calls made as part of processing a user request\n"
-            "* `service`: A service-to-service token used for internal calls"
-            " initiated by services, unrelated to a user request\n"
-            "* `oidc`: Access token for an OpenID Connect client\n"
-        ),
         title="Token type",
         examples=["session"],
     )
@@ -519,7 +506,7 @@ class AdminTokenRequest(BaseModel):
         title="User for which to issue a token",
         description=(
             "The username may only contain lowercase letters, digits,"
-            " and dash (`-`), and may not start or end with a dash"
+            " and hyphen-minus, and may not start or end with a dash"
         ),
         examples=["some-service"],
         min_length=1,
@@ -530,21 +517,14 @@ class AdminTokenRequest(BaseModel):
     token_type: TokenType = Field(
         ...,
         title="Token type",
-        description=(
-            "Must be either `service` or `user`"
-            "\n\n"
-            "* `service`: A service-to-service token used for internal calls"
-            " initiated by services, unrelated to a user request\n"
-            "* `user`: A user-generated token that may be used"
-            " programmatically\n"
-        ),
+        description="Must be either ``service`` or ``user``",
         examples=["service"],
     )
 
     token_name: str | None = Field(
         None,
         title="User-given name of the token",
-        description="Only provide this field for a token type of `user`",
+        description="Only provide this field for a token type of ``user``",
         examples=["laptop token"],
         min_length=1,
         max_length=64,

--- a/src/gafaelfawr/services/oidc.py
+++ b/src/gafaelfawr/services/oidc.py
@@ -160,7 +160,7 @@ class OIDCService:
         InvalidClientIdError
             Raised if the provided client ID is not registered as an OpenID
             Connect client.
-        RedirectUriMismatchError
+        ReturnUriMismatchError
             Raised if the provided redirect URI does not match the one
             registered for this client.
         """

--- a/tox.ini
+++ b/tox.ini
@@ -66,7 +66,7 @@ allowlist_externals =
 commands =
     rm -rf docs/dev/internals
     gafaelfawr openapi-schema --add-back-link --output docs/_static/openapi.json
-    sphinx-build --keep-going -n -T -b html -d {envtmpdir}/doctrees docs docs/_build/html
+    sphinx-build -W --keep-going -n -T -b html -d {envtmpdir}/doctrees docs docs/_build/html
 
 [testenv:docs-linkcheck]
 description = Check links in the documentation


### PR DESCRIPTION
Use the tox-uv plugin to speed up management of the tox virtual environments. Fix lots of documentation warnings (mostly from using Markdown in model descriptions), and re-enable fatal warnings for documentation builds.