### PR TITLE
DM-45518: Add support for OpenTelemetry metrics

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,12 +38,9 @@ ui:
 .PHONY: update
 update: update-deps init
 
-# The dependencies need --allow-unsafe because kubernetes-asyncio and
-# (transitively) pre-commit depends on setuptools, which is normally not
-# allowed to appear in a hashed dependency file.
 .PHONY: update-deps
 update-deps:
-	pip install --upgrade uv
+	pip install --upgrade pip uv
 	uv pip install --upgrade pre-commit
 	pre-commit autoupdate
 	uv pip compile --upgrade --generate-hashes			\

--- a/changelog.d/20240814_105528_rra_DM_45518.md
+++ b/changelog.d/20240814_105528_rra_DM_45518.md
@@ -1,0 +1,7 @@
+### New features
+
+- Add support for exporting metrics to an OpenTelemetry collector. The initial set of metrics is limited to login metrics, token delegation, and counts of active sessions and user tokens.
+
+### Bug fixes
+
+- Reset login state after an error so that any subsequent authentication attempt will generate a new, random state parameter.

--- a/docs/_rst_epilog.rst
+++ b/docs/_rst_epilog.rst
@@ -3,6 +3,7 @@
 .. _Keycloak: https://www.keycloak.org/
 .. _Kopf: https://kopf.readthedocs.io/en/stable/
 .. _mypy: https://mypy.readthedocs.io/en/stable/
+.. _OpenTelemetry: https://opentelemetry.io/
 .. _Phalanx: https://phalanx.lsst.io/
 .. _pre-commit: https://pre-commit.com
 .. _pytest: https://docs.pytest.org/en/latest/

--- a/docs/dev/internals.rst
+++ b/docs/dev/internals.rst
@@ -38,6 +38,9 @@ Python internal API
 .. automodapi:: gafaelfawr.keypair
    :include-all-objects:
 
+.. automodapi:: gafaelfawr.metrics
+   :include-all-objects:
+
 .. automodapi:: gafaelfawr.middleware.state
    :include-all-objects:
 

