### PR TITLE
DM-44136: Stop importing symbols from _pytest

### DIFF
--- a/tests/handlers/api_tokens_test.py
+++ b/tests/handlers/api_tokens_test.py
@@ -8,7 +8,6 @@ from pathlib import Path
 from unittest.mock import ANY
 
 import pytest
-from _pytest.logging import LogCaptureFixture
 from httpx import AsyncClient
 from safir.datetime import current_datetime, format_datetime_for_logging
 from safir.testing.slack import MockSlackWebhook
@@ -31,7 +30,7 @@ from ..support.tokens import create_session_token
 
 @pytest.mark.asyncio
 async def test_create_delete_modify(
-    client: AsyncClient, factory: Factory, caplog: LogCaptureFixture
+    client: AsyncClient, factory: Factory, caplog: pytest.LogCaptureFixture
 ) -> None:
     user_info = TokenUserInfo(
         username="example",
@@ -934,7 +933,7 @@ async def test_create_admin(
     client: AsyncClient,
     config: Config,
     factory: Factory,
-    caplog: LogCaptureFixture,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test creating a token through the admin interface."""
     token_data = await create_session_token(factory, scopes=["exec:admin"])
@@ -1339,7 +1338,7 @@ async def test_create_admin_firestore(
 async def test_no_form_post(
     client: AsyncClient,
     factory: Factory,
-    caplog: LogCaptureFixture,
+    caplog: pytest.LogCaptureFixture,
     mock_slack: MockSlackWebhook,
 ) -> None:
     """Ensure that the token creation API does not support a form POST.
@@ -1387,7 +1386,7 @@ async def test_no_form_post(
 
 @pytest.mark.asyncio
 async def test_scope_modify(
-    client: AsyncClient, factory: Factory, caplog: LogCaptureFixture
+    client: AsyncClient, factory: Factory, caplog: pytest.LogCaptureFixture
 ) -> None:
     """Ensure modifying the scope updates Redis.
 

--- a/tests/handlers/auth_logging_test.py
+++ b/tests/handlers/auth_logging_test.py
@@ -6,7 +6,6 @@ import base64
 from unittest.mock import ANY
 
 import pytest
-from _pytest.logging import LogCaptureFixture
 from httpx import AsyncClient
 from safir.datetime import format_datetime_for_logging
 
@@ -20,7 +19,7 @@ from ..support.tokens import create_session_token
 
 @pytest.mark.asyncio
 async def test_success(
-    client: AsyncClient, factory: Factory, caplog: LogCaptureFixture
+    client: AsyncClient, factory: Factory, caplog: pytest.LogCaptureFixture
 ) -> None:
     token_data = await create_session_token(factory, scopes=["exec:admin"])
 
@@ -91,7 +90,7 @@ async def test_success(
 
 @pytest.mark.asyncio
 async def test_authorization_failed(
-    client: AsyncClient, factory: Factory, caplog: LogCaptureFixture
+    client: AsyncClient, factory: Factory, caplog: pytest.LogCaptureFixture
 ) -> None:
     token_data = await create_session_token(factory, scopes=["exec:admin"])
 
@@ -132,7 +131,7 @@ async def test_authorization_failed(
 
 @pytest.mark.asyncio
 async def test_original_url(
-    client: AsyncClient, factory: Factory, caplog: LogCaptureFixture
+    client: AsyncClient, factory: Factory, caplog: pytest.LogCaptureFixture
 ) -> None:
     token_data = await create_session_token(factory)
 
@@ -184,7 +183,7 @@ async def test_original_url(
 
 @pytest.mark.asyncio
 async def test_chained_x_forwarded(
-    client: AsyncClient, factory: Factory, caplog: LogCaptureFixture
+    client: AsyncClient, factory: Factory, caplog: pytest.LogCaptureFixture
 ) -> None:
     token_data = await create_session_token(factory)
 
@@ -226,7 +225,7 @@ async def test_chained_x_forwarded(
 
 @pytest.mark.asyncio
 async def test_invalid_token(
-    client: AsyncClient, caplog: LogCaptureFixture
+    client: AsyncClient, caplog: pytest.LogCaptureFixture
 ) -> None:
     caplog.clear()
     r = await client.get(
@@ -258,7 +257,7 @@ async def test_invalid_token(
 
 @pytest.mark.asyncio
 async def test_notebook(
-    client: AsyncClient, factory: Factory, caplog: LogCaptureFixture
+    client: AsyncClient, factory: Factory, caplog: pytest.LogCaptureFixture
 ) -> None:
     token_data = await create_session_token(
         factory, group_names=["admin"], scopes=["exec:admin", "read:all"]
@@ -324,7 +323,7 @@ async def test_notebook(
 
 @pytest.mark.asyncio
 async def test_internal(
-    client: AsyncClient, factory: Factory, caplog: LogCaptureFixture
+    client: AsyncClient, factory: Factory, caplog: pytest.LogCaptureFixture
 ) -> None:
     token_data = await create_session_token(
         factory, group_names=["admin"], scopes=["exec:admin", "read:all"]

--- a/tests/handlers/login_github_test.py
+++ b/tests/handlers/login_github_test.py
@@ -7,7 +7,6 @@ from urllib.parse import parse_qs, urlparse
 
 import pytest
 import respx
-from _pytest.logging import LogCaptureFixture
 from httpx import AsyncClient, Response
 from safir.testing.slack import MockSlackWebhook
 
@@ -99,7 +98,9 @@ async def simulate_github_login(
 
 @pytest.mark.asyncio
 async def test_login(
-    client: AsyncClient, respx_mock: respx.Router, caplog: LogCaptureFixture
+    client: AsyncClient,
+    respx_mock: respx.Router,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     user_info = GitHubUserInfo(
         name="GitHub User",

--- a/tests/handlers/login_oidc_errors_test.py
+++ b/tests/handlers/login_oidc_errors_test.py
@@ -8,7 +8,6 @@ from urllib.parse import parse_qs, urljoin, urlparse
 
 import pytest
 import respx
-from _pytest.logging import LogCaptureFixture
 from httpx import AsyncClient, ConnectError
 from safir.testing.slack import MockSlackWebhook
 
@@ -24,7 +23,7 @@ async def test_callback_error(
     tmp_path: Path,
     client: AsyncClient,
     respx_mock: respx.Router,
-    caplog: LogCaptureFixture,
+    caplog: pytest.LogCaptureFixture,
     mock_slack: MockSlackWebhook,
 ) -> None:
     """Test an error return from the OIDC token endpoint."""

--- a/tests/handlers/logout_test.py
+++ b/tests/handlers/logout_test.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import pytest
 import respx
-from _pytest.logging import LogCaptureFixture
 from httpx import AsyncClient
 from safir.testing.slack import MockSlackWebhook
 
@@ -25,7 +24,7 @@ async def test_logout(
     client: AsyncClient,
     config: Config,
     factory: Factory,
-    caplog: LogCaptureFixture,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     token_data = await create_session_token(factory, scopes=["read:all"])
     await set_session_cookie(client, token_data.token)
@@ -80,7 +79,7 @@ async def test_logout_with_url(client: AsyncClient, factory: Factory) -> None:
 
 @pytest.mark.asyncio
 async def test_logout_not_logged_in(
-    client: AsyncClient, config: Config, caplog: LogCaptureFixture
+    client: AsyncClient, config: Config, caplog: pytest.LogCaptureFixture
 ) -> None:
     caplog.clear()
     r = await client.get("/logout")
@@ -125,7 +124,7 @@ async def test_logout_github(
     client: AsyncClient,
     config: Config,
     respx_mock: respx.Router,
-    caplog: LogCaptureFixture,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     user_info = GitHubUserInfo(
         name="GitHub User",

--- a/tests/handlers/oidc_test.py
+++ b/tests/handlers/oidc_test.py
@@ -11,7 +11,6 @@ from unittest.mock import ANY
 from urllib.parse import parse_qs, urlencode, urlparse
 
 import pytest
-from _pytest.logging import LogCaptureFixture
 from httpx import AsyncClient
 from safir.datetime import current_datetime, format_datetime_for_logging
 from safir.testing.slack import MockSlackWebhook
@@ -133,7 +132,7 @@ async def test_login(
     tmp_path: Path,
     client: AsyncClient,
     factory: Factory,
-    caplog: LogCaptureFixture,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     redirect_uri = f"https://{TEST_HOSTNAME}:4444/foo?a=bar&b=baz"
     clients = [
@@ -286,7 +285,7 @@ async def test_login(
 
 @pytest.mark.asyncio
 async def test_unauthenticated(
-    tmp_path: Path, client: AsyncClient, caplog: LogCaptureFixture
+    tmp_path: Path, client: AsyncClient, caplog: pytest.LogCaptureFixture
 ) -> None:
     return_url = f"https://{TEST_HOSTNAME}:4444/foo?a=bar&b=baz"
     clients = [
@@ -335,7 +334,7 @@ async def test_login_errors(
     tmp_path: Path,
     client: AsyncClient,
     factory: Factory,
-    caplog: LogCaptureFixture,
+    caplog: pytest.LogCaptureFixture,
     mock_slack: MockSlackWebhook,
 ) -> None:
     clients = [
@@ -475,7 +474,7 @@ async def test_token_errors(
     tmp_path: Path,
     client: AsyncClient,
     factory: Factory,
-    caplog: LogCaptureFixture,
+    caplog: pytest.LogCaptureFixture,
     mock_slack: MockSlackWebhook,
 ) -> None:
     redirect_uri = f"https://{TEST_HOSTNAME}/app"
@@ -688,7 +687,7 @@ async def test_invalid(
     tmp_path: Path,
     client: AsyncClient,
     factory: Factory,
-    caplog: LogCaptureFixture,
+    caplog: pytest.LogCaptureFixture,
     mock_slack: MockSlackWebhook,
 ) -> None:
     redirect_uri = "https://example.com/"

--- a/tests/providers/oidc_verifier_test.py
+++ b/tests/providers/oidc_verifier_test.py
@@ -10,7 +10,6 @@ from urllib.parse import urljoin
 import jwt
 import pytest
 import respx
-from _pytest._code import ExceptionInfo
 from jwt.exceptions import InvalidIssuerError
 from safir.datetime import current_datetime
 
@@ -63,7 +62,7 @@ async def test_verify_token(
         "exp": int(exp.timestamp()),
     }
     token = encode_token(payload, TEST_KEYPAIR)
-    excinfo: ExceptionInfo[Exception]
+    excinfo: pytest.ExceptionInfo[Exception]
 
     # Missing iss.
     with pytest.raises(InvalidIssuerError) as excinfo:

--- a/tests/support/logging.py
+++ b/tests/support/logging.py
@@ -6,14 +6,14 @@ import json
 from datetime import UTC, datetime, timedelta
 from typing import Any
 
-from _pytest.logging import LogCaptureFixture
+import pytest
 from safir.datetime import current_datetime
 
 __all__ = ["parse_log"]
 
 
 def parse_log(
-    caplog: LogCaptureFixture, *, ignore_debug: bool = False
+    caplog: pytest.LogCaptureFixture, *, ignore_debug: bool = False
 ) -> list[dict[str, Any]]:
     """Parse the accumulated logs as JSON.
 


### PR DESCRIPTION
The necessary types for proper type-checking of tests are now exported from the top level of pytest. Remove the now-unneeded imports from _pytest, and refer to those types qualified with pytest, following pytest best practices.