### PR TITLE
DM-46034: Remove test for top-level gafaelfawr module

### DIFF
--- a/tests/gafaelfawr_test.py
+++ b/tests/gafaelfawr_test.py
@@ -1,7 +1,0 @@
-"""Tests for gafaelfawr, the top-level import."""
-
-import gafaelfawr
-
-
-def test_version() -> None:
-    assert isinstance(gafaelfawr.__version__, str)


### PR DESCRIPTION
This was included for completeness but we never import the top-level module and there's no reason to test its version behavior.