### PR TITLE
DM-45858: Add service parameter to the auth endpoint

### DIFF
--- a/changelog.d/20240821_140900_rra_DM_45858.md
+++ b/changelog.d/20240821_140900_rra_DM_45858.md
@@ -1,0 +1,3 @@
+### New features
+
+- `GafaelfawrIngress` now accepts a `service` parameter at the top level of the configuration and uses that to tag authentication metrics by service. This corresponds to the `service` query parameter to the `/auth` route. If `delegate_to` is also set (`config.delegate.internal.service` in `GafaelfawrIngress`), it must match the value of `service`. This parameter is currently optional but will eventually become mandatory.

--- a/crds/ingress.yaml
+++ b/crds/ingress.yaml
@@ -179,6 +179,13 @@ spec:
                             - true
                       required:
                         - anonymous
+                service:
+                  type: string
+                  description: >-
+                    The name of the service corresponding to this ingress,
+                    used for metrics reporting. When delegating internal
+                    tokens, this must match config.delegate.internal.service.
+                    This attribute will be required in the future.
                 username:
                   type: string
                   description: >-

--- a/docs/_rst_epilog.rst
+++ b/docs/_rst_epilog.rst
@@ -8,7 +8,7 @@
 .. _pre-commit: https://pre-commit.com
 .. _pytest: https://docs.pytest.org/en/latest/
 .. _RFC 2307bis: https://datatracker.ietf.org/doc/html/draft-howard-rfc2307bis-02
-.. _Ruff: https://beta.ruff.rs/docs/
+.. _Ruff: https://docs.astral.sh/ruff/
 .. _Safir: https://safir.lsst.io/
 .. _scriv: https://scriv.readthedocs.io/en/latest/
 .. _semver: https://semver.org/

--- a/docs/dev/release.rst
+++ b/docs/dev/release.rst
@@ -6,7 +6,7 @@ This page gives an overview of how Gafaelfawr releases are made.
 This information is only useful for maintainers.
 
 Gafaelfawr's releases are largely automated through GitHub Actions (see the `ci.yaml`_ workflow file for details).
-When a semantic version tag is pushed to GitHub, Gafaelfawr Docker images are published on `GitHub <https://github.com/orgs/lsst-sqre/packages?repo_name=gafaelfawr>`__ and `Docker Hub <https://hub.docker.com/repository/docker/lsstsqre/gafaelfawr>`__ with that version.
+When a semantic version tag is pushed to GitHub, Gafaelfawr Docker images are published on `GitHub <https://github.com/orgs/lsst-sqre/packages?repo_name=gafaelfawr>`__ with that version.
 
 .. _`ci.yaml`: https://github.com/lsst-sqre/gafaelfawr/blob/main/.github/workflows/ci.yaml
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,19 +111,17 @@ warn_untyped_fields = true
 [tool.pytest.ini_options]
 asyncio_mode = "strict"
 filterwarnings = [
-    # Google modules call a deprecated pkg_resources API.
-    "ignore:pkg_resources is deprecated as an API:DeprecationWarning",
-    "ignore:.*pkg_resources\\.declare_namespace:DeprecationWarning",
     # Google modules use PyType_Spec in a deprecated way.
     "ignore:Type google\\..*metaclass.* custom tp_new:DeprecationWarning",
-    # dateutil uses a deprecated datetime function.
-    "ignore:datetime.datetime.utcfromtimestamp:DeprecationWarning:dateutil.*",
-    # Bug in kopf
-    "ignore:.*require all values to be sortable:DeprecationWarning:kopf.*",
+    # Bug in seleniumwire.
+    "ignore:.*X509Extension support in pyOpenSSL:DeprecationWarning",
+    # Some sphinxcontrib package and seleniumwire use pkg_resources.
+    "ignore:pkg_resources is deprecated as an API:DeprecationWarning",
+    "ignore:.*pkg_resources\\.declare_namespace:DeprecationWarning",
 ]
 # The python_files setting is not for test detection (pytest will pick up any
 # test files named *_test.py without this setting) but to enable special
-# assert processing in any non-test supporting files under tests.  We
+# assert processing in any non-test supporting files under tests. We
 # conventionally put test support functions under tests.support and may
 # sometimes use assert in test fixtures in conftest.py, and pytest only
 # enables magical assert processing (showing a full diff on assert failures

