### PR TITLE
DM-46034: Add a test that the database schema hasn't changed

### DIFF
--- a/changelog.d/20240911_155549_rra_DM_46034a.md
+++ b/changelog.d/20240911_155549_rra_DM_46034a.md
@@ -1,0 +1,3 @@
+### New features
+
+- Add new command `gafaelfawr generate-schema`, which generates the SQL required to create the Gafaelfawr database schema.

--- a/docs/dev/development.rst
+++ b/docs/dev/development.rst
@@ -283,6 +283,16 @@ You must have Docker running locally on your system and have the :command:`docke
 
       docker-compose -f alembic/docker-compose.yaml down
 
+#. Generate and save the new schema:
+
+   .. prompt:: bash
+
+      tox run -e gafaelfawr -- generate-schema -o tests/data/schemas/<version>
+
+   Replace ``<version>`` with the version of the Gafaelfawr release that will contain this schema version.
+   Then update the version in :file:`tests/support/constants.py` to match that new schema version.
+   This will update the test that ensures that there are no changes to the Gafaelfawr schema definition that would affect the SQL schema.
+
 Building documentation
 ======================
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -170,8 +170,11 @@ extend = "ruff-shared.toml"
 
 [tool.ruff.lint.extend-per-file-ignores]
 "alembic/**" = [
-    "INP001",  # Alembic files are magical
-    "D103",    # no docstrings for Alembic migrations
+    "INP001",   # Alembic files are magical
+    "D103",     # no docstrings for Alembic migrations
+]
+"tests/**" = [
+    "ASYNC221", # useful to run subprocess in async tests for Alembic
 ]
 
 [tool.ruff.lint.isort]

--- a/src/gafaelfawr/cli.py
+++ b/src/gafaelfawr/cli.py
@@ -21,6 +21,7 @@ from safir.slack.blockkit import SlackMessage
 from sqlalchemy import text
 
 from .database import (
+    generate_schema_sql,
     initialize_gafaelfawr_database,
     is_database_current,
     is_database_initialized,
@@ -37,6 +38,7 @@ __all__ = [
     "audit",
     "delete_all_data",
     "generate_key",
+    "generate_schema",
     "generate_token",
     "help",
     "init",
@@ -159,6 +161,32 @@ def generate_key() -> None:
     """
     keypair = RSAKeyPair.generate()
     sys.stdout.write(keypair.private_key_as_pem().decode())
+
+
+@main.command()
+@click.option(
+    "--config-path",
+    envvar="GAFAELFAWR_CONFIG_PATH",
+    type=click.Path(path_type=Path),
+    default=None,
+    help="Application configuration file.",
+)
+@click.option(
+    "--output",
+    default=None,
+    type=click.Path(path_type=Path),
+    help="Output path (output to stdout if not given).",
+)
+def generate_schema(*, config_path: Path | None, output: Path | None) -> None:
+    """Generate SQL to create the Gafaelfawr database schema."""
+    if config_path:
+        config_dependency.set_config_path(config_path)
+    config = config_dependency.config()
+    schema = generate_schema_sql(config)
+    if output:
+        output.write_text(schema)
+    else:
+        sys.stdout.write(schema)
 
 
 @main.command()

--- a/src/gafaelfawr/dependencies/config.py
+++ b/src/gafaelfawr/dependencies/config.py
@@ -31,6 +31,11 @@ class ConfigDependency:
         """Load the configuration if necessary and return it."""
         return self.config()
 
+    @property
+    def config_path(self) -> Path:
+        """Path to the configuration file."""
+        return self._config_path
+
     def config(self) -> Config:
         """Load the configuration if necessary and return it.
 

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -170,6 +170,14 @@ def test_generate_key() -> None:
     assert "-----BEGIN PRIVATE KEY-----" in result.output
 
 
+def test_generate_schema() -> None:
+    runner = CliRunner()
+    result = runner.invoke(main, ["generate-schema"], catch_exceptions=False)
+
+    assert result.exit_code == 0
+    assert "CREATE TABLE" in result.output
+
+
 def test_generate_session_secret() -> None:
     runner = CliRunner()
     result = runner.invoke(

--- a/tests/data/schemas/10.0.0
+++ b/tests/data/schemas/10.0.0
@@ -1,0 +1,95 @@
+CREATE TYPE adminchange AS ENUM ('add', 'remove');
+CREATE TYPE tokentype AS ENUM ('session', 'user', 'notebook', 'internal', 'service', 'oidc');
+CREATE TYPE tokenchange AS ENUM ('create', 'revoke', 'expire', 'edit');
+
+CREATE TABLE admin (
+	username VARCHAR(64) NOT NULL,
+	PRIMARY KEY (username)
+)
+
+;
+
+CREATE TABLE admin_history (
+	id SERIAL NOT NULL,
+	username VARCHAR(64) NOT NULL,
+	action adminchange NOT NULL,
+	actor VARCHAR(64) NOT NULL,
+	ip_address INET NOT NULL,
+	event_time TIMESTAMP WITHOUT TIME ZONE NOT NULL,
+	PRIMARY KEY (id)
+)
+
+;
+CREATE INDEX admin_history_by_time ON admin_history (event_time, id);
+
+CREATE TABLE token (
+	token VARCHAR(64) COLLATE "C" NOT NULL,
+	username VARCHAR(64) NOT NULL,
+	token_type tokentype NOT NULL,
+	token_name VARCHAR(64),
+	scopes VARCHAR(512) NOT NULL,
+	service VARCHAR(64),
+	created TIMESTAMP WITHOUT TIME ZONE NOT NULL,
+	last_used TIMESTAMP WITHOUT TIME ZONE,
+	expires TIMESTAMP WITHOUT TIME ZONE,
+	PRIMARY KEY (token),
+	UNIQUE (username, token_name)
+)
+
+;
+CREATE INDEX token_by_username ON token (username, token_type);
+
+CREATE TABLE token_auth_history (
+	id SERIAL NOT NULL,
+	token VARCHAR(64) NOT NULL,
+	username VARCHAR(64) NOT NULL,
+	token_type tokentype NOT NULL,
+	token_name VARCHAR(64),
+	parent VARCHAR(64),
+	scopes VARCHAR(512),
+	service VARCHAR(64),
+	ip_address INET,
+	event_time TIMESTAMP WITHOUT TIME ZONE NOT NULL,
+	PRIMARY KEY (id)
+)
+
+;
+CREATE INDEX token_auth_history_by_username ON token_auth_history (username, event_time, id);
+CREATE INDEX token_auth_history_by_time ON token_auth_history (event_time, id);
+CREATE INDEX token_auth_history_by_token ON token_auth_history (token, event_time, id);
+
+CREATE TABLE token_change_history (
+	id SERIAL NOT NULL,
+	token VARCHAR(64) NOT NULL,
+	username VARCHAR(64) NOT NULL,
+	token_type tokentype NOT NULL,
+	token_name VARCHAR(64),
+	parent VARCHAR(64),
+	scopes VARCHAR(512) NOT NULL,
+	service VARCHAR(64),
+	expires TIMESTAMP WITHOUT TIME ZONE,
+	actor VARCHAR(64),
+	action tokenchange NOT NULL,
+	old_token_name VARCHAR(64),
+	old_scopes VARCHAR(512),
+	old_expires TIMESTAMP WITHOUT TIME ZONE,
+	ip_address INET,
+	event_time TIMESTAMP WITHOUT TIME ZONE NOT NULL,
+	PRIMARY KEY (id)
+)
+
+;
+CREATE INDEX token_change_history_by_time ON token_change_history (event_time, id);
+CREATE INDEX token_change_history_by_username ON token_change_history (username, event_time, id);
+CREATE INDEX token_change_history_by_token ON token_change_history (token, event_time, id);
+
+CREATE TABLE subtoken (
+	child VARCHAR(64) NOT NULL,
+	parent VARCHAR(64),
+	PRIMARY KEY (child),
+	FOREIGN KEY(child) REFERENCES token (token) ON DELETE CASCADE,
+	FOREIGN KEY(parent) REFERENCES token (token) ON DELETE SET NULL
+)
+
+;
+CREATE INDEX subtoken_by_parent ON subtoken (parent);

--- a/tests/database_test.py
+++ b/tests/database_test.py
@@ -1,0 +1,47 @@
+"""Tests for the Gafaelfawr database schema."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+
+import pytest
+from alembic.config import Config as AlembicConfig
+from alembic.runtime.migration import MigrationContext
+from alembic.script import ScriptDirectory
+from sqlalchemy import Connection
+from sqlalchemy.ext.asyncio import AsyncEngine
+
+from gafaelfawr.config import Config
+from gafaelfawr.dependencies.config import config_dependency
+
+from .support.constants import CURRENT_SCHEMA
+from .support.database import create_old_database, drop_database
+
+
+@pytest.mark.asyncio
+async def test_schema(config: Config, engine: AsyncEngine) -> None:
+    """Test for any unmanaged schema changes.
+
+    Compare the current database schema in its SQLAlchemy ORM form against a
+    dump of the SQL generated from the last known Alembic migration and ensure
+    that Alembic doesn't detect any schema changes.
+    """
+    await drop_database(engine)
+    await create_old_database(config, engine, CURRENT_SCHEMA)
+    alembic_config = AlembicConfig("alembic.ini")
+    alembic_scripts = ScriptDirectory.from_config(alembic_config)
+    current_head = alembic_scripts.get_current_head()
+    assert current_head
+
+    def set_version(connection: Connection) -> None:
+        context = MigrationContext.configure(connection)
+        context.stamp(alembic_scripts, current_head)
+
+    async with engine.begin() as connection:
+        await connection.run_sync(set_version)
+    env = {
+        **os.environ,
+        "GAFAELFAWR_CONFIG_PATH": str(config_dependency.config_path),
+    }
+    subprocess.run(["alembic", "check"], check=True, env=env)

--- a/tests/support/constants.py
+++ b/tests/support/constants.py
@@ -2,6 +2,15 @@
 
 from gafaelfawr.keypair import RSAKeyPair
 
+__all__ = [
+    "CURRENT_SCHEMA",
+    "TEST_KEYPAIR",
+    "TEST_HOSTNAME",
+]
+
+CURRENT_SCHEMA = "10.0.0"
+"""Most recent saved schema version for schema compatibility tests."""
+
 TEST_HOSTNAME = "example.com"
 """The hostname used in ASGI requests to the application."""
 


### PR DESCRIPTION
Add a new test that uses `alembic check` to ensure that the database schema hasn't changed.

To support maintaining the data files used by that test, add a new `gafaelfawr generate-schema` command that dumps the SQL commands required to generate the current schema. Document using that command to update the most recent schema in the test suite after adding a new schema migration.