### PR TITLE
DM-46034: Convert to the new SQLAlchemy ORM syntax

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ dependencies = [
     "pyyaml",
     "redis>=4.2.0",
     "safir[db,kubernetes]>=6.2.0",
-    "sqlalchemy",
+    "sqlalchemy>=2.0.0",
     "structlog",
 ]
 dynamic = ["version"]

--- a/src/gafaelfawr/schema/admin.py
+++ b/src/gafaelfawr/schema/admin.py
@@ -6,7 +6,8 @@ group-based authorization system up and running.
 
 from __future__ import annotations
 
-from sqlalchemy import Column, String
+from sqlalchemy import String
+from sqlalchemy.orm import Mapped, mapped_column
 
 from .base import Base
 
@@ -18,4 +19,4 @@ class Admin(Base):
 
     __tablename__ = "admin"
 
-    username = Column(String(64), primary_key=True)
+    username: Mapped[str] = mapped_column(String(64), primary_key=True)

--- a/src/gafaelfawr/schema/admin_history.py
+++ b/src/gafaelfawr/schema/admin_history.py
@@ -8,8 +8,9 @@ from __future__ import annotations
 
 from datetime import datetime
 
-from sqlalchemy import Column, DateTime, Enum, Index, Integer, String
+from sqlalchemy import Index, String
 from sqlalchemy.dialects import postgresql
+from sqlalchemy.orm import Mapped, mapped_column
 
 from ..models.history import AdminChange
 from .base import Base
@@ -22,13 +23,13 @@ class AdminHistory(Base):
 
     __tablename__ = "admin_history"
 
