### PR TITLE
DM-47148: Use @override annotations where appropriate

### DIFF
--- a/src/gafaelfawr/cache.py
+++ b/src/gafaelfawr/cache.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 import asyncio
 from abc import ABCMeta, abstractmethod
 from types import TracebackType
-from typing import Generic, Literal, TypeVar
+from typing import Generic, Literal, TypeVar, override
 
 from cachetools import LRUCache, TTLCache
 
@@ -83,6 +83,7 @@ class IdCache(BaseCache):
         self._cache: LRUCache[str, int] = LRUCache(ID_CACHE_SIZE)
         self._lock = asyncio.Lock()
 
+    @override
     async def clear(self) -> None:
         """Invalidate the cache.
 
@@ -212,6 +213,7 @@ class PerUserCache(BaseCache):
         self._lock = asyncio.Lock()
         self._user_locks: dict[str, asyncio.Lock] = {}
 
+    @override
     async def clear(self) -> None:
         """Invalidate the cache.
 
@@ -285,6 +287,7 @@ class LDAPCache(PerUserCache, Generic[S]):
         """
         return self._cache.get(username)
 
+    @override
     def initialize(self) -> None:
         """Initialize the cache."""
         self._cache = TTLCache(LDAP_CACHE_SIZE, LDAP_CACHE_LIFETIME)
@@ -322,6 +325,7 @@ class TokenCache(PerUserCache):
         self._cache: _LRUTokenCache
         self.initialize()
 
+    @override
     def initialize(self) -> None:
         """Initialize the cache."""
         self._cache = LRUCache(TOKEN_CACHE_SIZE)

--- a/src/gafaelfawr/models/kubernetes.py
+++ b/src/gafaelfawr/models/kubernetes.py
@@ -6,7 +6,7 @@ from abc import ABCMeta, abstractmethod
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta
 from enum import Enum
-from typing import Literal, Self
+from typing import Literal, Self, override
 
 from kubernetes_asyncio.client import (
     V1HTTPIngressPath,
@@ -205,16 +205,19 @@ class GafaelfawrIngressScopesAll(GafaelfawrIngressScopesBase):
     all: list[str]
     """All of these scopes are required to allow access."""
 
+    @override
     @property
     def satisfy(self) -> Satisfy:
         """The authorization satisfy strategy."""
         return Satisfy.ALL
 
+    @override
     @property
     def scopes(self) -> list[str]:
         """List of scopes."""
         return self.all
 
+    @override
     def is_anonymous(self) -> bool:
         """Whether this ingress is anonymous."""
         return False
@@ -226,16 +229,19 @@ class GafaelfawrIngressScopesAny(GafaelfawrIngressScopesBase):
     any: list[str]
     """Any of these scopes is sufficient to allow access."""
 
+    @override
     @property
     def satisfy(self) -> Satisfy:
         """The authorization satisfy strategy."""
         return Satisfy.ANY
 
+    @override
     @property
     def scopes(self) -> list[str]:
         """List of scopes."""
         return self.any
 
+    @override
     def is_anonymous(self) -> bool:
         """Whether this ingress is anonymous."""
         return False
@@ -247,16 +253,19 @@ class GafaelfawrIngressScopesAnonymous(GafaelfawrIngressScopesBase):
     anonymous: Literal[True]
     """Mark this ingress as anonymous."""
 
+    @override
     @property
     def satisfy(self) -> Satisfy:
         """The authorization satisfy strategy."""
         return Satisfy.ANY
 
+    @override
     @property
     def scopes(self) -> list[str]:
         """List of scopes."""
         return []
 
+    @override
     def is_anonymous(self) -> bool:
         """Whether this ingress is anonymous."""
         return True

--- a/src/gafaelfawr/models/state.py
+++ b/src/gafaelfawr/models/state.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import json
 from dataclasses import dataclass
 from datetime import UTC, datetime
-from typing import Self
+from typing import Self, override
 
 from cryptography.fernet import Fernet
 from fastapi import Request
@@ -45,6 +45,7 @@ class State(BaseState):
     login_start: datetime | None = None
     """Start time of login process if one is in progress."""
 
+    @override
     @classmethod
     async def from_cookie(
         cls, cookie: str, request: Request | None = None
@@ -95,6 +96,7 @@ class State(BaseState):
             login_start=login_start,
         )
 
+    @override
     def to_cookie(self) -> str:
         """Build an encrypted cookie representation of the state.
 

--- a/src/gafaelfawr/providers/github.py
+++ b/src/gafaelfawr/providers/github.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import re
+from typing import override
 from urllib.parse import urlencode
 
 from httpx import AsyncClient, HTTPError
@@ -67,6 +68,7 @@ class GitHubProvider(Provider):
         self._http_client = http_client
         self._logger = logger
 
+    @override
     def get_redirect_url(self, state: str) -> str:
         """Get the login URL to which to redirect the user.
 
@@ -88,6 +90,7 @@ class GitHubProvider(Provider):
         self._logger.info("Redirecting user to GitHub for authentication")
         return f"{self._LOGIN_URL}?{urlencode(params)}"
 
+    @override
     async def create_user_info(
         self, code: str, state: str, session: State
     ) -> TokenUserInfo:
@@ -176,6 +179,7 @@ class GitHubProvider(Provider):
             groups=sorted(groups, key=lambda g: g.name),
         )
 
+    @override
     async def logout(self, session: State) -> None:
         """Revoke the OAuth authorization grant for this user.
 

--- a/src/gafaelfawr/providers/oidc.py
+++ b/src/gafaelfawr/providers/oidc.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import re
+from typing import override
 from urllib.parse import urlencode
 
 import jwt
@@ -63,6 +64,7 @@ class OIDCProvider(Provider):
         self._http_client = http_client
         self._logger = logger
 
+    @override
     def get_redirect_url(self, state: str) -> str:
         """Get the login URL to which to redirect the user.
 
@@ -92,6 +94,7 @@ class OIDCProvider(Provider):
         )
         return f"{self._config.login_url!s}?{urlencode(params)}"
 
+    @override
     async def create_user_info(
         self, code: str, state: str, session: State
     ) -> TokenUserInfo:
@@ -187,6 +190,7 @@ class OIDCProvider(Provider):
             msg = f"OpenID Connect token parsing failed: {e!s}"
             raise OIDCError(msg) from e
 
+    @override
     async def logout(self, session: State) -> None:
         """User logout callback.
 


### PR DESCRIPTION
Python 3.12 added a way to explicitly mark functions as being overrides using a decorator. This improves the type checking. Use that annotation where appropriate.