### PR TITLE
DM-45779: Improve documentation of headers

### DIFF
--- a/docs/user-guide/gafaelfawringress.rst
+++ b/docs/user-guide/gafaelfawringress.rst
@@ -179,6 +179,8 @@ Presumably logging in again will create a token with sufficient remaining lifeti
 Obviously, do not request a minimum lifetime longer than the default token lifetime!
 See :ref:`basic-settings` for more details.
 
+.. _delegate-authorization:
+
 Delegate token in Authorization header
 --------------------------------------
 
@@ -262,6 +264,7 @@ The following headers will be added by Gafaelfawr to the incoming request before
     The username of the authenticated user.
 
 In addition, if a delegated token was requested, it will be sent in the ``X-Auth-Request-Token`` HTTP header as discussed in :ref:`delegated-tokens`.
+If token delegation via the ``Authorization`` header is requested (see :ref:`delegate-authorization`), the delegated token will also be sent in an ``Authorization`` header with type ``bearer``.
 
 HTTP headers starting with ``X-Auth-Request-*`` are reserved for Gafaelfawr.
 More headers may be added in the future.

--- a/docs/user-guide/ingress-overview.rst
+++ b/docs/user-guide/ingress-overview.rst
@@ -20,11 +20,14 @@ If the user's authentication is syntactically invalid, Gafaelfawr will still ret
 See :ref:`error-handling` for more details.
 
 If the user is authenticated and authorized, Gafaelfawr will return a 200 response with some additional headers containing information about the user and (optionally) a delegated token.
+See :ref:`auth-headers` for the complete list.
 NGINX will then send the user's HTTP request along to the protected service, including those headers in the request.
 
-Gafaelfawr-protected services cannot return a full 403 response to a client.
-If they return a 403 error, the client will receive a 403 error, but the body of the response will be lost, as will any ``WWW-Authenticate`` header.
-This is an unfortunate side effect of the limitations of the NGINX ``auth_request`` module.
+.. caution::
+
+   Gafaelfawr-protected services cannot return a full 403 response to a client.
+   If they return a 403 error, the client will receive a response with the 403 HTTP status, but the body of the response will be lost, as will any ``WWW-Authenticate`` header.
+   This is an unfortunate side effect of the limitations of the NGINX ``auth_request`` module.
 
 .. _header-filtering:
 


### PR DESCRIPTION
Mention setting a custom Authorization header when delegating tokens that way in the guide to request headers, reference the request header guide in the overview of ingresses, and promote the problem with application-returned 403 responses to a caution.