-    id: int = Column(Integer, primary_key=True)
-    username: str = Column(String(64), nullable=False)
-    action: AdminChange = Column(Enum(AdminChange), nullable=False)
-    actor: str = Column(String(64), nullable=False)
-    ip_address: str = Column(
-        String(64).with_variant(postgresql.INET, "postgresql"), nullable=False
+    id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
+    username: Mapped[str] = mapped_column(String(64))
+    action: Mapped[AdminChange]
+    actor: Mapped[str] = mapped_column(String(64))
+    ip_address: Mapped[str] = mapped_column(
+        String(64).with_variant(postgresql.INET, "postgresql")
     )
-    event_time: datetime = Column(DateTime, nullable=False)
+    event_time: Mapped[datetime]
 
     __table_args__ = (Index("admin_history_by_time", "event_time", "id"),)

--- a/src/gafaelfawr/schema/base.py
+++ b/src/gafaelfawr/schema/base.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
-from sqlalchemy.orm import declarative_base
+from sqlalchemy.orm import DeclarativeBase
 
 __all__ = ["Base"]
 
-Base = declarative_base()
+
+class Base(DeclarativeBase):
+    """Declarative base for the Gafaelfawr database schema."""

--- a/src/gafaelfawr/schema/subtoken.py
+++ b/src/gafaelfawr/schema/subtoken.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from sqlalchemy import Column, ForeignKey, Index, String
+from sqlalchemy import ForeignKey, Index, String
+from sqlalchemy.orm import Mapped, mapped_column
 
 from .base import Base
 
@@ -14,12 +15,12 @@ class Subtoken(Base):
 
     __tablename__ = "subtoken"
 
-    child: str = Column(
+    child: Mapped[str] = mapped_column(
         String(64),
         ForeignKey("token.token", ondelete="CASCADE"),
         primary_key=True,
     )
-    parent: str | None = Column(
+    parent: Mapped[str | None] = mapped_column(
         String(64), ForeignKey("token.token", ondelete="SET NULL")
     )
 

--- a/src/gafaelfawr/schema/token.py
+++ b/src/gafaelfawr/schema/token.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 from datetime import datetime
 
-from sqlalchemy import Column, DateTime, Enum, Index, String, UniqueConstraint
+from sqlalchemy import Index, String, UniqueConstraint
+from sqlalchemy.orm import Mapped, mapped_column
 
 from ..models.token import TokenType
 from .base import Base
@@ -17,15 +18,17 @@ class Token(Base):
 
     __tablename__ = "token"
 
-    token: str = Column(String(64, collation="C"), primary_key=True)
-    username: str = Column(String(64), nullable=False)
-    token_type: TokenType = Column(Enum(TokenType), nullable=False)
-    token_name: str | None = Column(String(64))
-    scopes: str = Column(String(512), nullable=False)
-    service: str | None = Column(String(64))
-    created: datetime = Column(DateTime, nullable=False)
-    last_used: datetime | None = Column(DateTime)
-    expires: datetime | None = Column(DateTime)
+    token: Mapped[str] = mapped_column(
+        String(64, collation="C"), primary_key=True
+    )
+    username: Mapped[str] = mapped_column(String(64))
+    token_type: Mapped[TokenType]
+    token_name: Mapped[str | None] = mapped_column(String(64))
+    scopes: Mapped[str] = mapped_column(String(512))
+    service: Mapped[str | None] = mapped_column(String(64))
+    created: Mapped[datetime]
+    last_used: Mapped[datetime | None]
+    expires: Mapped[datetime | None]
 
     __table_args__ = (
         UniqueConstraint("username", "token_name"),

--- a/src/gafaelfawr/schema/token_auth_history.py
+++ b/src/gafaelfawr/schema/token_auth_history.py
@@ -4,8 +4,9 @@ from __future__ import annotations
 
 from datetime import datetime
 
-from sqlalchemy import Column, DateTime, Enum, Index, Integer, String
+from sqlalchemy import Index, String
 from sqlalchemy.dialects import postgresql
+from sqlalchemy.orm import Mapped, mapped_column
 
 from ..models.token import TokenType
 from .base import Base
@@ -18,18 +19,18 @@ class TokenAuthHistory(Base):
 
     __tablename__ = "token_auth_history"
 
-    id: int = Column(Integer, primary_key=True)
-    token: str = Column(String(64), nullable=False)
-    username: str = Column(String(64), nullable=False)
-    token_type: TokenType = Column(Enum(TokenType), nullable=False)
-    token_name: str | None = Column(String(64))
-    parent: str | None = Column(String(64))
-    scopes: str | None = Column(String(512))
-    service: str | None = Column(String(64))
-    ip_address: str | None = Column(
+    id: Mapped[int] = mapped_column(primary_key=True)
+    token: Mapped[str] = mapped_column(String(64))
+    username: Mapped[str] = mapped_column(String(64))
+    token_type: Mapped[TokenType]
+    token_name: Mapped[str | None] = mapped_column(String(64))
+    parent: Mapped[str | None] = mapped_column(String(64))
+    scopes: Mapped[str | None] = mapped_column(String(512))
+    service: Mapped[str | None] = mapped_column(String(64))
+    ip_address: Mapped[str | None] = mapped_column(
         String(64).with_variant(postgresql.INET, "postgresql")
     )
-    event_time: datetime = Column(DateTime, nullable=False)
+    event_time: Mapped[datetime]
 
     __table_args__ = (
         Index("token_auth_history_by_time", "event_time", "id"),

--- a/src/gafaelfawr/schema/token_change_history.py
+++ b/src/gafaelfawr/schema/token_change_history.py
@@ -4,8 +4,9 @@ from __future__ import annotations
 
 from datetime import datetime
 
-from sqlalchemy import Column, DateTime, Enum, Index, Integer, String
+from sqlalchemy import Index, String
 from sqlalchemy.dialects import postgresql
+from sqlalchemy.orm import Mapped, mapped_column
 
 from ..models.history import TokenChange
 from ..models.token import TokenType
@@ -19,24 +20,24 @@ class TokenChangeHistory(Base):
 
     __tablename__ = "token_change_history"
 
-    id: int = Column(Integer, primary_key=True)
-    token: str = Column(String(64), nullable=False)
-    username: str = Column(String(64), nullable=False)
-    token_type: TokenType = Column(Enum(TokenType), nullable=False)
-    token_name: str | None = Column(String(64))
-    parent: str = Column(String(64))
-    scopes: str = Column(String(512), nullable=False)
-    service: str | None = Column(String(64))
-    expires: datetime | None = Column(DateTime)
-    actor: str | None = Column(String(64))
-    action: TokenChange = Column(Enum(TokenChange), nullable=False)
-    old_token_name: str | None = Column(String(64))
-    old_scopes: str | None = Column(String(512))
-    old_expires: datetime | None = Column(DateTime)
-    ip_address: str | None = Column(
+    id: Mapped[int] = mapped_column(primary_key=True)
+    token: Mapped[str] = mapped_column(String(64))
+    username: Mapped[str] = mapped_column(String(64))
+    token_type: Mapped[TokenType]
+    token_name: Mapped[str | None] = mapped_column(String(64))
+    parent: Mapped[str | None] = mapped_column(String(64))
+    scopes: Mapped[str] = mapped_column(String(512))
+    service: Mapped[str | None] = mapped_column(String(64))
+    expires: Mapped[datetime | None]
+    actor: Mapped[str | None] = mapped_column(String(64))
+    action: Mapped[TokenChange]
+    old_token_name: Mapped[str | None] = mapped_column(String(64))
+    old_scopes: Mapped[str | None] = mapped_column(String(512))
+    old_expires: Mapped[datetime | None]
+    ip_address: Mapped[str | None] = mapped_column(
         String(64).with_variant(postgresql.INET, "postgresql")
     )
-    event_time: datetime = Column(DateTime, nullable=False)
+    event_time: Mapped[datetime]
 
     __table_args__ = (
         Index("token_change_history_by_time", "event_time", "id"),


### PR DESCRIPTION
Use the new inheritance-based `DeclarativeBase` and the new field mapping syntax instead of `Column`. Rely on type annotations for schema information where possible.