### PR TITLE
DM-44136: Update Docker base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@
 #   - Runs as a non-root user.
 #   - Sets up the entrypoint and port.
 
-FROM python:3.12.2-slim-bullseye as base-image
+FROM python:3.12.3-slim-bookworm as base-image
 
 # Update system packages
 COPY scripts/install-base-packages.sh .


### PR DESCRIPTION
Update to Python 3.12.3 and switch base Debian images from bullseye to bookworm.