### PR TITLE
DM-44136: Use Annotated for dependencies and handlers

### DIFF
--- a/src/gafaelfawr/dependencies/auth.py
+++ b/src/gafaelfawr/dependencies/auth.py
@@ -1,5 +1,6 @@
 """Authentication dependencies for FastAPI."""
 
+from typing import Annotated
 from urllib.parse import urlencode, urlparse
 
 from fastapi import Depends, Header, HTTPException, status
@@ -236,7 +237,9 @@ class AuthenticateRead(Authenticate):
     """
 
     async def __call__(
-        self, context: RequestContext = Depends(context_dependency)
+        self,
+        *,
+        context: Annotated[RequestContext, Depends(context_dependency)],
     ) -> TokenData:
         return await self.authenticate(context)
 
@@ -249,22 +252,26 @@ class AuthenticateWrite(Authenticate):
 
     async def __call__(
         self,
-        x_csrf_token: (str | None) = Header(
-            None,
-            title="CSRF token",
-            description=(
-                "Only required when authenticating with a cookie, such as via"
-                " the JavaScript UI."
+        *,
+        x_csrf_token: Annotated[
+            str | None,
+            Header(
+                title="CSRF token",
+                description=(
+                    "Only required when authenticating with a cookie, such as"
+                    " via the JavaScript UI."
+                ),
+                examples=["OmNdVTtKKuK_VuJsGFdrqg"],
             ),
-            examples=["OmNdVTtKKuK_VuJsGFdrqg"],
-        ),
-        context: RequestContext = Depends(context_dependency),
+        ] = None,
+        context: Annotated[RequestContext, Depends(context_dependency)],
     ) -> TokenData:
         return await self.authenticate(context, x_csrf_token)
 
 
 async def verified_oidc_token(
-    context: RequestContext = Depends(context_dependency),
+    *,
+    context: Annotated[RequestContext, Depends(context_dependency)],
 ) -> OIDCVerifiedToken:
     """Require that a request be authenticated with an OpenID Connect token.
 

--- a/src/gafaelfawr/dependencies/context.py
+++ b/src/gafaelfawr/dependencies/context.py
@@ -7,7 +7,7 @@ including from dependencies.
 """
 
 from dataclasses import dataclass
-from typing import Any
+from typing import Annotated, Any
 
 from fastapi import Depends, HTTPException, Request
 from safir.dependencies.db_session import db_session_dependency
@@ -91,9 +91,12 @@ class ContextDependency:
 
     async def __call__(
         self,
+        *,
         request: Request,
-        session: async_scoped_session = Depends(db_session_dependency),
-        logger: BoundLogger = Depends(logger_dependency),
+        session: Annotated[
+            async_scoped_session, Depends(db_session_dependency)
+        ],
+        logger: Annotated[BoundLogger, Depends(logger_dependency)],
     ) -> RequestContext:
         """Create a per-request context and return it."""
         if not self._config or not self._process_context:

--- a/src/gafaelfawr/dependencies/return_url.py
+++ b/src/gafaelfawr/dependencies/return_url.py
@@ -64,7 +64,7 @@ def _check_url(url: str, param: str, context: RequestContext) -> ParseResult:
 
 
 async def return_url(
-    context: Annotated[RequestContext, Depends(context_dependency)],
+    *,
     rd: Annotated[
         str | None,
         Query(
@@ -73,6 +73,7 @@ async def return_url(
             examples=["https://example.com/"],
         ),
     ] = None,
+    context: Annotated[RequestContext, Depends(context_dependency)],
 ) -> str | None:
     """Validate a return URL in an ``rd`` parameter.
 
