### PR TITLE
DM-47148: Add label to Gafaelfawr-managed ingresses

### DIFF
--- a/changelog.d/20241025_160624_rra_DM_47148.md
+++ b/changelog.d/20241025_160624_rra_DM_47148.md
@@ -1,0 +1,3 @@
+### New features
+
+- Gafaelfawr now adds the `app.kubernetes.io/managed-by` label with value `Gafaelfawr` to all `Ingress` resources generated from `GafaelfawrIngress` resources.

--- a/docs/user-guide/gafaelfawringress.rst
+++ b/docs/user-guide/gafaelfawringress.rst
@@ -72,7 +72,9 @@ The ``template`` section is a template for the ``Ingress`` resource.
 It uses a subset of the ``Ingress`` schema.
 
 ``template.metadata.name`` specifies the name of the ``Ingress`` resource to create and must be present.
+
 ``template.metadata.labels`` and ``template.metadata.annotations`` may be set to add labels and annotations to the created ``Ingress``, in addition to the annotations that will be added by Gafaelfawr.
+Gafaelfawr will always add the ``app.kubernetes.io/managed-by`` label with the value ``Gafaelfawr``, overriding any label by that name specified here.
 
 ``template.spec.rules`` are the normal ``Ingress`` routing rules.
 Only the above structure is supported, but all standard ``pathType`` options are supported, as is using either ``name`` or ``number`` for the port.
@@ -294,6 +296,12 @@ None of the other configuration options are supported in this mode.
 The reason to use this configuration over simply writing an ``Ingress`` resource directly is that Gafaelfawr will still be invoked to strip Gafaelfawr tokens and secrets from the request before it is passed to the underlying service.
 This prevents credential leakage to anonymous services.
 See :ref:`header-filtering` for more details.
+
+Locating Gafaelfawr-managed ingresses
+=====================================
+
+Gafaelfawr adds the label ``app.kubernetes.io/managed-by`` with the value ``Gafaelfawr`` to all of the ingresses that it generates from ``GafaelfawrIngress`` resources.
+This label can be used to locate all Gafaelfawr-managed ``Ingress`` resources, or all ``Ingress`` resources not managed by Gafaelfawr.
 
 .. _auth-headers:
 

--- a/src/gafaelfawr/services/kubernetes.py
+++ b/src/gafaelfawr/services/kubernetes.py
@@ -160,6 +160,11 @@ class KubernetesIngressService:
             annotations = self._build_anonymous_annotations(ingress)
         else:
             annotations = self._build_annotations(ingress)
+        if ingress.template.metadata.labels:
+            labels = dict(ingress.template.metadata.labels)
+        else:
+            labels = {}
+        labels["app.kubernetes.io/managed-by"] = "Gafaelfawr"
 
         tls = None
         if ingress.template.spec.tls:
@@ -169,7 +174,7 @@ class KubernetesIngressService:
                 name=ingress.template.metadata.name,
                 namespace=ingress.metadata.namespace,
                 annotations=annotations,
-                labels=ingress.template.metadata.labels,
+                labels=labels,
             ),
             spec=V1IngressSpec(
                 ingress_class_name="nginx",

--- a/tests/data/kubernetes/input/ingresses.yaml
+++ b/tests/data/kubernetes/input/ingresses.yaml
@@ -44,6 +44,7 @@ template:
     name: notebook
     labels:
       some-label: foo
+      app.kubernetes.io/managed-by: blah
     annotations:
       another.annotation.example.com: bar
   spec:

--- a/tests/data/kubernetes/output/ingresses.yaml
+++ b/tests/data/kubernetes/output/ingresses.yaml
@@ -11,6 +11,8 @@ metadata:
       {snippet}
   creationTimestamp: {any}
   generation: {any}
+  labels:
+    app.kubernetes.io/managed-by: Gafaelfawr
   managedFields: {any}
   ownerReferences:
     - apiVersion: gafaelfawr.lsst.io/v1alpha1
@@ -54,6 +56,7 @@ metadata:
   creationTimestamp: {any}
   generation: {any}
   labels:
+    app.kubernetes.io/managed-by: Gafaelfawr
     some-label: foo
   managedFields: {any}
   ownerReferences:
@@ -97,6 +100,8 @@ metadata:
       {snippet}
   creationTimestamp: {any}
   generation: {any}
+  labels:
+    app.kubernetes.io/managed-by: Gafaelfawr
   managedFields: {any}
   ownerReferences:
     - apiVersion: gafaelfawr.lsst.io/v1alpha1
@@ -136,6 +141,8 @@ metadata:
       {snippet}
   creationTimestamp: {any}
   generation: {any}
+  labels:
+    app.kubernetes.io/managed-by: Gafaelfawr
   managedFields: {any}
   ownerReferences:
     - apiVersion: gafaelfawr.lsst.io/v1alpha1
@@ -173,6 +180,8 @@ metadata:
     some.annotation: foo
   creationTimestamp: {any}
   generation: {any}
+  labels:
+    app.kubernetes.io/managed-by: Gafaelfawr
   managedFields: {any}
   ownerReferences:
     - apiVersion: gafaelfawr.lsst.io/v1alpha1
@@ -211,6 +220,8 @@ metadata:
       {snippet}
   creationTimestamp: {any}
   generation: {any}
+  labels:
+    app.kubernetes.io/managed-by: Gafaelfawr
   managedFields: {any}
   ownerReferences:
     - apiVersion: gafaelfawr.lsst.io/v1alpha1
@@ -249,6 +260,8 @@ metadata:
       {snippet}
   creationTimestamp: {any}
   generation: {any}
+  labels:
+    app.kubernetes.io/managed-by: Gafaelfawr
   managedFields: {any}
   ownerReferences:
     - apiVersion: gafaelfawr.lsst.io/v1alpha1


### PR DESCRIPTION
Add the label `app.kubernetes.io/managed-by` with value `Gafaelfawr` to all `Ingress` resources created by Gafaelfawr.