### PR TITLE
DM-46399: Rework handling of missing state during login

### DIFF
--- a/changelog.d/20240919_172648_rra_DM_46399.md
+++ b/changelog.d/20240919_172648_rra_DM_46399.md
@@ -1,0 +1,3 @@
+### Bug fixes
+
+- If the user returns from authentication and no longer has login state in their cookie, redirect them to the destination URL without further processing instead of returning an authentication state mismatch error. The most likely cause of this state is that the user authenticated from another browser tab while this authentication is pending, so Gafaelfawr should use their existing token or restart the authentication process.


### PR DESCRIPTION
If the authentication state is missing entirely, not incorrect, during return from authentication, the most likely explanation is that the user attempted multiple simultaneous logins and then finished the authentication in another browser window, thus invalidating the state.

In this case, redirect the user to their destination without further processing. If they did authentication separately, this is the (mostly) correct thing to do; they will go to the authenticated page, although their session might not be as currently as they would like.

If they're not authenticated, this will restart the authentication process with new state, which should be the correct thing to do. There is some risk of a redirect loop, but hopefully we won't go through that loop more than once, so browsers should cope.