### PR TITLE
DM-44541: Remove tokens from Redis if SQL write fails

### DIFF
--- a/changelog.d/20240524_124119_rra_DM_44541.md
+++ b/changelog.d/20240524_124119_rra_DM_44541.md
@@ -1,0 +1,3 @@
+### Bug fixes
+
+- When creating a new token, try to remove it from Redis if the SQL write fails. This will hopefully reduce the number of orphaned tokens created during SQL server or proxy restarts.

--- a/src/gafaelfawr/services/token.py
+++ b/src/gafaelfawr/services/token.py
@@ -217,8 +217,12 @@ class TokenService:
         )
 
         await self._token_redis_store.store_data(data)
-        await self._token_db_store.add(data)
-        await self._token_change_store.add(history_entry)
+        try:
+            await self._token_db_store.add(data)
+            await self._token_change_store.add(history_entry)
+        except Exception:
+            await self._token_redis_store.delete(data.token.key)
+            raise
 
         self._logger.info(
             "Successfully authenticated user %s",
@@ -287,8 +291,12 @@ class TokenService:
 
         # Store the new token in Redis and the database.
         await self._token_redis_store.store_data(data)
-        await self._token_db_store.add(data, parent=auth_data.token.key)
-        await self._token_change_store.add(history_entry)
+        try:
+            await self._token_db_store.add(data, parent=auth_data.token.key)
+            await self._token_change_store.add(history_entry)
+        except Exception:
+            await self._token_redis_store.delete(data.token.key)
+            raise
 
         # Log the token creation and return it.
         self._logger.info(
@@ -388,8 +396,12 @@ class TokenService:
         )
 
         await self._token_redis_store.store_data(data)
-        await self._token_db_store.add(data, token_name=token_name)
-        await self._token_change_store.add(history_entry)
+        try:
+            await self._token_db_store.add(data, token_name=token_name)
+            await self._token_change_store.add(history_entry)
+        except Exception:
+            await self._token_redis_store.delete(data.token.key)
+            raise
 
         self._logger.info(
             "Created new user token",
@@ -480,8 +492,12 @@ class TokenService:
         )
 
         await self._token_redis_store.store_data(data)
-        await self._token_db_store.add(data, token_name=request.token_name)
-        await self._token_change_store.add(history_entry)
+        try:
+            await self._token_db_store.add(data, token_name=request.token_name)
+            await self._token_change_store.add(history_entry)
+        except Exception:
+            await self._token_redis_store.delete(data.token.key)
+            raise
 
         if data.token_type == TokenType.user:
             self._logger.info(

--- a/src/gafaelfawr/services/token_cache.py
+++ b/src/gafaelfawr/services/token_cache.py
@@ -262,10 +262,14 @@ class TokenCacheService:
         )
 
         await self._token_redis_store.store_data(data)
-        await self._token_db_store.add(
-            data, service=service, parent=token_data.token.key
-        )
-        await self._token_change_store.add(history_entry)
+        try:
+            await self._token_db_store.add(
+                data, service=service, parent=token_data.token.key
+            )
+            await self._token_change_store.add(history_entry)
+        except Exception:
+            await self._token_redis_store.delete(data.token.key)
+            raise
 
         self._logger.info(
             "Created new internal token",
@@ -346,8 +350,12 @@ class TokenCacheService:
         )
 
         await self._token_redis_store.store_data(data)
-        await self._token_db_store.add(data, parent=token_data.token.key)
-        await self._token_change_store.add(history_entry)
+        try:
+            await self._token_db_store.add(data, parent=token_data.token.key)
+            await self._token_change_store.add(history_entry)
+        except Exception:
+            await self._token_redis_store.delete(data.token.key)
+            raise
 
         # Cache the token and return it.
         self._logger.info(


### PR DESCRIPTION
All token creation paths already created the token in Redis first and then added an entry to SQL, but if the SQL write failed for whatever reason, the Gafaelfawr call would fail but the token would be left behind in Redis. Instead, run the SQL code in a try/except block and try to remove the newly-created Redis key if the SQL write failed. This will hopefully reduce the number of orphaned tokens created during database failures.