### PR TITLE
DM-45779: Drop unnecessary get_secret_value()

### DIFF
--- a/src/gafaelfawr/cli.py
+++ b/src/gafaelfawr/cli.py
@@ -85,7 +85,7 @@ async def audit(*, fix: bool, config_path: Path | None) -> None:
     config = await config_dependency()
     logger = structlog.get_logger("gafaelfawr")
     engine = create_database_engine(
-        config.database_url, config.database_password.get_secret_value()
+        config.database_url, config.database_password
     )
     if not await is_database_current(config, logger, engine):
         raise click.ClickException("Database schema is not current")
@@ -131,7 +131,7 @@ async def delete_all_data(*, config_path: Path | None) -> None:
     logger = structlog.get_logger("gafaelfawr")
     logger.debug("Starting to delete all data")
     engine = create_database_engine(
-        config.database_url, config.database_password.get_secret_value()
+        config.database_url, config.database_password
     )
     tables = (t.name for t in Base.metadata.sorted_tables)
     async with Factory.standalone(config, engine) as factory:
@@ -222,7 +222,7 @@ async def maintenance(*, config_path: Path | None) -> None:
     config = await config_dependency()
     logger = structlog.get_logger("gafaelfawr")
     engine = create_database_engine(
-        config.database_url, config.database_password.get_secret_value()
+        config.database_url, config.database_password
     )
     if not await is_database_current(config, logger, engine):
         raise click.ClickException("Database schema is not current")
@@ -344,7 +344,7 @@ async def validate_schema(*, config_path: Path | None) -> None:
     config = config_dependency.config()
     logger = structlog.get_logger("gafaelfawr")
     engine = create_database_engine(
-        config.database_url, config.database_password.get_secret_value()
+        config.database_url, config.database_password
     )
     if not await is_database_initialized(config, logger, engine):
         raise click.ClickException("Database has not been initialized")

--- a/src/gafaelfawr/database.py
+++ b/src/gafaelfawr/database.py
@@ -46,7 +46,7 @@ async def initialize_gafaelfawr_database(
     """
     if not engine:
         engine = create_database_engine(
-            config.database_url, config.database_password.get_secret_value()
+            config.database_url, config.database_password
         )
     await initialize_database(engine, logger, schema=Base.metadata)
     async with Factory.standalone(config, engine) as factory:
@@ -88,7 +88,7 @@ async def is_database_current(
     """
     if not engine:
         engine = create_database_engine(
-            config.database_url, config.database_password.get_secret_value()
+            config.database_url, config.database_password
         )
 
     def get_current_heads(connection: Connection) -> set[str]:
@@ -132,7 +132,7 @@ async def is_database_initialized(
     """
     if not engine:
         engine = create_database_engine(
-            config.database_url, config.database_password.get_secret_value()
+            config.database_url, config.database_password
         )
     statement = select(Token).limit(1)
     try:

--- a/src/gafaelfawr/main.py
+++ b/src/gafaelfawr/main.py
@@ -80,8 +80,7 @@ def create_app(
                 raise DatabaseSchemaError("Database schema out of date")
         await context_dependency.initialize(config, metric_reader)
         await db_session_dependency.initialize(
-            str(config.database_url),
-            config.database_password.get_secret_value(),
+            str(config.database_url), config.database_password
         )
         if extra_startup:
             await extra_startup
@@ -181,7 +180,7 @@ def create_app(
     if config and config.slack_alerts and config.slack_webhook:
         logger = structlog.get_logger("gafaelfawr")
         SlackRouteErrorHandler.initialize(
-            config.slack_webhook.get_secret_value(), "Gafaelfawr", logger
+            config.slack_webhook, "Gafaelfawr", logger
         )
         logger.debug("Initialized Slack webhook")
 

--- a/src/gafaelfawr/operator/startup.py
+++ b/src/gafaelfawr/operator/startup.py
@@ -51,7 +51,7 @@ async def startup(
     await initialize_kubernetes()
 
     engine = create_database_engine(
-        config.database_url, config.database_password.get_secret_value()
+        config.database_url, config.database_password
     )
     logger = structlog.get_logger("gafaelfawr")
     if not await is_database_current(config, logger, engine):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -167,7 +167,7 @@ def engine(config: Config) -> AsyncEngine:
     burden doesn't seem worth it.
     """
     return create_database_engine(
-        config.database_url, config.database_password.get_secret_value()
+        config.database_url, config.database_password
     )
 
 

--- a/tests/support/selenium.py
+++ b/tests/support/selenium.py
@@ -94,7 +94,7 @@ async def _selenium_startup(token_path: Path) -> None:
     scopes = list(config.known_scopes.keys())
 
     engine = create_database_engine(
-        config.database_url, config.database_password.get_secret_value()
+        config.database_url, config.database_password
     )
     async with Factory.standalone(config, engine) as factory:
         async with factory.session.begin():


### PR DESCRIPTION
The database password and Slack webhook can now be passed into Safir code as SecretStr, so drop now-unnecessary get_secret_value() method calls.