### PR TITLE
DM-44541: Respect enrollmentUrl for CILogon

### DIFF
--- a/changelog.d/20240524_120600_rra_DM_44541.md
+++ b/changelog.d/20240524_120600_rra_DM_44541.md
@@ -1,0 +1,3 @@
+### Bug fixes
+
+- Respect the enrollmentUrl configuration setting when CILogon is the authentication provider, fixing a problem introduced in the 11.0.0 release.

--- a/src/gafaelfawr/config.py
+++ b/src/gafaelfawr/config.py
@@ -332,6 +332,7 @@ class CILogonConfig(EnvFirstSettings):
             audience=self.client_id,
             client_id=self.client_id,
             client_secret=self.client_secret,
+            enrollment_url=self.enrollment_url,
             login_url=f"{base_url}/authorize",
             login_params=self.login_params,
             token_url=f"{base_url}/oauth2/token",

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -118,6 +118,7 @@ def test_config_cilogon_test(monkeypatch: pytest.MonkeyPatch) -> None:
         client_id="some-cilogon-client-id",
         client_secret=SecretStr("some-secret"),
         audience="some-cilogon-client-id",
+        enrollment_url="https://id.example.com/some-enrollment",
         login_url="https://test.cilogon.org/authorize",
         login_params={},
         token_url="https://test.cilogon.org/oauth2/token",

--- a/tests/data/config/cilogon-test.yaml
+++ b/tests/data/config/cilogon-test.yaml
@@ -19,6 +19,7 @@ ldap:
   userBaseDn: "ou=people,dc=example,dc=com"
 cilogon:
   clientId: "some-cilogon-client-id"
+  enrollmentUrl: "https://id.example.com/some-enrollment"
   test: true
 
 # Ensure that the configuration parser correctly discards empty or partial


### PR DESCRIPTION
The configuration refactoring in Gafaelfawr 11.0.0 accidentally discarded the enrollmentUrl setting for CILogon rather than copying it into the generated OpenID Connect provider configuration. Fix this and add a test.