### PR TITLE
DM-47148: Add support for `client_secret_basic`

### DIFF
--- a/changelog.d/20241028_133552_rra_DM_47148.md
+++ b/changelog.d/20241028_133552_rra_DM_47148.md
@@ -1,0 +1,3 @@
+### New features
+
+- Add support for `client_secret_basic` to the token endpoint for the OpenID Connect server. This is the recommended default authentication strategy and some clients don't support negotiating `client_secret_post` instead.

--- a/docs/user-guide/openid-connect.rst
+++ b/docs/user-guide/openid-connect.rst
@@ -37,11 +37,14 @@ For clients that require more manual configuration, the OpenID Connect routes ar
 - userinfo endpoint: ``/auth/openid/userinfo``.
 - JWKS endpoint: ``/.well-known/jwks.json``.
 
-As with any other protected service, the client must run on the same URL host as Gafaelfawr.
-These endpoints are all at that shared host (and should be specified using ``https``).
+The hostname for those routes is whatever host Gafaelfawr itself is configured to use.
+(Generally this will be the default domain of the Phalanx cluster.)
 
 The client must use the authentication code OpenID Connect flow (see `OpenID Connect Core 1.0 section 3.1 <https://openid.net/specs/openid-connect-core-1_0.html#CodeFlowAuth>`__).
 The other authentication flows are not supported.
+
+The authentication methods ``client_secret_basic`` and ``client_secret_post`` are supported.
+Gafaelfawr does not register a specific authentication method for a client and supports either authentication method for any client.
 
 OpenID scopes
 -------------

--- a/src/gafaelfawr/models/oidc.py
+++ b/src/gafaelfawr/models/oidc.py
@@ -456,8 +456,10 @@ class OIDCConfig(BaseModel):
     )
 
     token_endpoint_auth_methods_supported: list[str] = Field(
-        ["client_secret_post"],
+        ["client_secret_basic", "client_secret_post"],
         title="Supported client auth methods",
-        description="``client_secret_post`` is the only supported auth method",
-        examples=[["client_secret_post"]],
+        description=(
+            "``client_secret_basic`` and ``client_secret_post`` are supported"
+        ),
+        examples=[["client_secret_basic", "client_secret_post"]],
     )


### PR DESCRIPTION
In the OpenID Connect server, add `client_secret_basic` support for authentication to the token endpoint. This is the recommended authentication method and some clients (specifically SATOSA, used by the Brazilian IDAC) do not successfully negotiate `client_secret_post`.