### PR TITLE
Add explicit mention of Keycloak to docs

### DIFF
--- a/docs/_rst_epilog.rst
+++ b/docs/_rst_epilog.rst
@@ -1,5 +1,6 @@
 .. _Alembic: https://alembic.sqlalchemy.org/en/latest/index.html
 .. _ingress-nginx: https://kubernetes.github.io/ingress-nginx/
+.. _Keycloak: https://www.keycloak.org/
 .. _Kopf: https://kopf.readthedocs.io/en/stable/
 .. _mypy: https://mypy.readthedocs.io/en/stable/
 .. _Phalanx: https://phalanx.lsst.io/

--- a/docs/user-guide/helm.rst
+++ b/docs/user-guide/helm.rst
@@ -199,6 +199,9 @@ CILogon has some additional options under ``config.cilogon`` that you may want t
 Generic OpenID Connect
 ----------------------
 
+Gafaelfawr should be able to support most OpenID Connect servers as sources of authentication.
+This support has primarily been tested with Keycloak_.
+
 .. code-block:: yaml
 
    config:

--- a/docs/user-guide/provider.rst
+++ b/docs/user-guide/provider.rst
@@ -20,14 +20,14 @@ CILogon
 If you will use CILogon as the authentication provider, you will need to register with CILogon to get a client ID and secret.
 
 Normally, CILogon is used in conjunction with COmanage, and Gafaelfawr should be registered as a OIDC client in the settings of the corresponding COmanage instance.
-For details on how to do this, see SQR-055_.
-
-.. _SQR-055: https://sqr-055.lsst.io/
+For details on how to do this, see :sqr:`055`.
 
 Other OpenID Connect provider
 -----------------------------
 
 Gafaelfawr supports client authentication using an arbitrary OpenID Connect provider, as long as the provider supports a ``response_type`` of ``code``, a ``grant_type`` of ``authorization_code``, accepts a ``client_secret`` for authentication, and returns tokens that contain a username and numeric UID.
+This support is primarily tested with Keycloak_.
+
 You will need the following information from the OpenID Connect provider:
 
 - Client ID that Gafaelfawr will use to authenticate


### PR DESCRIPTION
Note at the start of the documentation for generic OpenID Connect that this support has been primarily tested with Keycloak. Also mention it in the page about authentication providers.