### PR TITLE
DM-44490: Close async database sessions in the operator

### DIFF
--- a/changelog.d/20240522_152758_rra_DM_44490.md
+++ b/changelog.d/20240522_152758_rra_DM_44490.md
@@ -1,0 +1,3 @@
+### Bug fixes
+
+- Close database sessions after each execution of a Kopf Kubernetes operator. Previous versions of Gafaelfawr leaked sessions until the Kubernetes operator restarted.

--- a/src/gafaelfawr/operator/health.py
+++ b/src/gafaelfawr/operator/health.py
@@ -28,4 +28,5 @@ async def get_health(memo: kopf.Memo, **_: Any) -> dict[str, Any]:
 
     health_check_service = factory.create_health_check_service()
     await health_check_service.check(check_user_info=False)
+    await factory.session.remove()
     return HealthCheck(status=HealthStatus.HEALTHY).model_dump()

--- a/src/gafaelfawr/operator/tokens.py
+++ b/src/gafaelfawr/operator/tokens.py
@@ -10,6 +10,7 @@ from pydantic import ValidationError
 
 from ..constants import KUBERNETES_TIMER_DELAY, KUBERNETES_TOKEN_INTERVAL
 from ..exceptions import KubernetesObjectError
+from ..factory import Factory
 from ..models.kubernetes import GafaelfawrServiceToken
 from ..services.kubernetes import KubernetesTokenService
 
@@ -26,6 +27,7 @@ async def _update_token(
     memo: kopf.Memo,
 ) -> dict[str, int | str] | None:
     """Do the work of updating the token, shared by `create` and `periodic`."""
+    factory: Factory = memo.factory
     token_service: KubernetesTokenService = memo.token_service
 
     # These cases are probably not possible given how the handlers are
@@ -43,6 +45,7 @@ async def _update_token(
 
     # Update the corresponding Secret and return the new status information.
     status = await token_service.update(name, namespace, service_token)
+    await factory.session.remove()
     return status.to_dict() if status else None
 
 


### PR DESCRIPTION
Explicitly close async database sessions in the health check and token portions of the Kubernetes operator. (The ingress handler doesn't use the database.) Even with an async_scoped_session, the database session has to be explicitly removed or it will leak and eventually force the operator to crash and restart.