@@ -94,7 +95,7 @@ async def return_url(
 
 
 async def return_url_with_header(
-    context: Annotated[RequestContext, Depends(context_dependency)],
+    *,
     rd: Annotated[
         str | None,
         Query(
@@ -114,6 +115,7 @@ async def return_url_with_header(
             examples=["https://example.com/"],
         ),
     ] = None,
+    context: Annotated[RequestContext, Depends(context_dependency)],
 ) -> str | None:
     """Validate a return URL in an ``rd`` parameter or header.
 
@@ -133,4 +135,4 @@ async def return_url_with_header(
     """
     if not rd and x_auth_request_redirect:
         rd = x_auth_request_redirect
-    return await return_url(context, rd)
+    return await return_url(context=context, rd=rd)

--- a/src/gafaelfawr/handlers/analyze.py
+++ b/src/gafaelfawr/handlers/analyze.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import json
-from typing import Any
+from typing import Annotated, Any
 
 from fastapi import APIRouter, Depends, Form
 from fastapi.responses import JSONResponse
@@ -97,8 +97,9 @@ def token_data_to_analysis(token_data: TokenData) -> dict[str, dict[str, Any]]:
     tags=["user"],
 )
 async def get_analyze(
-    token_data: TokenData = Depends(authenticate),
-    context: RequestContext = Depends(context_dependency),
+    *,
+    token_data: Annotated[TokenData, Depends(authenticate)],
+    context: Annotated[RequestContext, Depends(context_dependency)],
 ) -> dict[str, dict[str, Any]]:
     """Analyze a token from a web session."""
     return token_data_to_analysis(token_data)
@@ -120,13 +121,16 @@ async def get_analyze(
     tags=["user"],
 )
 async def post_analyze(
-    token_str: str = Form(
-        ...,
-        alias="token",
-        title="Token to analyze",
-        examples=["gt-db59fbkT5LrGHvhLMglNWw.G3NEmhWZr8JwO8AQ8sIWpQ"],
-    ),
-    context: RequestContext = Depends(context_dependency),
+    *,
+    token_str: Annotated[
+        str,
+        Form(
+            alias="token",
+            title="Token to analyze",
+            examples=["gt-db59fbkT5LrGHvhLMglNWw.G3NEmhWZr8JwO8AQ8sIWpQ"],
+        ),
+    ],
+    context: Annotated[RequestContext, Depends(context_dependency)],
 ) -> dict[str, dict[str, Any]]:
     """Analyze a token.
 

--- a/src/gafaelfawr/handlers/cadc.py
+++ b/src/gafaelfawr/handlers/cadc.py
@@ -7,6 +7,7 @@ currently CADC code requires ``sub`` be a UUID and we have other integrations
 that use ``sub`` as a username.
 """
 
+from typing import Annotated
 from uuid import uuid5
 
 from fastapi import APIRouter, Depends, HTTPException, status
@@ -56,8 +57,9 @@ authenticate_read = AuthenticateRead()
     tags=["oidc"],
 )
 async def get_userinfo(
-    auth_data: TokenData = Depends(authenticate_read),
-    context: RequestContext = Depends(context_dependency),
+    *,
+    auth_data: Annotated[TokenData, Depends(authenticate_read)],
+    context: Annotated[RequestContext, Depends(context_dependency)],
 ) -> CADCUserInfo:
     config = context.config
     if not config.cadc_base_uuid:

--- a/src/gafaelfawr/handlers/internal.py
+++ b/src/gafaelfawr/handlers/internal.py
@@ -1,5 +1,7 @@
 """Handlers for internal routes not exposed outside the cluster."""
 
+from typing import Annotated
+
 from fastapi import APIRouter, Depends
 from safir.metadata import Metadata, get_metadata
 from safir.slack.webhook import SlackRouteErrorHandler
@@ -38,7 +40,8 @@ async def get_index() -> Metadata:
     tags=["internal"],
 )
 async def get_health(
-    context: RequestContext = Depends(context_dependency),
+    *,
+    context: Annotated[RequestContext, Depends(context_dependency)],
 ) -> HealthCheck:
     health_check_service = context.factory.create_health_check_service()
     await health_check_service.check()

--- a/src/gafaelfawr/handlers/login.py
+++ b/src/gafaelfawr/handlers/login.py
@@ -3,6 +3,7 @@
 import base64
 import os
 from enum import Enum
+from typing import Annotated
 
 from fastapi import APIRouter, Depends, Query, status
 from fastapi.responses import RedirectResponse, Response
@@ -26,7 +27,7 @@ from ..templates import templates
 
 router = APIRouter(route_class=SlackRouteErrorHandler)
 
-__all__ = ["get_login"]
+__all__ = ["router"]
 
 
 class LoginError(Enum):
