### PR TITLE
DM-44540: Fix HTTP error code for duplicate token names

### DIFF
--- a/changelog.d/20240524_115108_rra_DM_44540.md
+++ b/changelog.d/20240524_115108_rra_DM_44540.md
@@ -1,0 +1,3 @@
+### Bug fixes
+
+- Return a more-correct 409 HTTP error code, instead of 422, when a user attempts to use a duplicate token name.

--- a/src/gafaelfawr/exceptions.py
+++ b/src/gafaelfawr/exceptions.py
@@ -86,6 +86,7 @@ class DuplicateTokenNameError(InputValidationError):
     """The user tried to reuse the name of a token."""
 
     error = "duplicate_token_name"
+    status_code = status.HTTP_409_CONFLICT
 
     def __init__(self, message: str) -> None:
         super().__init__(message, ErrorLocation.body, ["token_name"])

--- a/tests/handlers/api_tokens_test.py
+++ b/tests/handlers/api_tokens_test.py
@@ -802,7 +802,7 @@ async def test_duplicate_token_name(
         headers={"X-CSRF-Token": csrf},
         json={"token_name": "some token"},
     )
-    assert r.status_code == 422
+    assert r.status_code == 409
     assert r.json()["detail"][0]["type"] == "duplicate_token_name"
 
     # Create a token with a different name and then try to modify the name to
@@ -819,7 +819,7 @@ async def test_duplicate_token_name(
         headers={"X-CSRF-Token": csrf},
         json={"token_name": "some token"},
     )
-    assert r.status_code == 422
+    assert r.status_code == 409
     assert r.json()["detail"][0]["type"] == "duplicate_token_name"
 
     # None of these errors should have resulted in Slack alerts.
@@ -1141,7 +1141,7 @@ async def test_create_admin(
             "token_name": "some token",
         },
     )
-    assert r.status_code == 422
+    assert r.status_code == 409
     assert r.json()["detail"][0]["type"] == "duplicate_token_name"
 
     # Check handling of an invalid username.


### PR DESCRIPTION
Return the more-correct 409 Conflict HTTP error code when a user attempts to duplicate a token name instead of the generic 422 input validation error.