### PR TITLE
DM-44468: Add configuration for NGINX caching

### DIFF
--- a/changelog.d/20240521_162006_rra_DM_44468.md
+++ b/changelog.d/20240521_162006_rra_DM_44468.md
@@ -1,0 +1,3 @@
+### New features
+
+- Add new `authCacheDuration` setting to the `GafaelfawrIngress` Kubernetes resource, which tells Gafaelfawr to configure NGINX to cache a Gafaelfawr response for the specified length of time. The cache is invalidated if the `Cookie` or `Authorization` HTTP headers change.

--- a/crds/ingress.yaml
+++ b/crds/ingress.yaml
@@ -59,10 +59,13 @@ spec:
               required:
                 - baseUrl
               properties:
-                baseUrl:
+                authCacheDuration:
                   type: string
-                  description: "Base URL for Gafaelfawr APIs."
-                  pattern: "^https://[a-z.-]+"
+                  description: >-
+                    The length of time for which the Gafaelfawr authorization
+                    results should be cached by NGINX. The cache is
+                    invalidated if the `Cookie` or `Authorization` HTTP
+                    headers change. Must be a valid NGINX duration string.
                 authType:
                   type: string
                   enum:
@@ -72,6 +75,10 @@ spec:
                     Controls the authentication type in the challenge
                     returned in the `WWW-Authenticate` header if the user
                     is not authenticated. By default, this is `bearer`.
+                baseUrl:
+                  type: string
+                  description: "Base URL for Gafaelfawr APIs."
+                  pattern: "^https://[a-z.-]+"
                 delegate:
                   type: object
                   description: >-

--- a/docs/user-guide/gafaelfawringress.rst
+++ b/docs/user-guide/gafaelfawringress.rst
@@ -196,6 +196,26 @@ The same token will also still be passed in the ``X-Auth-Request-Token`` header.
 
 If this configuration option is set, the incoming ``Authorization`` header will be entirely replaced by one containing only the delegated token, unlike Gafaelfawr's normal behavior of preserving any incoming ``Authorization`` header that doesn't include a Gafaelfawr token.
 
+Caching
+=======
+
+By default, Gafaelfawr is consulted for every HTTP request handled by the NGINX ingress.
+
+For lower-volume API services, this is normally desirable, but for interactive web sites that may load large numbers of supporting resources or make a large number of small HTTP requests, this can cause unnecessary load on NGINX and Gafaelfawr.
+In those cases, you may wish to trade some security and predictability for performance by telling NGINX to cache the Gafaelfawr response for a short period of time.
+
+You can do this with the ``authCacheDuration`` setting:
+
+.. code-block:: yaml
+
+   config:
+     authCacheDuration: 5m
+
+The value must be an `NGINX time interval <https://nginx.org/en/docs/syntax.html>`__.
+``5m`` for five minutes represents a reasonable tradeoff between respecting token invalidation and reducing the NGINX and Gafaelfawr load.
+
+The cache is automatically invalidated if the ``Cookie`` or ``Authorization`` HTTP headers change.
+
 Per-user ingresses
 ==================
 

--- a/src/gafaelfawr/models/kubernetes.py
+++ b/src/gafaelfawr/models/kubernetes.py
@@ -266,11 +266,14 @@ class GafaelfawrIngressScopesAnonymous(GafaelfawrIngressScopesBase):
 class GafaelfawrIngressConfig(BaseModel):
     """Configuration settings for an ingress using Gafaelfawr for auth."""
 
-    base_url: str
-    """The base URL for Gafaelfawr URLs in Ingress annotations."""
+    auth_cache_duration: str | None = None
+    """How long NGINX should cache the Gafaelfawr authorization response."""
 
     auth_type: AuthType | None = None
     """Auth type of challenge for 401 responses."""
+
+    base_url: str
+    """The base URL for Gafaelfawr URLs in Ingress annotations."""
 
     delegate: GafaelfawrIngressDelegate | None = None
     """Details of the requested delegated token, if any."""
@@ -309,6 +312,7 @@ class GafaelfawrIngressConfig(BaseModel):
 
         if self.scopes and self.scopes.is_anonymous():
             fields = (
+                "auth_cache_duration",
                 "auth_type",
                 "delegate",
                 "login_redirect",

--- a/src/gafaelfawr/services/kubernetes.py
+++ b/src/gafaelfawr/services/kubernetes.py
@@ -119,6 +119,13 @@ class KubernetesIngressService:
             "nginx.ingress.kubernetes.io/auth-url": auth_url,
             snippet_key: snippet,
         }
+        if ingress.config.auth_cache_duration:
+            annotations["nginx.ingress.kubernetes.io/auth-cache-key"] = (
+                "$http_cookie$http_authorization"
+            )
+            annotations["nginx.ingress.kubernetes.io/auth-cache-duration"] = (
+                f"200 202 401 {ingress.config.auth_cache_duration}"
+            )
         if ingress.config.login_redirect:
             url = ingress.config.base_url.rstrip("/") + "/login"
             annotations["nginx.ingress.kubernetes.io/auth-signin"] = url

--- a/tests/data/kubernetes/input/ingresses.yaml
+++ b/tests/data/kubernetes/input/ingresses.yaml
@@ -32,6 +32,7 @@ config:
   baseUrl: "https://foo.example.com"
   scopes:
     any: ["read:all"]
+  authCacheDuration: 5m
   loginRedirect: true
   replace403: true
   delegate:

--- a/tests/data/kubernetes/output/ingresses.yaml
+++ b/tests/data/kubernetes/output/ingresses.yaml
@@ -43,7 +43,9 @@ metadata:
   namespace: {namespace}
   annotations:
     another.annotation.example.com: bar
-    nginx.ingress.kubernetes.io/auth-method: GET
+    nginx.ingress.kubernetes.io/auth-cache-key: "$http_cookie$http_authorization"
+    nginx.ingress.kubernetes.io/auth-cache-duration: "200 202 401 5m"
+    nginx.ingress.kubernetes.io/auth-method: "GET"
     nginx.ingress.kubernetes.io/auth-response-headers: "Authorization,Cookie,X-Auth-Request-Email,X-Auth-Request-Token,X-Auth-Request-User"
     nginx.ingress.kubernetes.io/auth-signin: "https://foo.example.com/login"
     nginx.ingress.kubernetes.io/auth-url: "https://foo.example.com/auth?scope=read%3Aall&satisfy=any&notebook=true&minimum_lifetime=600"


### PR DESCRIPTION
Add an authCacheDuration configuration option to GafaelfawrIngress, which tells Gafaelfawr to set the NGINX annotations that enable caching of the Gafaelfawr response for the specified length of time. The cache is automatically invalidated if the Cookie or Authorization HTTP headers change.