@@ -75,23 +76,30 @@ class LoginError(Enum):
     tags=["browser"],
 )
 async def get_login(
-    code: (str | None) = Query(
-        None,
-        title="Provider code",
-        description="Set by the authentication provider after authentication",
-        examples=["V2hrNqgM_eiIjXvV41RlMw"],
-    ),
-    state: (str | None) = Query(
-        None,
-        title="Authentication state",
-        description=(
-            "Set by the authentication provider after authentication to"
-            " protect against session fixation"
+    *,
+    code: Annotated[
+        str | None,
+        Query(
+            title="Provider code",
+            description=(
+                "Set by the authentication provider after authentication"
+            ),
+            examples=["V2hrNqgM_eiIjXvV41RlMw"],
         ),
-        examples=["wkC2bAP5VFpDioKc3JfaDA"],
-    ),
-    return_url: str | None = Depends(return_url_with_header),
-    context: RequestContext = Depends(context_dependency),
+    ] = None,
+    state: Annotated[
+        str | None,
+        Query(
+            title="Authentication state",
+            description=(
+                "Set by the authentication provider after authentication to"
+                " protect against session fixation"
+            ),
+            examples=["wkC2bAP5VFpDioKc3JfaDA"],
+        ),
+    ] = None,
+    return_url: Annotated[str | None, Depends(return_url_with_header)],
+    context: Annotated[RequestContext, Depends(context_dependency)],
 ) -> Response:
     """Handle an initial login or the return from a login provider.
 

--- a/src/gafaelfawr/handlers/logout.py
+++ b/src/gafaelfawr/handlers/logout.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Annotated
+
 from fastapi import APIRouter, Depends, status
 from fastapi.responses import RedirectResponse
 from safir.slack.webhook import SlackRouteErrorHandler
@@ -24,8 +26,9 @@ __all__ = ["get_logout"]
     tags=["browser"],
 )
 async def get_logout(
-    return_url: str | None = Depends(return_url),
-    context: RequestContext = Depends(context_dependency),
+    *,
+    return_url: Annotated[str | None, Depends(return_url)],
+    context: Annotated[RequestContext, Depends(context_dependency)],
 ) -> str:
     """Log out and redirect the user.
 

--- a/src/gafaelfawr/handlers/oidc.py
+++ b/src/gafaelfawr/handlers/oidc.py
@@ -60,6 +60,7 @@ authenticate_token = AuthenticateRead(require_bearer_token=True)
     tags=["oidc"],
 )
 async def get_login(
+    *,
     client_id: Annotated[
         str,
         Query(
@@ -78,8 +79,6 @@ async def get_login(
             examples=["https://example.com/"],
         ),
     ],
-    token_data: Annotated[TokenData, Depends(authenticate)],
-    context: Annotated[RequestContext, Depends(context_dependency)],
     response_type: Annotated[
         str | None,
         Query(
@@ -124,6 +123,8 @@ async def get_login(
             examples=["5Ndm2AFSZ6dN6Gt-Iu6lng"],
         ),
     ] = None,
+    token_data: Annotated[TokenData, Depends(authenticate)],
+    context: Annotated[RequestContext, Depends(context_dependency)],
 ) -> str:
     context.rebind_logger(return_uri=redirect_uri)
     oidc_service = context.factory.create_oidc_service()
@@ -202,7 +203,7 @@ def build_return_url(redirect_uri: str, **params: str | None) -> str:
     tags=["oidc"],
 )
 async def post_token(
-    response: Response,
+    *,
     grant_type: Annotated[
         str | None,
         Form(
@@ -243,7 +244,8 @@ async def post_token(
             examples=["https://example.com/"],
         ),
     ] = None,
-    context: RequestContext = Depends(context_dependency),
+    context: Annotated[RequestContext, Depends(context_dependency)],
+    response: Response,
 ) -> OIDCTokenReply | JSONResponse:
     oidc_service = context.factory.create_oidc_service()
     async with context.session.begin():
@@ -295,8 +297,9 @@ async def post_token(
     tags=["oidc"],
 )
 async def get_userinfo(
+    *,
     token_data: Annotated[TokenData, Depends(authenticate_token)],
-    context: RequestContext = Depends(context_dependency),
+    context: Annotated[RequestContext, Depends(context_dependency)],
 ) -> Mapping[str, Any]:
     if token_data.token_type != TokenType.oidc:
         msg = f"Token of type {token_data.token_type.value} not allowed"
@@ -320,7 +323,8 @@ async def get_userinfo(
     tags=["oidc"],
 )
 async def get_well_known_jwks(
-    context: RequestContext = Depends(context_dependency),
+    *,
+    context: Annotated[RequestContext, Depends(context_dependency)],
 ) -> JWKS:
     oidc_server = context.factory.create_oidc_service()
     return oidc_server.get_jwks()
@@ -340,7 +344,8 @@ async def get_well_known_jwks(
     tags=["oidc"],
 )
 async def get_well_known_openid(
-    context: RequestContext = Depends(context_dependency),
+    *,
+    context: Annotated[RequestContext, Depends(context_dependency)],
 ) -> OIDCConfig:
     oidc_server = context.factory.create_oidc_service()
     return oidc_server.get_openid_configuration()


### PR DESCRIPTION
Change the type annotations for all dependencies and handlers to use Annotated rather than putting the FastAPI magic functions in default values. Add * to force keyword arguments for these functions.