### PR TITLE
DM-45779: Set sub to username for CADC reply

### DIFF
--- a/changelog.d/20240814_154819_rra_DM_45779.md
+++ b/changelog.d/20240814_154819_rra_DM_45779.md
@@ -1,0 +1,3 @@
+### Backwards-incompatible changes
+
+- Since the CADC authentication code no longer requires the `sub` claim be a UUID, set `sub` to the username in the response from `/auth/cadc/userinfo`. This allows the CADC TAP server to store the username in the UWS jobs table.

--- a/src/gafaelfawr/config.py
+++ b/src/gafaelfawr/config.py
@@ -25,7 +25,6 @@ from datetime import timedelta
 from ipaddress import IPv4Network, IPv6Network
 from pathlib import Path
 from typing import Annotated, Any, Self
-from uuid import UUID
 
 import yaml
 from pydantic import (
@@ -760,14 +759,6 @@ class Config(EnvFirstSettings):
         ),
         validation_alias=AliasChoices(
             "GAFAELFAWR_BOOTSTRAP_TOKEN", "bootstrapToken"
-        ),
-    )
-
-    cadc_base_uuid: UUID | None = Field(
-        None,
-        title="Base UUID for CADC UUIDs",
-        description=(
-            "Namespace UUID used to generate UUIDs for CADC-compatible auth"
         ),
     )
 

--- a/src/gafaelfawr/models/userinfo.py
+++ b/src/gafaelfawr/models/userinfo.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from datetime import datetime
-from uuid import UUID
 
 from pydantic import BaseModel, Field, field_serializer
 
@@ -42,17 +41,15 @@ class CADCUserInfo(BaseModel):
         examples=["someuser"],
     )
 
-    sub: UUID = Field(
+    sub: str = Field(
         ...,
         title="Unique identifier",
         description=(
-            "CADC code currently requires a UUID in this field. In practice,"
-            " this is generated as a version 5 UUID based on a configured"
-            " UUID namespace and the string representation of the user's"
-            " numeric UID (thus allowing username changes if the UID is"
-            " preserved."
+            "For now, Gafaelfawr uses the username for this field as well,"
+            " even though this is not entirely correct in the presence of"
+            " username changes."
         ),
-        examples=["78410c93-841d-53b1-a353-6411524d149e"],
+        examples=["someuser"],
     )
 
     @field_serializer("exp")

--- a/tests/data/config/github.yaml
+++ b/tests/data/config/github.yaml
@@ -30,7 +30,6 @@ github:
   clientId: "some-github-client-id"
 errorFooter: |
   Some <strong>error instructions</strong> with HTML.
-cadcBaseUuid: "750a0d94-e0eb-4b4e-a732-bcf87d7197fd"
 
 # Ensure that the configuration parser correctly discards empty or partial
 # configurations that should not be used.

--- a/tests/handlers/cadc_test.py
+++ b/tests/handlers/cadc_test.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from datetime import timedelta
-from uuid import uuid5
 
 import pytest
 from httpx import AsyncClient
@@ -18,14 +17,11 @@ from gafaelfawr.models.token import (
     TokenType,
 )
 
-from ..support.config import reconfigure
-
 
 @pytest.mark.asyncio
 async def test_userinfo(
     config: Config, client: AsyncClient, factory: Factory
 ) -> None:
-    assert config.cadc_base_uuid
     expires = current_datetime() + timedelta(days=7)
     request = AdminTokenRequest(
         username="bot-example",
@@ -46,7 +42,7 @@ async def test_userinfo(
     assert r.json() == {
         "exp": int(expires.timestamp()),
         "preferred_username": "bot-example",
-        "sub": str(uuid5(config.cadc_base_uuid, "45613")),
+        "sub": "bot-example",
     }
 
 
@@ -54,8 +50,6 @@ async def test_userinfo(
 async def test_userinfo_errors(
     config: Config, client: AsyncClient, factory: Factory
 ) -> None:
-    assert config.cadc_base_uuid
-
     r = await client.get("/auth/cadc/userinfo")
     assert r.status_code == 401
     r = await client.get(
@@ -66,30 +60,3 @@ async def test_userinfo_errors(
         "/auth/cadc/userinfo", headers={"Authorization": "bearer blahblah"}
     )
     assert r.status_code == 401
-
-    # Create a token that doesn't have a UID. We cannot generate a UUID for
-    # these, so they will produce an error.
-    request = AdminTokenRequest(
-        username="bot-example", token_type=TokenType.service
-    )
-    token_service = factory.create_token_service()
-    async with factory.session.begin():
-        token = await token_service.create_token_from_admin_request(
-            request, TokenData.internal_token(), ip_address=None
-        )
-    r = await client.get(
-        "/auth/cadc/userinfo", headers={"Authorization": f"bearer {token!s}"}
-    )
-    assert r.status_code == 403
-
-    # Switch to a configuration that doesn't have CADC auth configuration.
-    await reconfigure("github-quota", factory)
-    token_service = factory.create_token_service()
-    async with factory.session.begin():
-        token = await token_service.create_token_from_admin_request(
-            request, TokenData.internal_token(), ip_address=None
-        )
-    r = await client.get(
-        "/auth/cadc/userinfo", headers={"Authorization": f"bearer {token!s}"}
-    )
-    assert r.status_code == 404


### PR DESCRIPTION
The new CADC authentication code no longer requires the sub claim returned by the userinfo endpoint to be a UUID, so send the username instead so that the TAP server will store the username in the UWS jobs table. This is still not ideal, since the username is not necessarily a permanent, unique identifier given the possibility of username changes, but it will do for now.