### PR TITLE
DM-46399: Check that token lifetime is long enough

### DIFF
--- a/changelog.d/20240919_154251_rra_DM_46399.md
+++ b/changelog.d/20240919_154251_rra_DM_46399.md
@@ -1,0 +1,3 @@
+### Bug fixes
+
+- Check that `tokenLifetime` is at least as long as twice the minimum token lifetime.

--- a/src/gafaelfawr/config.py
+++ b/src/gafaelfawr/config.py
@@ -50,7 +50,7 @@ from pydantic_settings import (
 from safir.logging import LogLevel, configure_logging
 from safir.pydantic import EnvAsyncPostgresDsn, EnvRedisDsn, HumanTimedelta
 
-from .constants import SCOPE_REGEX, USERNAME_REGEX
+from .constants import MINIMUM_LIFETIME, SCOPE_REGEX, USERNAME_REGEX
 from .exceptions import InvalidTokenError
 from .keypair import RSAKeyPair
 from .models.token import Token
@@ -991,6 +991,15 @@ class Config(EnvFirstSettings):
         for required in ("admin:token", "user:token"):
             if required not in v:
                 raise ValueError(f"required scope {required} missing")
+        return v
+
+    @field_validator("token_lifetime")
+    @classmethod
+    def _validate_token_lifetime(cls, v: timedelta) -> timedelta:
+        """Ensure the token lifetime is longer than minimal lifetime."""
+        limit = MINIMUM_LIFETIME + MINIMUM_LIFETIME
+        if v < limit:
+            raise ValueError(f"must be longer than {limit.total_seconds}s")
         return v
 
     @model_validator(mode="before")

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -82,6 +82,11 @@ def test_config_invalid_token(monkeypatch: pytest.MonkeyPatch) -> None:
         parse_config(config_path("github"))
 
 
+def test_config_invalid_lifetime() -> None:
+    with pytest.raises(ValidationError, match=r"must be longer than"):
+        parse_config(config_path("bad-lifetime"))
+
+
 def test_config_bad_groups() -> None:
     with pytest.raises(ValidationError, match="Input should be a valid list"):
         parse_config(config_path("bad-groups"))

--- a/tests/data/config/bad-lifetime.yaml
+++ b/tests/data/config/bad-lifetime.yaml
@@ -1,0 +1,15 @@
+# Test too short of a token lifetime.
+
+realm: "example.com"
+slackAlerts: true
+initialAdmins: ["admin"]
+afterLogoutUrl: "https://example.com/landing"
+groupMapping:
+  "exec:admin": ["admin"]
+knownScopes:
+  "admin:token": "token administration"
+  "exec:admin": "admin description"
+  "user:token": "Can create and modify user tokens"
+github:
+  clientId: "some-github-client-id"
+tokenLifetime: "8m"


### PR DESCRIPTION
Check that the configured token lifetime is at least as long as twice the minimum token lifetime so that we don't get weird redirect loops with very short token lifetimes.