### PR TITLE
DM-44540: Fix handling of duplicate admins

### DIFF
--- a/changelog.d/20240524_114021_rra_DM_44540.md
+++ b/changelog.d/20240524_114021_rra_DM_44540.md
@@ -1,0 +1,3 @@
+### Bug fixes
+
+- Detect when someone attempts to mark as admin a username that is already an admin and return a 409 error instead of raising an uncaught exception.

--- a/src/gafaelfawr/exceptions.py
+++ b/src/gafaelfawr/exceptions.py
@@ -13,6 +13,7 @@ from safir.slack.blockkit import SlackException, SlackWebException
 
 __all__ = [
     "DatabaseSchemaError",
+    "DuplicateAdminError",
     "DuplicateTokenNameError",
     "ExternalUserInfoError",
     "FetchKeysError",
@@ -69,6 +70,16 @@ class InputValidationError(ClientRequestError, kopf.PermanentError):
     This is a thin wrapper around `~safir.fastapi.ClientRequestError` to add
     inheritance from `kopf.PermanentError` for the Kubernetes operator.
     """
+
+
+class DuplicateAdminError(InputValidationError):
+    """The user attempted to add an admin who already existed."""
+
+    error = "duplicate_admin"
+    status_code = status.HTTP_409_CONFLICT
+
+    def __init__(self, message: str) -> None:
+        super().__init__(message, ErrorLocation.body, ["username"])
 
 
 class DuplicateTokenNameError(InputValidationError):

--- a/src/gafaelfawr/services/admin.py
+++ b/src/gafaelfawr/services/admin.py
@@ -7,7 +7,7 @@ from collections.abc import Iterable
 from safir.datetime import current_datetime
 from structlog.stdlib import BoundLogger
 
-from ..exceptions import PermissionDeniedError
+from ..exceptions import DuplicateAdminError, PermissionDeniedError
 from ..models.admin import Admin
 from ..models.history import AdminChange, AdminHistoryEntry
 from ..storage.admin import AdminStore
@@ -55,11 +55,15 @@ class AdminService:
 
         Raises
         ------
+        DuplicateAdminError
+            Raised if the specified user is already an admin.
         PermissionDeniedError
-            If the actor is not an admin.
+            Raised if the actor is not an admin.
         """
         if not await self.is_admin(actor) and actor != "<bootstrap>":
             raise PermissionDeniedError(f"{actor} is not an admin")
+        if await self.is_admin(username):
+            raise DuplicateAdminError(f"{username} is already an admin")
         admin = Admin(username=username)
         history_entry = AdminHistoryEntry(
             username=username,

--- a/tests/handlers/api_admins_test.py
+++ b/tests/handlers/api_admins_test.py
@@ -58,6 +58,7 @@ async def test_admins(
 
 @pytest.mark.asyncio
 async def test_add_delete(client: AsyncClient, factory: Factory) -> None:
+    # Adding or deleting without authentication should fail.
     r = await client.post(
         "/auth/api/v1/admins", json={"username": "some-user"}
     )
@@ -65,6 +66,7 @@ async def test_add_delete(client: AsyncClient, factory: Factory) -> None:
     r = await client.delete("/auth/api/v1/admins/admin")
     assert r.status_code == 401
 
+    # Adding or deleting without the appropriate scopes should fail.
     token_data = await create_session_token(factory, username="admin")
     csrf = await set_session_cookie(client, token_data.token)
     r = await client.post(
@@ -86,6 +88,8 @@ async def test_add_delete(client: AsyncClient, factory: Factory) -> None:
         "type": "permission_denied",
     }
 
+    # Adding without the appropriate CSRF token should fail, but with a CSRF
+    # token should succeed.
     token_data = await create_session_token(
         factory, username="admin", scopes=["admin:token"]
     )
@@ -104,6 +108,18 @@ async def test_add_delete(client: AsyncClient, factory: Factory) -> None:
     r = await client.get("/auth/api/v1/admins")
     assert r.status_code == 200
     assert r.json() == [{"username": "admin"}, {"username": "new-admin"}]
+
+    # Add the same user again. This should result in a reasonable failure and
+    # not an internal server error.
+    r = await client.post(
+        "/auth/api/v1/admins",
+        headers={"X-CSRF-Token": csrf},
+        json={"username": "new-admin"},
+    )
+    assert r.status_code == 409
+
+    # Deleting the user should fail without a CSRF code and should succeed
+    # with one.
     r = await client.delete("/auth/api/v1/admins/admin")
     assert r.status_code == 403
     assert r.json()["detail"][0]["type"] == "invalid_csrf"


### PR DESCRIPTION
When someone uses the API to mark as admin a username that is already an admin, catch the error and return a 409 error code instead of raising an uncaught exception.