### PR TITLE
DM-44269: Fix configuration parsing of empty quota

### DIFF
--- a/changelog.d/20240520_165608_rra_DM_44269.md
+++ b/changelog.d/20240520_165608_rra_DM_44269.md
@@ -1,0 +1,3 @@
+### Bug fixes
+
+- Correctly parse the configuration if `quota` is set to an empty object.

--- a/src/gafaelfawr/config.py
+++ b/src/gafaelfawr/config.py
@@ -1015,6 +1015,7 @@ class Config(EnvFirstSettings):
             ("ldap", "url"),
             ("firestore", "project"),
             ("oidcServer", "enabled"),
+            ("quota", "default"),
         ):
             if data.get(key) is not None and not data[key].get(needed):
                 del data[key]

--- a/tests/data/config/github.yaml
+++ b/tests/data/config/github.yaml
@@ -42,3 +42,4 @@ ldap:
 firestore: {}
 oidcServer:
   keyId: "gafaelfawr"
+quota: {}


### PR DESCRIPTION
The default config.quota setting is an empty dictionary, which wasn't being parsed correctly. Add it to the list of configurations to trim if it's not set.