### PR TITLE
DM-44136: Move database test helper functions to module

### DIFF
--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -20,9 +20,9 @@ def parse_config(path: Path, *, fix_token: bool = False) -> None:
 
     Parameters
     ----------
-    path : `pathlib.Path`
+    path
         The path to the configuration file to test.
-    fix_token : `bool`, optional
+    fix_token
         Whether to fix an invalid ``bootstrap_token`` before checking the
         configuration file.  Some examples have intentionally invalid tokens.
     """

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -2,66 +2,24 @@
 
 from __future__ import annotations
 
-from pathlib import Path
-
 import pytest
 from asgi_lifespan import LifespanManager
 from safir.database import create_database_engine
 from safir.dependencies.db_session import db_session_dependency
-from sqlalchemy import text
-from sqlalchemy.exc import ProgrammingError
-from sqlalchemy.ext.asyncio import AsyncEngine
 
 from gafaelfawr.config import Config
 from gafaelfawr.exceptions import DatabaseSchemaError
-from gafaelfawr.factory import Factory
 from gafaelfawr.main import create_app
-from gafaelfawr.schema import Base
 
 from .support.constants import TEST_DATABASE_URL
-
-
-# Initialize the database from an old schema. This was the database schema
-# before Alembic was introduced, so it should run all migrations.
-async def create_old_database(config: Config, engine: AsyncEngine) -> None:
-    """Initialize the database from an old schema.
-
-    Used to test whether the application refuses to start if the schema is out
-    of date.
-
-    Parameters
-    ----------
-    config
-        Gafaelfawr configuration.
-    engine
-        Database engine.
-    """
-    old_schema = Path(__file__).parent / "data" / "schemas" / "9.6.1"
-
-    async with engine.begin() as conn:
-        await conn.run_sync(Base.metadata.drop_all)
-    async with Factory.standalone(config, engine) as factory:
-        async with factory.session.begin():
-            try:
-                sql = "DROP TABLE alembic_version"
-                await factory.session.execute(text(sql))
-            except ProgrammingError:
-                pass
-        async with factory.session.begin():
-            with old_schema.open() as f:
-                statement = ""
-                for line in f:
-                    if not line.startswith("--") and line.strip("\n"):
-                        statement += line.strip("\n")
-                    if statement.endswith(";"):
-                        await factory.session.execute(text(statement))
-                        statement = ""
+from .support.database import create_old_database, drop_database
 
 
 @pytest.mark.asyncio
 async def test_out_of_date_schema(config: Config) -> None:
     engine = create_database_engine(TEST_DATABASE_URL, None)
-    await create_old_database(config, engine)
+    await drop_database(engine)
+    await create_old_database(config, engine, "9.6.1")
 
     db_session_dependency.override_engine(engine)
     app = create_app()

--- a/tests/support/database.py
+++ b/tests/support/database.py
@@ -1,0 +1,80 @@
+"""Support code for testing database handling."""
+
+from __future__ import annotations
+
+import contextlib
+from pathlib import Path
+
+from sqlalchemy import text
+from sqlalchemy.exc import ProgrammingError
+from sqlalchemy.ext.asyncio import AsyncEngine
+
+from gafaelfawr.config import Config
+from gafaelfawr.factory import Factory
+from gafaelfawr.schema import Base
+
+__all__ = [
+    "clear_alembic_version",
+    "create_old_database",
+    "drop_database",
+]
+
+
+async def clear_alembic_version(engine: AsyncEngine) -> None:
+    """Clear the Alembic version from the database.
+
+    This is done when clearing the whole database or before stamping the
+    database to ensure that the database is in the expected state.
+
+    Parameters
+    ----------
+    engine
+        Engine to use for SQL calls.
+    """
+    async with engine.begin() as conn:
+        with contextlib.suppress(ProgrammingError):
+            await conn.execute(text("DROP TABLE alembic_version"))
+
+
+async def create_old_database(
+    config: Config, engine: AsyncEngine, version: str
+) -> None:
+    """Initialize the database from an old schema.
+
+    Used to test whether the application refuses to start if the schema is out
+    of date. This was the database schema # before Alembic was introduced, so
+    it should run all migrations.
+
+    Parameters
+    ----------
+    config
+        Gafaelfawr configuration.
+    engine
+        Database engine.
+    version
+        Version of schema to load.
+    """
+    old_schema = Path(__file__).parent.parent / "data" / "schemas" / version
+    async with Factory.standalone(config, engine) as factory:
+        async with factory.session.begin():
+            with old_schema.open() as f:
+                statement = ""
+                for line in f:
+                    if not line.startswith("--") and line.strip("\n"):
+                        statement += line.strip("\n")
+                    if statement.endswith(";"):
+                        await factory.session.execute(text(statement))
+                        statement = ""
+
+
+async def drop_database(engine: AsyncEngine) -> None:
+    """Drop all tables from the database.
+
+    Parameters
+    ----------
+    engine
+        Engine to use to issue the SQL commands.
+    """
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.drop_all)
+    await clear_alembic_version(engine)


### PR DESCRIPTION
Lift various database helper functions that were scattered around into a module and call those functions to avoid some code duplication.