### PR TITLE
DM-46399: Make baseUrl optional in GafaelfawrIngress CRD

### DIFF
--- a/crds/ingress.yaml
+++ b/crds/ingress.yaml
@@ -56,8 +56,6 @@ spec:
             config:
               type: object
               description: "Configuration for the ingress to create."
-              required:
-                - baseUrl
               properties:
                 authCacheDuration:
                   type: string

--- a/src/gafaelfawr/models/kubernetes.py
+++ b/src/gafaelfawr/models/kubernetes.py
@@ -271,7 +271,7 @@ class GafaelfawrIngressConfig(BaseModel):
     auth_type: AuthType | None = None
     """Auth type of challenge for 401 responses."""
 
-    base_url: str
+    base_url: str | None = None
     """The base URL for user-facing Gafaelfawr URLs in Ingress annotations."""
 
     delegate: GafaelfawrIngressDelegate | None = None


### PR DESCRIPTION
The base URL is now set in the global Gafaelfawr configuration by default, so baseUrl is now optional. Reflect that in the CRD and the model.