### PR TITLE
DM-47646: Fix double slashes in openid-configuration URLs

### DIFF
--- a/changelog.d/20241118_171429_rra_DM_47646.md
+++ b/changelog.d/20241118_171429_rra_DM_47646.md
@@ -1,0 +1,3 @@
+### Bug fixes
+
+- Avoid double slashes in the endpoint URLs returned by `/.well-known/openid-configuration`, fixing a bug introduced in Gafaelfawr 12.0.0.

--- a/src/gafaelfawr/services/oidc.py
+++ b/src/gafaelfawr/services/oidc.py
@@ -125,7 +125,7 @@ class OIDCService:
 
     def get_openid_configuration(self) -> OIDCConfig:
         """Return the OpenID Connect configuration for the internal server."""
-        base_url = str(self._config.issuer)
+        base_url = str(self._config.issuer).rstrip("/")
         return OIDCConfig(
             issuer=base_url,
             authorization_endpoint=base_url + "/auth/openid/login",

--- a/tests/handlers/oidc_test.py
+++ b/tests/handlers/oidc_test.py
@@ -866,7 +866,7 @@ async def test_well_known_oidc(
     r = await client.get("/.well-known/openid-configuration")
     assert r.status_code == 200
 
-    base_url = str(config.oidc_server.issuer)
+    base_url = str(config.oidc_server.issuer).rstrip("/")
     assert r.json() == {
         "issuer": base_url,
         "authorization_endpoint": base_url + "/auth/openid/login",


### PR DESCRIPTION
Avoid double slashes in the endpoint URLs returned by `/.well-known/openid-configuration`, fixing a bug introduced in Gafaelfawr 12.0.0. The stringification of the base URL now always includes a trailing slash for URLs with no path, which resulted in a doubled slash and an invalid URL.