--- a/src/gafaelfawr/exceptions.py
+++ b/src/gafaelfawr/exceptions.py
@@ -35,6 +35,7 @@ __all__ = [
     "InvalidRequestError",
     "InvalidReturnURLError",
     "InvalidScopesError",
+    "InvalidServiceError",
     "InvalidTokenClaimsError",
     "InvalidTokenError",
     "KubernetesError",
@@ -173,6 +174,15 @@ class InvalidScopesError(InputValidationError):
 
     def __init__(self, message: str) -> None:
         super().__init__(message, ErrorLocation.body, ["scopes"])
+
+
+class InvalidServiceError(InputValidationError):
+    """The ``service`` parameter was set to an invalid value."""
+
+    error = "invalid_service"
+
+    def __init__(self, message: str) -> None:
+        super().__init__(message, ErrorLocation.query, ["delegate_to"])
 
 
 class NoScopesError(InputValidationError):

--- a/tests/data/kubernetes/input/ingresses.yaml
+++ b/tests/data/kubernetes/input/ingresses.yaml
@@ -7,6 +7,7 @@ config:
   baseUrl: "https://foo.example.com"
   scopes:
     all: ["read:all"]
+  service: tap
 template:
   metadata:
     name: small

--- a/tests/data/kubernetes/output/ingresses.yaml
+++ b/tests/data/kubernetes/output/ingresses.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     nginx.ingress.kubernetes.io/auth-method: GET
     nginx.ingress.kubernetes.io/auth-response-headers: "Authorization,Cookie,X-Auth-Request-Email,X-Auth-Request-Token,X-Auth-Request-User"
-    nginx.ingress.kubernetes.io/auth-url: "https://foo.example.com/auth?scope=read%3Aall"
+    nginx.ingress.kubernetes.io/auth-url: "https://foo.example.com/auth?scope=read%3Aall&service=tap"
     nginx.ingress.kubernetes.io/configuration-snippet: |
       {snippet}
   creationTimestamp: {any}

--- a/tests/handlers/auth_test.py
+++ b/tests/handlers/auth_test.py
@@ -214,7 +214,7 @@ async def test_success(client: AsyncClient, factory: Factory) -> None:
 
     r = await client.get(
         "/auth",
-        params={"scope": "exec:admin"},
+        params={"scope": "exec:admin", "service": "example"},
         headers={"Authorization": f"Bearer {token_data.token}"},
     )
     assert r.status_code == 200
@@ -311,6 +311,7 @@ async def test_internal(client: AsyncClient, factory: Factory) -> None:
         "/auth",
         params={
             "scope": "exec:admin",
+            "service": "a-service",
             "delegate_to": "a-service",
             "delegate_scope": " read:some  ,read:all  ",
         },
@@ -441,6 +442,19 @@ async def test_internal_errors(
         params={
             "scope": "read:some",
             "notebook": "true",
+            "delegate_to": "a-service",
+            "delegate_scope": "read:some",
+        },
+        headers={"Authorization": f"Bearer {token_data.token}"},
+    )
+    assert r.status_code == 422
+
+    # If set, service must match delegate_to.
+    r = await client.get(
+        "/auth",
+        params={
+            "scope": "read:some",
+            "service": "b-service",
             "delegate_to": "a-service",
             "delegate_scope": "read:some",
         },

--- a/tests/operator/ingress_test.py
+++ b/tests/operator/ingress_test.py
@@ -78,9 +78,13 @@ async def test_replace(
         )
         await asyncio.sleep(1)
 
+        expected_url = (
+            "https://foo.example.com/auth?scope=read%3Aall&service=tap"
+            "&auth_type=basic"
+        )
         expected["metadata"]["annotations"][
             "nginx.ingress.kubernetes.io/auth-url"
-        ] = "https://foo.example.com/auth?scope=read%3Aall&auth_type=basic"
+        ] = expected_url
         await assert_resources_match(api_client, [expected])
         status.message = "Ingress was updated"
         status.reason = StatusReason.Updated
@@ -105,9 +109,13 @@ async def test_replace(
         )
         await asyncio.sleep(1)
 
+        expected_url = (
+            "https://foo.example.com/auth?scope=read%3Aall&service=tap"
+            "&auth_type=bearer"
+        )
         expected["metadata"]["annotations"][
             "nginx.ingress.kubernetes.io/auth-url"
-        ] = "https://foo.example.com/auth?scope=read%3Aall&auth_type=bearer"
+        ] = expected_url
         expected["metadata"]["annotations"][
             "nginx.ingress.kubernetes.io/auth-signin"
         ] = "https://foo.example.com/login"


### PR DESCRIPTION
Add a top-level service configuration attribute to GafaelfawrIngress and a service parameter to the auth endpoint. Use this instead of delegate_to for logging. This is currently optional but will become mandatory in the future.

If internal token delegation is enabled in GafaelfawrIngress, the value of the service attribute in the delegation configuration must match the top-level service attribute. The service attribute inside the delegation configuration will be removed in the future.

If service and delegate_to are set as parameters to the auth endpoint, they must have the same values.