### PR TITLE
DM-46399: Allow restricting ingresses to services

### DIFF
--- a/changelog.d/20240925_144604_rra_DM_46399.md
+++ b/changelog.d/20240925_144604_rra_DM_46399.md
@@ -1,0 +1,7 @@
+### New features
+
+- Add `config.onlyServices` to `GafaelfawrIngress`, which restricts the ingress to tokens issued to one of the listed services in addition to the other constraints.
+
+### Bug fixes
+
+- Stop including the required scopes in 403 errors when the request was rejected by a username restriction rather than a scope restriction, since the client cannot fix this problem by obtaining different scopes.

--- a/crds/ingress.yaml
+++ b/crds/ingress.yaml
@@ -131,6 +131,15 @@ spec:
                   description: >-
                     Whether to redirect to the login flow if the user is
                     not currently authenticated.
+                onlyServices:
+                  type: array
+                  description: >-
+                    If set, access is restricted to tokens issued to one of
+                    the listed services, in addition to any other access
+                    constraints. Users will not be able to access the ingress
+                    directly with their own tokens.
+                  items:
+                    type: string
                 replace403:
                   type: boolean
                   description: >-

--- a/src/gafaelfawr/models/kubernetes.py
+++ b/src/gafaelfawr/models/kubernetes.py
@@ -280,6 +280,9 @@ class GafaelfawrIngressConfig(BaseModel):
     login_redirect: bool = False
     """Whether to redirect unauthenticated users to the login flow."""
 
+    only_services: list[str] | None = None
+    """If non-empty, restrict to tokens issued by one of the services."""
+
     replace_403: bool = False
     """Whether to generate a custom error response for 403 errors."""
 
@@ -318,6 +321,7 @@ class GafaelfawrIngressConfig(BaseModel):
                 "auth_type",
                 "delegate",
                 "login_redirect",
+                "only_services",
                 "replace_403",
                 "username",
             )
@@ -349,6 +353,7 @@ class GafaelfawrIngressConfig(BaseModel):
             configuration to pass to the Gafaelfawr ``/ingress/auth`` route.
         """
         query = [("scope", s) for s in self.scopes.scopes]
+        query.extend(("only_service", s) for s in self.only_services or [])
         if self.service:
             query.append(("service", self.service))
         if self.scopes.satisfy != Satisfy.ALL:

--- a/tests/data/kubernetes/input/ingresses.yaml
+++ b/tests/data/kubernetes/input/ingresses.yaml
@@ -183,3 +183,31 @@ template:
                   name: something
                   port:
                     name: http
+---
+apiVersion: gafaelfawr.lsst.io/v1alpha1
+kind: GafaelfawrIngress
+metadata:
+  name: service-ingress
+  namespace: {namespace}
+config:
+  scopes:
+    all: ["read:all"]
+  onlyServices:
+    - portal
+    - vo-cutouts
+  service: uws
+template:
+  metadata:
+    name: service
+  spec:
+    rules:
+      - host: foo.example.com
+        http:
+          paths:
+            - path: /foo
+              pathType: Prefix
+              backend:
+                service:
+                  name: something
+                  port:
+                    name: http

--- a/tests/data/kubernetes/output/ingresses.yaml
+++ b/tests/data/kubernetes/output/ingresses.yaml
@@ -235,3 +235,41 @@ spec:
                 port:
                   name: http
 status: {any}
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: service
+  namespace: {namespace}
+  annotations:
+    nginx.ingress.kubernetes.io/auth-method: GET
+    nginx.ingress.kubernetes.io/auth-response-headers: "Authorization,Cookie,X-Auth-Request-Email,X-Auth-Request-Service,X-Auth-Request-Token,X-Auth-Request-User"
+    nginx.ingress.kubernetes.io/auth-url: "http://gafaelfawr.gafaelfawr.svc.cluster.local:8080/ingress/auth?scope=read%3Aall&only_service=portal&only_service=vo-cutouts&service=uws"
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      {snippet}
+  creationTimestamp: {any}
+  generation: {any}
+  managedFields: {any}
+  ownerReferences:
+    - apiVersion: gafaelfawr.lsst.io/v1alpha1
+      blockOwnerDeletion: true
+      controller: true
+      kind: GafaelfawrIngress
+      name: service-ingress
+      uid: {any}
+  resourceVersion: {any}
+  uid: {any}
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: foo.example.com
+      http:
+        paths:
+          - path: /foo
+            pathType: Prefix
+            backend:
+              service:
+                name: something
+                port:
+                  name: http
+status: {any}


### PR DESCRIPTION
Add the concept of a service-only ingress, which in addition to any other authorization requirements also requires the authentication token be a token issued to a particular service. Currently, this means an internal token obtained through a delegation request in its ingress, although in the future this may include other methods of associating a token with the service. The key point is that this will reject authentication directly from users, allowing services to be limited to requests from other services on behalf of users but not allow access from those same users directly.

Update some of the `GafaelfawrIngress` documentation to urge setting `config.service`, mark `config.delegate.internal.service` as deprecated, and otherwise update for recent changes.