### PR TITLE
DM-46019: Switch to new documenteer REST API method

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,6 +3,9 @@
 ui/.cache/
 ui/node_modules/
 
+# VSCode
+.vscode/
+
 # Everything below this point is a copy of .gitignore.
 
 # Byte-compiled / optimized / DLL files
@@ -77,8 +80,8 @@ instance/
 
 # Sphinx documentation
 docs/_build/
-docs/api/
-docs/_static/*.png
+docs/_static/openapi.json
+docs/dev/internals/
 
 # PyBuilder
 target/
@@ -142,9 +145,5 @@ dmypy.json
 # pytype static type analyzer
 .pytype/
 
-# Emacs temporary files
-.#*
-\#*#
-
-# Modified to set up the local development server.
-/examples/secrets/github-client-secret
+# macOS
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -69,10 +69,9 @@ instance/
 .scrapy
 
 # Sphinx documentation
-/docs/_build/
-/docs/_static/openapi.json
-/docs/_static/*.png
-/docs/dev/internals/
+docs/_build/
+docs/_static/openapi.json
+docs/dev/internals/
 
 # PyBuilder
 target/
@@ -136,9 +135,5 @@ dmypy.json
 # pytype static type analyzer
 .pytype/
 
-# Emacs temporary files
-.#*
-\#*#
-
-# Modified to set up the local development server.
-/examples/secrets/github-client-secret
+# macOS
+.DS_Store

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -2,9 +2,4 @@
 REST API
 ########
 
-Once Gafaelfawr is installed, API documentation is available at ``/auth/docs`` and ``/auth/redoc``.
-The latter provides somewhat more detailed information.
-
-You can view a pregenerated version of the Redoc documentation for the current development version of Gafaelfawr by following the link below.
-
-`REST API <rest.html>`__
+This is a stub page for the API.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -9,15 +9,3 @@ exclude_patterns = [
     "_rst_epilog.rst",
     "_templates/**",
 ]
-redoc = [
-    {
-        "name": "REST API",
-        "page": "rest",
-        "spec": "_static/openapi.json",
-        "embed": True,
-        "opts": {"hide-hostname": True},
-    }
-]
-redoc_uri = (
-    "https://cdn.jsdelivr.net/npm/redoc@next/bundles/redoc.standalone.js"
-)

--- a/docs/documenteer.toml
+++ b/docs/documenteer.toml
@@ -2,6 +2,14 @@
 title = "Gafaelfawr"
 copyright = "2020-2022 Association of Universities for Research in Astronomy, Inc. (AURA)"
 
+[project.openapi]
+openapi_path = "_static/openapi.json"
+doc_path = "api"
+
+[project.openapi.generator]
+function = "gafaelfawr.main:create_openapi"
+keyword_args = {add_back_link = true}
+
 [project.python]
 package = "gafaelfawr"
 

--- a/src/gafaelfawr/cli.py
+++ b/src/gafaelfawr/cli.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import asyncio
-import json
 import os
 import subprocess
 import sys
@@ -15,7 +14,6 @@ import structlog
 import uvicorn
 from alembic.config import Config
 from cryptography.fernet import Fernet
-from fastapi.openapi.utils import get_openapi
 from safir.asyncio import run_with_asyncio
 from safir.click import display_help
 from safir.database import create_database_engine
@@ -30,7 +28,7 @@ from .database import (
 from .dependencies.config import config_dependency
 from .factory import Factory
 from .keypair import RSAKeyPair
-from .main import create_app
+from .main import create_openapi
 from .metrics import StateMetrics
 from .models.token import Token
 from .schema import Base
@@ -257,22 +255,12 @@ async def maintenance(*, config_path: Path | None) -> None:
 )
 def openapi_schema(*, add_back_link: bool, output: Path | None) -> None:
     """Generate the OpenAPI schema."""
-    app = create_app(load_config=False, validate_schema=False)
-    description = app.description
-    if add_back_link:
-        description += "\n\n[Return to Gafaelfawr documentation](api.html)."
-    schema = get_openapi(
-        title=app.title,
-        description=description,
-        version=app.version,
-        routes=app.routes,
-    )
+    schema = create_openapi(add_back_link=add_back_link)
     if output:
         output.parent.mkdir(exist_ok=True)
-        with output.open("w") as f:
-            json.dump(schema, f)
+        output.write_text(schema)
     else:
-        json.dump(schema, sys.stdout)
+        sys.stdout.write(schema)
 
 
 @main.command()

--- a/tox.ini
+++ b/tox.ini
@@ -69,7 +69,6 @@ commands =
     rm -rf docs/dev/internals
     # https://github.com/sphinx-contrib/redoc/issues/48
     rm -f docs/_build/html/_static/redoc.js
-    gafaelfawr openapi-schema --add-back-link --output docs/_static/openapi.json
     sphinx-build -W --keep-going -n -T -b html -d {envtmpdir}/doctrees docs docs/_build/html
 
 [testenv:docs-linkcheck]


### PR DESCRIPTION
Use the new documenteer method for generating the REST API documentation rather than building openapi.json inside of tox.

Resync .dockerignore and .gitignore with the package templates and remove some old things that are no longer needed.