### PR TITLE
DM-46399: Add X-Auth-Request-Service HTTP header

### DIFF
--- a/changelog.d/20240925_110256_rra_DM_46399.md
+++ b/changelog.d/20240925_110256_rra_DM_46399.md
@@ -1,0 +1,3 @@
+### New features
+
+- If a request is authenticated with an internal token, include the service associated with that token in an `X-Auth-Request-Service` header passed to the protected service.

--- a/docs/user-guide/gafaelfawringress.rst
+++ b/docs/user-guide/gafaelfawringress.rst
@@ -255,6 +255,9 @@ The following headers will be added by Gafaelfawr to the incoming request before
 ``X-Auth-Request-Email``
     The email address of the authenticated user, if available.
 
+``X-Auth-Request-Service``
+    If the authenticating token is an internal token issued to a service, the name of the service authenticating on behalf of the user.
+
 ``X-Auth-Request-User``
     The username of the authenticated user.
 

--- a/src/gafaelfawr/constants.py
+++ b/src/gafaelfawr/constants.py
@@ -94,6 +94,7 @@ NGINX_RESPONSE_HEADERS = (
     "Authorization",
     "Cookie",
     "X-Auth-Request-Email",
+    "X-Auth-Request-Service",
     "X-Auth-Request-Token",
     "X-Auth-Request-User",
 )

