### PR TITLE
DM-45858: Cap Gafaelfawr Kopf workers at five

### DIFF
--- a/changelog.d/20240820_162506_rra_DM_45858.md
+++ b/changelog.d/20240820_162506_rra_DM_45858.md
@@ -1,0 +1,3 @@
+### Bug fixes
+
+- Cap the Kubernetes operator worker limit at 5 to avoid overwhelming the API server.

--- a/src/gafaelfawr/operator/startup.py
+++ b/src/gafaelfawr/operator/startup.py
@@ -47,6 +47,10 @@ async def startup(
     settings.watching.server_timeout = KUBERNETES_WATCH_TIMEOUT
     settings.watching.client_timeout = KUBERNETES_WATCH_TIMEOUT + 60
 
+    # Only run at most five workers at a time. Nothing the Gafaelfawr operator
+    # does will be that urgent and we don't want to overwhelm the API server.
+    settings.batching.worker_limit = 5
+
     config = await config_dependency()
     await initialize_kubernetes()
 


### PR DESCRIPTION
Follow recommendations from a Reddit comment linked in the Kopf documentation to cap the worker limit at five. We do want to create Ingress objects in a timely fashion because we use them for labs, but it doesn't need to be immediate and we don't want to overwhelm the API server.