### PR TITLE
DM-46034: Update Alembic configuration

### DIFF
--- a/alembic.ini
+++ b/alembic.ini
@@ -6,7 +6,7 @@
 # for settings that are not used here.
 
 [alembic]
-script_location = alembic
+script_location = %(here)s/alembic
 file_template = %%(year)d%%(month).2d%%(day).2d_%%(hour).2d%%(minute).2d_%%(rev)s_%%(slug)s
 prepend_sys_path = .
 timezone = UTC
@@ -16,7 +16,7 @@ version_path_separator = os
 hooks = ruff ruff_format
 ruff.type = exec
 ruff.executable = ruff
-ruff.options = --fix REVISION_SCRIPT_FILENAME
+ruff.options = check --fix REVISION_SCRIPT_FILENAME
 ruff_format.type = exec
 ruff_format.executable = ruff
-ruff_format.options = --format REVISION_SCRIPT_FILENAME
+ruff_format.options = format REVISION_SCRIPT_FILENAME


### PR DESCRIPTION
Find the Alembic scripts relative to `alembic.ini` and fix how Ruff is invoked after creating Alembic migrations.