--- a/src/gafaelfawr/handlers/ingress.py
+++ b/src/gafaelfawr/handlers/ingress.py
@@ -442,19 +442,21 @@ async def build_success_headers(
 
     The following headers may be included:
 
-    X-Auth-Request-Email
-        The email address of the authenticated user, if known.
-    X-Auth-Request-User
-        The username of the authenticated user.
-    X-Auth-Request-Token
-        If requested by ``notebook`` or ``delegate_to``, will be set to the
-        delegated token.
     Authorization
         The input ``Authorization`` headers with any headers containing
         Gafaelfawr tokens stripped.
     Cookie
         The input ``Cookie`` headers with any cookie values containing
         Gafaelfawr tokens stripped.
+    X-Auth-Request-Email
+        The email address of the authenticated user, if known.
+    X-Auth-Request-Service
+        The service associated with the token if one was present.
+    X-Auth-Request-User
+        The username of the authenticated user.
+    X-Auth-Request-Token
+        If requested by ``notebook`` or ``delegate_to``, will be set to the
+        delegated token.
 
     Parameters
     ----------
@@ -500,6 +502,10 @@ async def build_success_headers(
     if user_info.email:
         headers.append(("X-Auth-Request-Email", user_info.email))
 
+    # Add the service of the token if the token is associated with a service.
+    if token_data.service:
+        headers.append(("X-Auth-Request-Service", token_data.service))
+
     # Add the delegated token, if there should be one.
     delegated = await build_delegated_token(context, auth_config, token_data)
     if delegated:
@@ -517,13 +523,11 @@ async def build_success_headers(
     elif "Authorization" in context.request.headers:
         raw_authorizations = context.request.headers.getlist("Authorization")
         authorizations = clean_authorization(raw_authorizations)
-        if authorizations:
-            headers.extend(("Authorization", v) for v in authorizations)
+        headers.extend(("Authorization", v) for v in authorizations)
     if "Cookie" in context.request.headers:
         raw_cookies = context.request.headers.getlist("Cookie")
         cookies = clean_cookies(raw_cookies)
-        if cookies:
-            headers.extend(("Cookie", v) for v in cookies)
+        headers.extend(("Cookie", v) for v in cookies)
 
     return headers
 

--- a/tests/data/kubernetes/output/ingresses.yaml
+++ b/tests/data/kubernetes/output/ingresses.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: {namespace}
   annotations:
     nginx.ingress.kubernetes.io/auth-method: GET
-    nginx.ingress.kubernetes.io/auth-response-headers: "Authorization,Cookie,X-Auth-Request-Email,X-Auth-Request-Token,X-Auth-Request-User"
+    nginx.ingress.kubernetes.io/auth-response-headers: "Authorization,Cookie,X-Auth-Request-Email,X-Auth-Request-Service,X-Auth-Request-Token,X-Auth-Request-User"
     nginx.ingress.kubernetes.io/auth-url: "http://gafaelfawr.gafaelfawr.svc.cluster.local:8080/ingress/auth?scope=read%3Aall&service=tap"
     nginx.ingress.kubernetes.io/configuration-snippet: |
       {snippet}
@@ -46,7 +46,7 @@ metadata:
     nginx.ingress.kubernetes.io/auth-cache-key: "$http_cookie$http_authorization"
     nginx.ingress.kubernetes.io/auth-cache-duration: "200 202 401 5m"
     nginx.ingress.kubernetes.io/auth-method: "GET"
-    nginx.ingress.kubernetes.io/auth-response-headers: "Authorization,Cookie,X-Auth-Request-Email,X-Auth-Request-Token,X-Auth-Request-User"
+    nginx.ingress.kubernetes.io/auth-response-headers: "Authorization,Cookie,X-Auth-Request-Email,X-Auth-Request-Service,X-Auth-Request-Token,X-Auth-Request-User"
     nginx.ingress.kubernetes.io/auth-signin: "https://foo.example.com/login"
     nginx.ingress.kubernetes.io/auth-url: "http://gafaelfawr.gafaelfawr.svc.cluster.local:8080/ingress/auth?scope=read%3Aall&satisfy=any&notebook=true&minimum_lifetime=600"
     nginx.ingress.kubernetes.io/configuration-snippet: |
@@ -91,7 +91,7 @@ metadata:
   namespace: {namespace}
   annotations:
     nginx.ingress.kubernetes.io/auth-method: GET
-    nginx.ingress.kubernetes.io/auth-response-headers: "Authorization,Cookie,X-Auth-Request-Email,X-Auth-Request-Token,X-Auth-Request-User"
+    nginx.ingress.kubernetes.io/auth-response-headers: "Authorization,Cookie,X-Auth-Request-Email,X-Auth-Request-Service,X-Auth-Request-Token,X-Auth-Request-User"
     nginx.ingress.kubernetes.io/auth-url: "http://gafaelfawr.gafaelfawr.svc.cluster.local:8080/ingress/auth?scope=read%3Aall&scope=read%3Asome&delegate_to=some-service&delegate_scope=read%3Aall%2Cread%3Asome&auth_type=basic"
     nginx.ingress.kubernetes.io/configuration-snippet: |
       {snippet}
@@ -129,7 +129,7 @@ metadata:
   namespace: {namespace}
   annotations:
     nginx.ingress.kubernetes.io/auth-method: GET
-    nginx.ingress.kubernetes.io/auth-response-headers: "Authorization,Cookie,X-Auth-Request-Email,X-Auth-Request-Token,X-Auth-Request-User"
+    nginx.ingress.kubernetes.io/auth-response-headers: "Authorization,Cookie,X-Auth-Request-Email,X-Auth-Request-Service,X-Auth-Request-Token,X-Auth-Request-User"
     nginx.ingress.kubernetes.io/auth-url: "http://gafaelfawr.gafaelfawr.svc.cluster.local:8080/ingress/auth?scope=read%3Aall&delegate_to=some-service&delegate_scope=read%3Aall&use_authorization=true"
     nginx.ingress.kubernetes.io/configuration-snippet: |
       add_header "X-Foo" "bar";
@@ -168,7 +168,7 @@ metadata:
   namespace: {namespace}
   annotations:
     nginx.ingress.kubernetes.io/auth-method: GET
-    nginx.ingress.kubernetes.io/auth-response-headers: "Authorization,Cookie,X-Auth-Request-Email,X-Auth-Request-Token,X-Auth-Request-User"
+    nginx.ingress.kubernetes.io/auth-response-headers: "Authorization,Cookie,X-Auth-Request-Email,X-Auth-Request-Service,X-Auth-Request-Token,X-Auth-Request-User"
     nginx.ingress.kubernetes.io/auth-url: "http://gafaelfawr.gafaelfawr.svc.cluster.local:8080/ingress/anonymous"
     some.annotation: foo
   creationTimestamp: {any}
@@ -205,7 +205,7 @@ metadata:
   namespace: {namespace}
   annotations:
     nginx.ingress.kubernetes.io/auth-method: GET
-    nginx.ingress.kubernetes.io/auth-response-headers: "Authorization,Cookie,X-Auth-Request-Email,X-Auth-Request-Token,X-Auth-Request-User"
+    nginx.ingress.kubernetes.io/auth-response-headers: "Authorization,Cookie,X-Auth-Request-Email,X-Auth-Request-Service,X-Auth-Request-Token,X-Auth-Request-User"
     nginx.ingress.kubernetes.io/auth-url: "http://gafaelfawr.gafaelfawr.svc.cluster.local:8080/ingress/auth?scope=read%3Aall&username=some-user"
     nginx.ingress.kubernetes.io/configuration-snippet: |
       {snippet}

--- a/tests/handlers/ingress_test.py
+++ b/tests/handlers/ingress_test.py
@@ -220,6 +220,7 @@ async def test_success(client: AsyncClient, factory: Factory) -> None:
     assert r.status_code == 200
     assert r.headers["X-Auth-Request-User"] == token_data.username
     assert r.headers["X-Auth-Request-Email"] == token_data.email
+    assert "X-Auth-Request-Service" not in r.headers
 
 
 @pytest.mark.asyncio
@@ -350,6 +351,15 @@ async def test_internal(client: AsyncClient, factory: Factory) -> None:
         "gid": token_data.gid,
         "groups": [g.model_dump() for g in token_data.groups],
     }
+
+    r = await client.get(
+        "/ingress/auth",
+        params={"scope": "read:all"},
+        headers={"Authorization": f"Bearer {internal_token}"},
+    )
+    assert r.status_code == 200
+    assert r.headers["X-Auth-Request-Service"] == "a-service"
+    assert r.headers["X-Auth-Request-User"] == token_data.username
 
     # Requesting a token with the same parameters returns the same token.
     r = await client.get(


### PR DESCRIPTION
When the authenticating token is an internal token with an associated service, include an X-Auth-Request-Service header in the response to the ingress, propagated to the incoming request, that includes the name of the associated service.