### PR TITLE
DM-46399: Add service of internal tokens to Redis

### DIFF
--- a/src/gafaelfawr/models/token.py
+++ b/src/gafaelfawr/models/token.py
@@ -166,6 +166,18 @@ class TokenBase(BaseModel):
         examples=["session"],
     )
 
+    service: str | None = Field(
+        None,
+        title="Service",
+        description=(
+            "Service to which the token was delegated. Only present for"
+            " internal tokens."
+        ),
+        examples=["some-service"],
+        min_length=1,
+        max_length=64,
+    )
+
     scopes: list[str] = Field(
         ...,
         title="Token scopes",
@@ -211,18 +223,6 @@ class TokenInfo(TokenBase):
         None,
         title="User-given name of the token",
         examples=["laptop token"],
-        min_length=1,
-        max_length=64,
-    )
-
-    service: str | None = Field(
-        None,
-        title="Service",
-        description=(
-            "Service to which the token was delegated.  Only present for"
-            " internal tokens"
-        ),
-        examples=["some-service"],
         min_length=1,
         max_length=64,
     )

--- a/src/gafaelfawr/services/token_cache.py
+++ b/src/gafaelfawr/services/token_cache.py
@@ -238,6 +238,7 @@ class TokenCacheService:
             token=token,
             username=token_data.username,
             token_type=TokenType.internal,
+            service=service,
             scopes=scopes,
             created=created,
             expires=expires,
@@ -263,9 +264,7 @@ class TokenCacheService:
 
         await self._token_redis_store.store_data(data)
         try:
-            await self._token_db_store.add(
-                data, service=service, parent=token_data.token.key
-            )
+            await self._token_db_store.add(data, parent=token_data.token.key)
             await self._token_change_store.add(history_entry)
         except Exception:
             await self._token_redis_store.delete(data.token.key)

--- a/src/gafaelfawr/storage/token.py
+++ b/src/gafaelfawr/storage/token.py
@@ -43,7 +43,6 @@ class TokenDatabaseStore:
         data: TokenData,
         *,
         token_name: str | None = None,
-        service: str | None = None,
         parent: str | None = None,
     ) -> None:
         """Store a new token.
@@ -72,7 +71,7 @@ class TokenDatabaseStore:
             token_type=data.token_type,
             token_name=token_name,
             scopes=",".join(sorted(data.scopes)),
-            service=service,
+            service=data.service,
             created=datetime_to_db(data.created),
             expires=datetime_to_db(data.expires),
         )

--- a/tests/services/oidc_test.py
+++ b/tests/services/oidc_test.py
@@ -141,6 +141,7 @@ async def test_redeem_code(
         "token": access_token.model_dump(),
         "username": token_data.username,
         "token_type": TokenType.oidc,
+        "service": None,
         "scopes": [],
         "created": ANY,
         "expires": int(token_data.expires.timestamp()),


### PR DESCRIPTION
In preparation for exposing service information for internal tokens and using it for authorization decisions, add that data to Redis.