### PR TITLE
DM-45779: Exclude mobu bot users from metrics

### DIFF
--- a/src/gafaelfawr/handlers/auth.py
+++ b/src/gafaelfawr/handlers/auth.py
@@ -29,6 +29,7 @@ from ..exceptions import (
 )
 from ..models.auth import AuthType, Satisfy
 from ..models.token import TokenData
+from ..util import is_mobu_bot_user
 
 router = APIRouter(route_class=SlackRouteErrorHandler)
 
@@ -372,11 +373,12 @@ async def get_auth(
     for key, value in headers:
         response.headers.append(key, value)
     if context.metrics and auth_config.delegate_to:
-        attrs = {
-            "username": token_data.username,
-            "service": auth_config.delegate_to,
-        }
-        context.metrics.request_auth.add(1, attrs)
+        if not is_mobu_bot_user(token_data.username):
+            attrs = {
+                "username": token_data.username,
+                "service": auth_config.delegate_to,
+            }
+            context.metrics.request_auth.add(1, attrs)
     return {"status": "ok"}
 
 

--- a/src/gafaelfawr/util.py
+++ b/src/gafaelfawr/util.py
@@ -25,6 +25,7 @@ __all__ = [
     "base64_to_number",
     "group_name_for_github_team",
     "is_bot_user",
+    "is_mobu_bot_user",
     "normalize_ip_address",
     "normalize_scopes",
     "normalize_timedelta",
@@ -85,6 +86,21 @@ def is_bot_user(username: str) -> bool:
         Username to check.
     """
     return re.search(BOT_USERNAME_REGEX, username) is not None
+
+
+def is_mobu_bot_user(username: str) -> bool:
+    """Return whether the given username is a mobu bot user.
+
+    mobu is the integration testing bot. Its actions should not be included in
+    usage metrics, since they could swamp the measurements for regular users
+    or distort the metrics.
+
+    Parameters
+    ----------
+    username
+        Username to check.
+    """
+    return is_bot_user(username) and username.startswith("bot-mobu")
 
 
 def group_name_for_github_team(organization: str, team: str) -> str:

--- a/tests/util_test.py
+++ b/tests/util_test.py
@@ -12,6 +12,7 @@ from gafaelfawr.util import (
     add_padding,
     base64_to_number,
     is_bot_user,
+    is_mobu_bot_user,
     normalize_timedelta,
     number_to_base64,
 )
@@ -50,6 +51,16 @@ def test_is_bot_user() -> None:
     assert not is_bot_user("bot")
     assert not is_bot_user("botuser")
     assert not is_bot_user("bot-in!valid")
+
+
+def test_is_mobu_bot_user() -> None:
+    assert is_mobu_bot_user("bot-mobu-weekly")
+    assert is_mobu_bot_user("bot-mobu")
+    assert not is_mobu_bot_user("bot-user")
+    assert not is_mobu_bot_user("some-user")
+    assert not is_mobu_bot_user("bot")
+    assert not is_mobu_bot_user("botuser")
+    assert not is_mobu_bot_user("bot-in!valid")
 
 
 def test_normalize_timedelta() -> None:


### PR DESCRIPTION
This is only needed for auth metrics, not login or state metrics, since the latter two already don't count mobu bot users since they don't do session logins and don't create user tokens.