### PR TITLE
DM-44269: Cross-check groupMapping and knownScopes

### DIFF
--- a/changelog.d/20240521_074906_rra_DM_44269.md
+++ b/changelog.d/20240521_074906_rra_DM_44269.md
@@ -1,0 +1,3 @@
+### Bug fixes
+
+- Reject configuration files that assign scopes in `groupMapping` but do not define those scopes in `knownScopes`.

--- a/src/gafaelfawr/config.py
+++ b/src/gafaelfawr/config.py
@@ -1022,6 +1022,15 @@ class Config(EnvFirstSettings):
         return data
 
     @model_validator(mode="after")
+    def _validate_scopes(self) -> Self:
+        """Ensure all assigned scopes are listed in ``known_scopes``."""
+        for scope in self.group_mapping:
+            if scope not in self.known_scopes:
+                msg = f"Scope {scope} assigned but not in knownScopes"
+                raise ValueError(msg)
+        return self
+
+    @model_validator(mode="after")
     def _validate_userinfo(self) -> Self:
         """Ensure user information sources are configured properly."""
         # Convert CILogon configuration to OpenID Connect configuration.

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -46,44 +46,50 @@ def test_config_alembic(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 def test_config_no_provider() -> None:
-    with pytest.raises(ValidationError):
+    with pytest.raises(ValidationError, match="No authentication provider"):
         parse_config(config_path("no-provider"))
 
 
-def test_config_both_providers() -> None:
-    with pytest.raises(ValidationError):
+def test_config_both_providers(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("GAFAELFAWR_OIDC_CLIENT_SECRET", "oidc-secret")
+    with pytest.raises(ValidationError, match=r"Only one of .* may be used"):
         parse_config(config_path("both-providers"))
 
 
 def test_config_invalid_admin() -> None:
-    with pytest.raises(ValidationError):
+    with pytest.raises(ValidationError, match="invalid username"):
         parse_config(config_path("bad-admin"))
 
 
 def test_config_invalid_log_level() -> None:
-    with pytest.raises(ValidationError):
+    with pytest.raises(ValidationError, match="logLevel"):
         parse_config(config_path("bad-log-level"))
 
 
 def test_config_invalid_scope() -> None:
-    with pytest.raises(ValidationError):
+    with pytest.raises(ValidationError, match="invalid scope"):
         parse_config(config_path("bad-scope"))
 
 
 def test_config_missing_scope() -> None:
-    with pytest.raises(ValidationError):
+    with pytest.raises(ValidationError, match=r"required scope .* missing"):
         parse_config(config_path("missing-scope"))
 
 
 def test_config_invalid_token(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("GAFAELFAWR_BOOTSTRAP_TOKEN", "bad-token")
-    with pytest.raises(ValidationError):
+    with pytest.raises(ValidationError, match="Token does not start with gt-"):
         parse_config(config_path("github"))
 
 
 def test_config_bad_groups() -> None:
-    with pytest.raises(ValidationError):
+    with pytest.raises(ValidationError, match="Input should be a valid list"):
         parse_config(config_path("bad-groups"))
+
+
+def test_config_scope_mismatch() -> None:
+    with pytest.raises(ValidationError, match=r"Scope .* assigned but not in"):
+        parse_config(config_path("scope-mismatch"))
 
 
 def test_config_cilogon(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/data/config/scope-mismatch.yaml
+++ b/tests/data/config/scope-mismatch.yaml
@@ -1,0 +1,15 @@
+# Bad configuration file with assigned scopes not in knownScopes.
+
+realm: "testing"
+initialAdmins: ["admin"]
+afterLogoutUrl: "https://example.com/landing"
+groupMapping:
+  "exec:admin": ["admin"]
+  "exec:test": ["test"]
+  "read:all": ["foo", "admin", "org-a-team"]
+knownScopes:
+  "admin:token": "Can create and modify tokens for any user"
+  "exec:admin": "Administrator"
+  "user:token": "Can create and modify user tokens"
+github:
+  clientId: "some-github-client-id"


### PR DESCRIPTION
Reject configuration files that assign scopes in groupMapping but do not define those scopes in knownScopes. Improve the configuration tests to check for a specific validation error, ensuring the tests don't accidentally fail due to some other configuration issue.