--- a/docs/documenteer.toml
+++ b/docs/documenteer.toml
@@ -41,6 +41,7 @@ nitpick_ignore = [
     ["py:class", "pydantic.networks.IPvAnyNetwork"],
     ["py:class", "pydantic.types.SecretStr"],
     ["py:class", "pydantic.utils.Representation"],
+    ["py:class", "pydantic_core._pydantic_core.Url"],
     ["py:class", "pydantic_core._pydantic_core.ValidationError"],
     ["py:class", "pydantic_settings.main.BaseSettings"],
     ["py:class", "pydantic_settings.sources.CliSettingsSource"],
@@ -66,15 +67,16 @@ python_api_dir = "dev/internals"
 rst_epilog_file = "_rst_epilog.rst"
 
 [sphinx.intersphinx.projects]
-bonsai = "https://bonsai.readthedocs.io/en/latest/"
-cryptography = "https://cryptography.io/en/latest/"
-jwt = "https://pyjwt.readthedocs.io/en/latest/"
-kopf = "https://kopf.readthedocs.io/en/stable/"
-python = "https://docs.python.org/3/"
-redis = "https://redis-py.readthedocs.io/en/stable/"
-safir = "https://safir.lsst.io/"
-sqlalchemy = "https://docs.sqlalchemy.org/en/latest/"
-structlog = "https://www.structlog.org/en/stable/"
+bonsai = "https://bonsai.readthedocs.io/en/latest"
+cryptography = "https://cryptography.io/en/latest"
+jwt = "https://pyjwt.readthedocs.io/en/latest"
+kopf = "https://kopf.readthedocs.io/en/stable"
+opentelemetry = "https://opentelemetry-python.readthedocs.io/en/latest"
+python = "https://docs.python.org/3"
+redis = "https://redis-py.readthedocs.io/en/stable"
+safir = "https://safir.lsst.io"
+sqlalchemy = "https://docs.sqlalchemy.org/en/latest"
+structlog = "https://www.structlog.org/en/stable"
 
 [sphinx.linkcheck]
 ignore = [

--- a/docs/user-guide/helm.rst
+++ b/docs/user-guide/helm.rst
@@ -636,6 +636,23 @@ Set this with ``config.proxies``:
 If not set, defaults to the `RFC 1918 private address spaces <https://datatracker.ietf.org/doc/html/rfc1918>`__.
 See :ref:`client-ips` for more details.
 
+.. _config-metrics:
+
+Metrics
+=======
+
+Gafaelfawr can export metrics to an OpenTelemetry_ collector.
+Currently, it only supports the insecure gRPC mechanism for sending metrics, and therefore should use a collector within the same Kubernetes cluster.
+
+To enable metrics collection and reporting, set the URL of the metrics collector:
+
+.. code-block:: yaml
+
+   config:
+     metricsUrl: "http://telegraf.telegraf:4317"
+
+For a list of all of the metrics Gafaelfawr exports, see :doc:`metrics`.
+
 .. _slack-alerts:
 
 Slack alerts

--- a/docs/user-guide/index.rst
+++ b/docs/user-guide/index.rst
@@ -30,3 +30,4 @@ Also see the `Phalanx Gafaelfawr application documentation <https://phalanx.lsst
 
    logging
    cli
+   metrics

--- a/docs/user-guide/metrics.rst
+++ b/docs/user-guide/metrics.rst
@@ -1,0 +1,52 @@
+#######
+Metrics
+#######
+
+Gafaelfawr optionally supports exporting metrics to an OpenTelemetry_ collector.
+To enable this support, see :ref:`config-metrics`.
+
+All metrics are logged with a service name of ``gafaelfawr``.
+
+If metrics collection is enabled, the following metrics will currently be logged.
+More metrics will likely be added in the future.
+
+Frontend metrics
+================
+
+The following metrics are logged with the meter name of ``frontend``:
+
+login.attempts (counter)
+    Count of times Gafaelfawr sends a user to the identity provider to authenticate, not including duplicate redirects when the user already has an authentication in progress.
+    Duplicates are suppressed by not counting redirects if the ``state`` attribute of the user's cookie is already set.
+
+login.enrollment (counter)
+    Count of the times Gafaelfawr redirects a user to the enrollment flow.
+
+login.failures (counter)
+    Count of the times a login fails at the Gafaelfawr end, meaning that either something went wrong in Gafaelfawr itself, with the request to the remote authentication service, or via an error reported by the remote authentication service.
+    This does not count cases where the authentication service never returns the user to us.
+    It also does not count redirects to the enrollment flow.
+
+login.successes (counter)
+    Count of the times Gafaelfawr successfully authenticates a user and creates a new session.
+    The username will be attached as the ``username`` attribute.
+
+login.success_time (gauge)
+    Total elapsed time in floating point seconds from when Gafaelfawr redirected the user for authentication to when the user successfully authenticated.
+    The username will be attached as the ``username`` attribute.
+
+request.auth (counter)
+    Count of successful authentication attempts to a service.
+    Currently, this only counts authentications to a service that requests delegated tokens.
+    The username is attached as the ``username`` attribute and the service name is attached as the ``service`` attribute.
+
+State metrics
+=============
+
+The following metrics are logged by the Gafaelfawr maintenance cron job with the meter name of ``state``.
+
+sessions.active_users (gauge)
+    Number of users with unexpired sessions.
+
+user_tokens.active
+    Number of active (unexpired) user tokens.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -263,9 +263,6 @@ builtins-ignorelist = [
 fixture-parentheses = false
 mark-parentheses = false
 
-[tool.ruff.lint.mccabe]
-max-complexity = 11
-
 [tool.ruff.lint.pydocstyle]
 convention = "numpy"
 

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -620,10 +620,11 @@ imagesize==1.4.1 \
     --hash=sha256:0d8d18d08f840c19d0ee7ca1fd82490fdc3729b7ac93f49870406ddde8ef8d8b \
     --hash=sha256:69150444affb9cb0d5cc5a92b3676f0b2fb7cd9ae39e947a5e11a36b4497cd4a
     # via sphinx
-importlib-metadata==8.2.0 \
-    --hash=sha256:11901fa0c2f97919b288679932bb64febaeacf289d18ac84dd68cb2e74213369 \
-    --hash=sha256:72e8d4399996132204f9a16dcc751af254a48f8d1b20b9ff0f98d4a8f901e73d
+importlib-metadata==8.0.0 \
+    --hash=sha256:15584cf2b1bf449d98ff8a6ff1abef57bf20f3ac6454f431736cd3e660921b2f \
+    --hash=sha256:188bd24e4c346d3f0a933f275c2fec67050326a856b9a359881d7c2a697e8812
     # via
+    #   -c requirements/main.txt
     #   jupyter-cache
     #   myst-nb
 iniconfig==2.0.0 \
@@ -1751,7 +1752,9 @@ wsproto==1.2.0 \
 zipp==3.20.0 \
     --hash=sha256:0145e43d89664cfe1a2e533adc75adafed82fe2da404b4bbb6b026c0157bdb31 \
     --hash=sha256:58da6168be89f0be59beb194da1250516fdaa062ccebd30127ac65d30045e10d
-    # via importlib-metadata
+    # via
+    #   -c requirements/main.txt
+    #   importlib-metadata
 zstandard==0.23.0 \
     --hash=sha256:034b88913ecc1b097f528e42b539453fa82c3557e414b3de9d5632c80439a473 \
     --hash=sha256:0a7f0804bb3799414af278e9ad51be25edf67f78f916e08afdb983e74161b916 \

--- a/requirements/main.in
+++ b/requirements/main.in
@@ -23,6 +23,9 @@ httpx
 kopf
 kubernetes_asyncio
 jinja2
+opentelemetry-api
+opentelemetry-exporter-otlp-proto-grpc
+opentelemetry-sdk
 pydantic>2
 pydantic-settings
 PyJWT

--- a/requirements/main.txt
+++ b/requirements/main.txt
@@ -386,6 +386,13 @@ cryptography==43.0.0 \
     #   -r requirements/main.in
     #   pyjwt
     #   safir
+deprecated==1.2.14 \
+    --hash=sha256:6fac8b097794a90302bdbb17b9b815e732d3c4720583ff1b198499d78470466c \
+    --hash=sha256:e5323eb936458dccc2582dc6f9c322c852a775a27065ff2b0c4970b9d53d01b3
+    # via
+    #   opentelemetry-api
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-semantic-conventions
 fastapi==0.112.0 \
     --hash=sha256:3487ded9778006a45834b8c816ec4a48d522e2631ca9e75ec5a774f1b052f821 \
     --hash=sha256:d262bc56b7d101d1f4e8fc0ad2ac75bb9935fec504d2b7117686cec50710cf05
@@ -504,6 +511,7 @@ googleapis-common-protos==1.63.2 \
     # via
     #   google-api-core
     #   grpcio-status
+    #   opentelemetry-exporter-otlp-proto-grpc
 greenlet==3.0.3 \
     --hash=sha256:01bc7ea167cf943b4c802068e178bbf70ae2e8c080467070d01bfa02f337ee67 \
     --hash=sha256:0448abc479fab28b00cb472d278828b3ccca164531daab4e970a0458786055d6 \
@@ -614,6 +622,7 @@ grpcio==1.65.4 \
     # via
     #   google-api-core
     #   grpcio-status
+    #   opentelemetry-exporter-otlp-proto-grpc
 grpcio-status==1.62.3 \
     --hash=sha256:289bdd7b2459794a12cf95dc0cb727bd4a1742c37bd823f760236c937e53a485 \
     --hash=sha256:f9049b762ba8de6b1086789d8315846e094edac2c50beaf462338b301a8fd4b8
@@ -680,6 +689,10 @@ idna==3.7 \
     #   httpx
     #   requests
     #   yarl
+importlib-metadata==8.0.0 \
+    --hash=sha256:15584cf2b1bf449d98ff8a6ff1abef57bf20f3ac6454f431736cd3e660921b2f \
+    --hash=sha256:188bd24e4c346d3f0a933f275c2fec67050326a856b9a359881d7c2a697e8812
+    # via opentelemetry-api
 iso8601==2.1.0 \
     --hash=sha256:6b1d3829ee8921c4301998c909f7829fa9ed3cbdac0d3b16af2d743aed1ba8df \
     --hash=sha256:aac4145c4dcb66ad8b648a02830f5e2ff6c24af20f4f482689be402db2429242
@@ -860,6 +873,38 @@ multidict==6.0.5 \
     # via
     #   aiohttp
     #   yarl
+opentelemetry-api==1.26.0 \
+    --hash=sha256:2bd639e4bed5b18486fef0b5a520aaffde5a18fc225e808a1ac4df363f43a1ce \
+    --hash=sha256:7d7ea33adf2ceda2dd680b18b1677e4152000b37ca76e679da71ff103b943064
+    # via
+    #   -r requirements/main.in
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
+opentelemetry-exporter-otlp-proto-common==1.26.0 \
+    --hash=sha256:bdbe50e2e22a1c71acaa0c8ba6efaadd58882e5a5978737a44a4c4b10d304c92 \
+    --hash=sha256:ee4d8f8891a1b9c372abf8d109409e5b81947cf66423fd998e56880057afbc71
+    # via opentelemetry-exporter-otlp-proto-grpc
+opentelemetry-exporter-otlp-proto-grpc==1.26.0 \
+    --hash=sha256:a65b67a9a6b06ba1ec406114568e21afe88c1cdb29c464f2507d529eb906d8ae \
+    --hash=sha256:e2be5eff72ebcb010675b818e8d7c2e7d61ec451755b8de67a140bc49b9b0280
+    # via -r requirements/main.in
+opentelemetry-proto==1.26.0 \
+    --hash=sha256:6c4d7b4d4d9c88543bcf8c28ae3f8f0448a753dc291c18c5390444c90b76a725 \
+    --hash=sha256:c5c18796c0cab3751fc3b98dee53855835e90c0422924b484432ac852d93dc1e
+    # via
+    #   opentelemetry-exporter-otlp-proto-common
+    #   opentelemetry-exporter-otlp-proto-grpc
+opentelemetry-sdk==1.26.0 \
+    --hash=sha256:c90d2868f8805619535c05562d699e2f4fb1f00dbd55a86dcefca4da6fa02f85 \
+    --hash=sha256:feb5056a84a88670c041ea0ded9921fca559efec03905dddeb3885525e0af897
+    # via
+    #   -r requirements/main.in
+    #   opentelemetry-exporter-otlp-proto-grpc
+opentelemetry-semantic-conventions==0.47b0 \
+    --hash=sha256:4ff9d595b85a59c1c1413f02bba320ce7ea6bf9e2ead2b0913c4395c7bbc1063 \
+    --hash=sha256:a8d57999bbe3495ffd4d510de26a97dadc1dace53e0275001b2c1b2f67992a7e
+    # via opentelemetry-sdk
 proto-plus==1.24.0 \
     --hash=sha256:30b72a5ecafe4406b0d339db35b56c4059064e69227b8c3bda7462397f966445 \
     --hash=sha256:402576830425e5f6ce4c2a6702400ac79897dab0b4343821aa5188b0fab81a12
@@ -883,6 +928,7 @@ protobuf==4.25.4 \
     #   google-cloud-firestore
     #   googleapis-common-protos
     #   grpcio-status
+    #   opentelemetry-proto
     #   proto-plus
 pyasn1==0.6.0 \
     --hash=sha256:3a35ab2c4b5ef98e17dfdec8ab074046fbda76e281c5a706ccd82328cfc8f64c \
@@ -1188,6 +1234,7 @@ typing-extensions==4.12.2 \
     #   alembic
     #   fastapi
     #   kopf
+    #   opentelemetry-sdk
     #   pydantic
     #   pydantic-core
     #   sqlalchemy
@@ -1401,6 +1448,78 @@ websockets==12.0 \
     --hash=sha256:fc4e7fa5414512b481a2483775a8e8be7803a35b30ca805afa4998a84f9fd9e8 \
     --hash=sha256:ffefa1374cd508d633646d51a8e9277763a9b78ae71324183693959cf94635a7
     # via uvicorn
+wrapt==1.16.0 \
+    --hash=sha256:0d2691979e93d06a95a26257adb7bfd0c93818e89b1406f5a28f36e0d8c1e1fc \
+    --hash=sha256:14d7dc606219cdd7405133c713f2c218d4252f2a469003f8c46bb92d5d095d81 \
+    --hash=sha256:1a5db485fe2de4403f13fafdc231b0dbae5eca4359232d2efc79025527375b09 \
+    --hash=sha256:1acd723ee2a8826f3d53910255643e33673e1d11db84ce5880675954183ec47e \
+    --hash=sha256:1ca9b6085e4f866bd584fb135a041bfc32cab916e69f714a7d1d397f8c4891ca \
+    --hash=sha256:1dd50a2696ff89f57bd8847647a1c363b687d3d796dc30d4dd4a9d1689a706f0 \
+    --hash=sha256:2076fad65c6736184e77d7d4729b63a6d1ae0b70da4868adeec40989858eb3fb \
+    --hash=sha256:2a88e6010048489cda82b1326889ec075a8c856c2e6a256072b28eaee3ccf487 \
+    --hash=sha256:3ebf019be5c09d400cf7b024aa52b1f3aeebeff51550d007e92c3c1c4afc2a40 \
+    --hash=sha256:418abb18146475c310d7a6dc71143d6f7adec5b004ac9ce08dc7a34e2babdc5c \
+    --hash=sha256:43aa59eadec7890d9958748db829df269f0368521ba6dc68cc172d5d03ed8060 \
+    --hash=sha256:44a2754372e32ab315734c6c73b24351d06e77ffff6ae27d2ecf14cf3d229202 \
+    --hash=sha256:490b0ee15c1a55be9c1bd8609b8cecd60e325f0575fc98f50058eae366e01f41 \
+    --hash=sha256:49aac49dc4782cb04f58986e81ea0b4768e4ff197b57324dcbd7699c5dfb40b9 \
+    --hash=sha256:5eb404d89131ec9b4f748fa5cfb5346802e5ee8836f57d516576e61f304f3b7b \
+    --hash=sha256:5f15814a33e42b04e3de432e573aa557f9f0f56458745c2074952f564c50e664 \
+    --hash=sha256:5f370f952971e7d17c7d1ead40e49f32345a7f7a5373571ef44d800d06b1899d \
+    --hash=sha256:66027d667efe95cc4fa945af59f92c5a02c6f5bb6012bff9e60542c74c75c362 \
+    --hash=sha256:66dfbaa7cfa3eb707bbfcd46dab2bc6207b005cbc9caa2199bcbc81d95071a00 \
+    --hash=sha256:685f568fa5e627e93f3b52fda002c7ed2fa1800b50ce51f6ed1d572d8ab3e7fc \
+    --hash=sha256:6906c4100a8fcbf2fa735f6059214bb13b97f75b1a61777fcf6432121ef12ef1 \
+    --hash=sha256:6a42cd0cfa8ffc1915aef79cb4284f6383d8a3e9dcca70c445dcfdd639d51267 \
+    --hash=sha256:6dcfcffe73710be01d90cae08c3e548d90932d37b39ef83969ae135d36ef3956 \
+    --hash=sha256:6f6eac2360f2d543cc875a0e5efd413b6cbd483cb3ad7ebf888884a6e0d2e966 \
+    --hash=sha256:72554a23c78a8e7aa02abbd699d129eead8b147a23c56e08d08dfc29cfdddca1 \
+    --hash=sha256:73870c364c11f03ed072dda68ff7aea6d2a3a5c3fe250d917a429c7432e15228 \
+    --hash=sha256:73aa7d98215d39b8455f103de64391cb79dfcad601701a3aa0dddacf74911d72 \
+    --hash=sha256:75ea7d0ee2a15733684badb16de6794894ed9c55aa5e9903260922f0482e687d \
+    --hash=sha256:7bd2d7ff69a2cac767fbf7a2b206add2e9a210e57947dd7ce03e25d03d2de292 \
+    --hash=sha256:807cc8543a477ab7422f1120a217054f958a66ef7314f76dd9e77d3f02cdccd0 \
+    --hash=sha256:8e9723528b9f787dc59168369e42ae1c3b0d3fadb2f1a71de14531d321ee05b0 \
+    --hash=sha256:9090c9e676d5236a6948330e83cb89969f433b1943a558968f659ead07cb3b36 \
+    --hash=sha256:9153ed35fc5e4fa3b2fe97bddaa7cbec0ed22412b85bcdaf54aeba92ea37428c \
+    --hash=sha256:9159485323798c8dc530a224bd3ffcf76659319ccc7bbd52e01e73bd0241a0c5 \
+    --hash=sha256:941988b89b4fd6b41c3f0bfb20e92bd23746579736b7343283297c4c8cbae68f \
+    --hash=sha256:94265b00870aa407bd0cbcfd536f17ecde43b94fb8d228560a1e9d3041462d73 \
+    --hash=sha256:98b5e1f498a8ca1858a1cdbffb023bfd954da4e3fa2c0cb5853d40014557248b \
+    --hash=sha256:9b201ae332c3637a42f02d1045e1d0cccfdc41f1f2f801dafbaa7e9b4797bfc2 \
+    --hash=sha256:a0ea261ce52b5952bf669684a251a66df239ec6d441ccb59ec7afa882265d593 \
+    --hash=sha256:a33a747400b94b6d6b8a165e4480264a64a78c8a4c734b62136062e9a248dd39 \
+    --hash=sha256:a452f9ca3e3267cd4d0fcf2edd0d035b1934ac2bd7e0e57ac91ad6b95c0c6389 \
+    --hash=sha256:a86373cf37cd7764f2201b76496aba58a52e76dedfaa698ef9e9688bfd9e41cf \
+    --hash=sha256:ac83a914ebaf589b69f7d0a1277602ff494e21f4c2f743313414378f8f50a4cf \
+    --hash=sha256:aefbc4cb0a54f91af643660a0a150ce2c090d3652cf4052a5397fb2de549cd89 \
+    --hash=sha256:b3646eefa23daeba62643a58aac816945cadc0afaf21800a1421eeba5f6cfb9c \
+    --hash=sha256:b47cfad9e9bbbed2339081f4e346c93ecd7ab504299403320bf85f7f85c7d46c \
+    --hash=sha256:b935ae30c6e7400022b50f8d359c03ed233d45b725cfdd299462f41ee5ffba6f \
+    --hash=sha256:bb2dee3874a500de01c93d5c71415fcaef1d858370d405824783e7a8ef5db440 \
+    --hash=sha256:bc57efac2da352a51cc4658878a68d2b1b67dbe9d33c36cb826ca449d80a8465 \
+    --hash=sha256:bf5703fdeb350e36885f2875d853ce13172ae281c56e509f4e6eca049bdfb136 \
+    --hash=sha256:c31f72b1b6624c9d863fc095da460802f43a7c6868c5dda140f51da24fd47d7b \
+    --hash=sha256:c5cd603b575ebceca7da5a3a251e69561bec509e0b46e4993e1cac402b7247b8 \
+    --hash=sha256:d2efee35b4b0a347e0d99d28e884dfd82797852d62fcd7ebdeee26f3ceb72cf3 \
+    --hash=sha256:d462f28826f4657968ae51d2181a074dfe03c200d6131690b7d65d55b0f360f8 \
+    --hash=sha256:d5e49454f19ef621089e204f862388d29e6e8d8b162efce05208913dde5b9ad6 \
+    --hash=sha256:da4813f751142436b075ed7aa012a8778aa43a99f7b36afe9b742d3ed8bdc95e \
+    --hash=sha256:db2e408d983b0e61e238cf579c09ef7020560441906ca990fe8412153e3b291f \
+    --hash=sha256:db98ad84a55eb09b3c32a96c576476777e87c520a34e2519d3e59c44710c002c \
+    --hash=sha256:dbed418ba5c3dce92619656802cc5355cb679e58d0d89b50f116e4a9d5a9603e \
+    --hash=sha256:dcdba5c86e368442528f7060039eda390cc4091bfd1dca41e8046af7c910dda8 \
+    --hash=sha256:decbfa2f618fa8ed81c95ee18a387ff973143c656ef800c9f24fb7e9c16054e2 \
+    --hash=sha256:e4fdb9275308292e880dcbeb12546df7f3e0f96c6b41197e0cf37d2826359020 \
+    --hash=sha256:eb1b046be06b0fce7249f1d025cd359b4b80fc1c3e24ad9eca33e0dcdb2e4a35 \
+    --hash=sha256:eb6e651000a19c96f452c85132811d25e9264d836951022d6e81df2fff38337d \
+    --hash=sha256:ed867c42c268f876097248e05b6117a65bcd1e63b779e916fe2e33cd6fd0d3c3 \
+    --hash=sha256:edfad1d29c73f9b863ebe7082ae9321374ccb10879eeabc84ba3b69f2579d537 \
+    --hash=sha256:f2058f813d4f2b5e3a9eb2eb3faf8f1d99b81c3e51aeda4b168406443e8ba809 \
+    --hash=sha256:f6b2d0c6703c988d334f297aa5df18c45e97b0af3679bb75059e0e0bd8b1069d \
+    --hash=sha256:f8212564d49c50eb4565e502814f694e240c55551a5f1bc841d4fcaabb0a9b8a \
+    --hash=sha256:ffa565331890b90056c01db69c0fe634a776f8019c143a5ae265f9c6bc4bd6d4
+    # via deprecated
 yarl==1.9.4 \
     --hash=sha256:008d3e808d03ef28542372d01057fd09168419cdc8f848efe2804f894ae03e51 \
     --hash=sha256:03caa9507d3d3c83bca08650678e25364e1843b484f19986a527630ca376ecce \
@@ -1493,3 +1612,7 @@ yarl==1.9.4 \
     --hash=sha256:f3bc6af6e2b8f92eced34ef6a96ffb248e863af20ef4fde9448cc8c9b858b749 \
     --hash=sha256:f7d6b36dd2e029b6bcb8a13cf19664c7b8e19ab3a58e0fefbb5b8461447ed5ec
     # via aiohttp
+zipp==3.20.0 \
+    --hash=sha256:0145e43d89664cfe1a2e533adc75adafed82fe2da404b4bbb6b026c0157bdb31 \
+    --hash=sha256:58da6168be89f0be59beb194da1250516fdaa062ccebd30127ac65d30045e10d
+    # via importlib-metadata

--- a/src/gafaelfawr/cli.py
+++ b/src/gafaelfawr/cli.py
@@ -31,6 +31,7 @@ from .dependencies.config import config_dependency
 from .factory import Factory
 from .keypair import RSAKeyPair
 from .main import create_app
+from .metrics import StateMetrics
 from .models.token import Token
 from .schema import Base
 
@@ -233,6 +234,10 @@ async def maintenance(*, config_path: Path | None) -> None:
             await token_service.expire_tokens()
             logger.info("Truncating token history")
             await token_service.truncate_history()
+        if config.metrics_url:
+            metrics = StateMetrics(config.metrics_url)
+            async with factory.session.begin():
+                await token_service.gather_state_metrics(metrics)
     await engine.dispose()
     logger.debug("Finished background maintenance")
 

--- a/src/gafaelfawr/config.py
+++ b/src/gafaelfawr/config.py
@@ -32,6 +32,7 @@ from uuid import UUID
 import yaml
 from pydantic import (
     AliasChoices,
+    AnyHttpUrl,
     BaseModel,
     ConfigDict,
     Field,
@@ -798,6 +799,16 @@ class Config(EnvFirstSettings):
         LogLevel.INFO,
         title="Logging level",
         description="Python logging level",
+    )
+
+    metrics_url: AnyHttpUrl | None = Field(
+        None,
+        title="Metrics collector URL",
+        description=(
+            "If set, report metrics using the OpenTelemetry protocol to this"
+            " URL. Normally this will be a cluster-internal URL of a telegraf"
+            " instance. The metrics will be sent using insecure gRPC."
+        ),
     )
 
     proxies: list[IPv4Network | IPv6Network] | None = Field(

--- a/src/gafaelfawr/handlers/auth.py
+++ b/src/gafaelfawr/handlers/auth.py
@@ -371,6 +371,12 @@ async def get_auth(
     headers = await build_success_headers(context, auth_config, token_data)
     for key, value in headers:
         response.headers.append(key, value)
+    if context.metrics and auth_config.delegate_to:
+        attrs = {
+            "username": token_data.username,
+            "service": auth_config.delegate_to,
+        }
+        context.metrics.request_auth.add(1, attrs)
     return {"status": "ok"}
 
 

--- a/src/gafaelfawr/metrics.py
+++ b/src/gafaelfawr/metrics.py
@@ -1,0 +1,210 @@
+"""Metrics implementation for Gafaelfawr."""
+
+from __future__ import annotations
+
+from opentelemetry.exporter.otlp.proto.grpc.metric_exporter import (
+    OTLPMetricExporter,
+)
+from opentelemetry.sdk.metrics import MeterProvider
+from opentelemetry.sdk.metrics.export import (
+    MetricReader,
+    PeriodicExportingMetricReader,
+)
+from opentelemetry.sdk.resources import SERVICE_NAME, Resource
+from pydantic import AnyHttpUrl
+
+__all__ = [
+    "FrontendMetrics",
+    "GafaelfawrMetrics",
+    "StateMetrics",
+]
+
+
+class GafaelfawrMetrics:
+    """Base class for OpenTelemetry instruments for Gafaelfawr.
+
+    Gafaelfawr has several different containers of metrics instruments used by
+    its different components. This base class contains the shared code common
+    to all of them, such as initializing the metrics exporter. Only one
+    subclass of this class should be instantiated in a given process. (This is
+    not enforced.)
+
+    Parameters
+    ----------
+    url
+        URL to the OpenTelemetry collector to which to send metrics.
+    meter_name
+        Name of the meter, which should correspond to the component of
+        Gafaelfawr that logs these metrics.
+    metric_reader
+        If provided, do not collect and send metrics to the OpenTelemetry
+        collector, and instead use the provided metric reader. This is used by
+        the test suite to disable the OpenTelemetry exporter in favor of an
+        in-memory metrics reader that can be queried by the test suite.
+
+    Attributes
+    ----------
+    meter
+        Meter that should be used to create instruments.
+    """
+
+    def __init__(
+        self,
+        url: AnyHttpUrl | str,
+        meter_name: str,
+        metric_reader: MetricReader | None = None,
+    ) -> None:
+        resource = Resource(attributes={SERVICE_NAME: "gafaelfawr"})
+        if not metric_reader:
+            exporter = OTLPMetricExporter(str(url), insecure=True)
+            metric_reader = PeriodicExportingMetricReader(exporter)
+        provider = MeterProvider([metric_reader], resource)
+        self.meter = provider.get_meter(meter_name)
+
+
+class FrontendMetrics(GafaelfawrMetrics):
+    """Metric instruments for the Gafaelfawr frontend.
+
+    Parameters
+    ----------
+    url
+        URL to the OpenTelemetry collector to which to send metrics.
+    metric_reader
+        If provided, do not collect and send metrics to the OpenTelemetry
+        collector, and instead use the provided metric reader. This is used by
+        the test suite to disable the OpenTelemetry exporter in favor of an
+        in-memory metrics reader that can be queried by the test suite.
+
+    Attributes
+    ----------
+    login_attempts
+        Count of times Gafaelfawr sends the user to the identity provider for
+        authentication. This does not include duplicate redirects when the
+        given user already has an authentication in progress.
+    login_enrollment
+        Count of the number of Gafaelfawr redirects an authenticated but
+        unknown user to the enrollment flow.
+    login_failures
+        Count of the times a login fails at the Gafaelfawr end, meaning that
+        either something went wrong in Gafaelfawr itself, with the request to
+        the remote authentication service, or via an error reported by the
+        remote authentication service. This does not count cases where the
+        authentication service never returns the user to us.
+    login_success_time
+        How long it takes for the user to go through the login process. The
+        authenticated username must be included as the ``username`` attribute.
+    login_successes
+        Count of times the user returns successfully from the identity
+        provider after authenticating. The authenticated username must be
+        included as the ``username`` attribute.
+    request_auth
+        An authenticated request to a service. Currently this is only logged
+        when a token is delegated to the service due to limitations in the
+        Gafaelfawr design. The authenticated username must be included as the
+        ``username`` attribute and the service name must be included as the
+        ``service`` attribute.
+    """
+
+    def __init__(
+        self, url: AnyHttpUrl | str, metric_reader: MetricReader | None = None
+    ) -> None:
+        super().__init__(url, "frontend", metric_reader)
+        self.login_attempts = self.meter.create_counter(
+            "login.attempts",
+            unit="1",
+            description=(
+                "Count of times Gafaelfawr sends the user to the identity"
+                " provider to authenticate, not including duplicate redirects"
+                " when the given user already has an authentication in"
+                " progress."
+            ),
+        )
+        self.login_enrollment = self.meter.create_counter(
+            "login.enrollment",
+            unit="1",
+            description=(
+                "Count of times Gafaelfawr redirects a user to the enrollment"
+                " flow."
+            ),
+        )
+        self.login_failures = self.meter.create_counter(
+            "login.failures",
+            unit="1",
+            description=(
+                "Count of the times a login fails at the Gafaelfawr end,"
+                " meaning that either something went wrong in Gafaelfawr"
+                " itself, with the request to the remote authentication"
+                " service, or via an error reported by the remote"
+                " authentication service. This does not count cases where"
+                " the authentication service never returns the user to us."
+            ),
+        )
+        self.login_success_time = self.meter.create_gauge(
+            "login.success_time",
+            unit="s",
+            description=(
+                "How long it takes for the user to go through the login"
+                " process. The authenticated username is included as an"
+                " attribute."
+            ),
+        )
+        self.login_successes = self.meter.create_counter(
+            "login.successes",
+            unit="1",
+            description=(
+                "Count of times the user returns successfully from the"
+                " identity provider after authenticating. The authenticated"
+                " username is included as an attribute."
+            ),
+        )
+        self.request_auth = self.meter.create_counter(
+            "request.auth",
+            unit="1",
+            description=(
+                "An authenticated request to an underlying service. Currently"
+                " this is only logged for requests that delegate an internal"
+                " token to the service, since those are the only ones for"
+                " which Gafaelfawr knows the service name. Attributes are the"
+                " service name and the authenticated username."
+            ),
+        )
+
+
+class StateMetrics(GafaelfawrMetrics):
+    """Metric instruments based on stored state.
+
+    Collects metrics determined from the current stored state. These are
+    gathered and reported by the maintenance cron job.
+
+    Parameters
+    ----------
+    url
+        URL to the OpenTelemetry collector to which to send metrics.
+    metric_reader
+        If provided, do not collect and send metrics to the OpenTelemetry
+        collector, and instead use the provided metric reader. This is used by
+        the test suite to disable the OpenTelemetry exporter in favor of an
+        in-memory metrics reader that can be queried by the test suite.
+
+    Attributes
+    ----------
+    sessions_active_users
+        Total number of unexpired user sessions (unexpired session tokens).
+    user_tokens_active
+        Total number of unexpired user tokens.
+    """
+
+    def __init__(
+        self, url: AnyHttpUrl | str, metric_reader: MetricReader | None = None
+    ) -> None:
+        super().__init__(url, "state", metric_reader)
+        self.sessions_active_users = self.meter.create_gauge(
+            "sessions.active_users",
+            unit="1",
+            description="Number of users with unexpired user sessions",
+        )
+        self.user_tokens_active = self.meter.create_gauge(
+            "user_tokens.active",
+            unit="1",
+            description="Number of unexpired user tokens",
+        )

--- a/tests/storage/token_test.py
+++ b/tests/storage/token_test.py
@@ -1,0 +1,35 @@
+"""Tests for the token storage layer."""
+
+import pytest
+
+from gafaelfawr.factory import Factory
+from gafaelfawr.storage.token import TokenDatabaseStore
+
+from ..support.tokens import create_session_token
+
+
+@pytest.mark.asyncio
+async def test_metrics(factory: Factory) -> None:
+    token_db_store = TokenDatabaseStore(factory.session)
+
+    async with factory.session.begin():
+        assert await token_db_store.count_unique_sessions() == 0
+    await create_session_token(factory, username="someuser")
+    await create_session_token(factory, username="otheruser")
+    token_data = await create_session_token(factory, username="someuser")
+    async with factory.session.begin():
+        assert await token_db_store.count_unique_sessions() == 2
+
+    async with factory.session.begin():
+        assert await token_db_store.count_user_tokens() == 0
+    token_service = factory.create_token_service()
+    async with factory.session.begin():
+        await token_service.create_user_token(
+            token_data,
+            "someuser",
+            token_name="some-token",
+            scopes=[],
+            ip_address="192.168.0.1",
+        )
+    async with factory.session.begin():
+        assert await token_db_store.count_user_tokens() == 1

--- a/tox.ini
+++ b/tox.ini
@@ -40,6 +40,7 @@ setenv =
     GAFAELFAWR_DATABASE_URL = postgresql://gafaelfawr@localhost/gafaelfawr
     GAFAELFAWR_DATABASE_PASSWORD = INSECURE-PASSWORD
     GAFAELFAWR_REDIS_URL = redis://localhost/0
+    GAFAELFAWR_TESTING = true
     GAFAELFAWR_UI_PATH = {toxinidir}/ui/public
 
 [testenv:alembic]
@@ -66,6 +67,8 @@ allowlist_externals =
     rm
 commands =
     rm -rf docs/dev/internals
+    # https://github.com/sphinx-contrib/redoc/issues/48
+    rm -f docs/_build/html/_static/redoc.js
     gafaelfawr openapi-schema --add-back-link --output docs/_static/openapi.json
     sphinx-build -W --keep-going -n -T -b html -d {envtmpdir}/doctrees docs docs/_build/html
 


### PR DESCRIPTION
Add initial support for exporting OpenTelemetry metrics to a collector via insecure gRPC. The initial metrics only cover logins (counts of success, failure, enrollment redirects, and attempts, plus time to successful authentication), authentications where Gafaelfawr is delegating a token, and counts of active sessions and user tokens from database queries in the maintenance cron job.

Reset login state after an error so that any subsequent authentication attempts will generate a new, random state parameter. This also improves reporting of the login metrics.