### PR TITLE
DM-47646: Move or remove model_config settings

### DIFF
--- a/src/gafaelfawr/config.py
+++ b/src/gafaelfawr/config.py
@@ -549,14 +549,14 @@ class LDAPConfig(EnvFirstSettings):
 class FirestoreConfig(BaseModel):
     """Configuration for Firestore-based UID/GID assignment."""
 
+    model_config = ConfigDict(
+        alias_generator=to_camel, extra="forbid", populate_by_name=True
+    )
+
     project: str = Field(
         ...,
         title="Firestore GCP project",
         description="Project containing the Firestore collections",
-    )
-
-    model_config = ConfigDict(
-        alias_generator=to_camel, extra="forbid", populate_by_name=True
     )
 
 
@@ -566,6 +566,8 @@ class OIDCClient(BaseModel):
     Unlike the other configuration models, this model parses the value of a
     secret rather than the Helm values file and does not support camel-case.
     """
+
+    model_config = ConfigDict(extra="forbid")
 
     id: str = Field(
         ..., title="Client ID", description="Unique identifier of the client"
@@ -584,8 +586,6 @@ class OIDCClient(BaseModel):
             "Acceptable return URL when authenticating users for this client"
         ),
     )
-
-    model_config = ConfigDict(extra="forbid")
 
 
 class OIDCServerConfig(EnvFirstSettings):
@@ -660,6 +660,8 @@ class OIDCServerConfig(EnvFirstSettings):
 class NotebookQuota(BaseModel):
     """Quota settings for the Notebook Aspect."""
 
+    model_config = ConfigDict(extra="forbid")
+
     cpu: float = Field(
         ..., title="CPU limit", description="Maximum number of CPU equivalents"
     )
@@ -670,8 +672,6 @@ class NotebookQuota(BaseModel):
         description="Maximum memory usage in GiB",
     )
 
-    model_config = ConfigDict(extra="forbid")
-
 
 class QuotaGrant(BaseModel):
     """One grant of quotas.
@@ -679,6 +679,8 @@ class QuotaGrant(BaseModel):
     There may be one of these per group, as well as a default one, in the
     overall quota configuration.
     """
+
+    model_config = ConfigDict(extra="forbid")
 
     api: dict[str, int] = Field(
         {},
@@ -694,11 +696,11 @@ class QuotaGrant(BaseModel):
         description="Quota settings for the Notebook Aspect",
     )
 
-    model_config = ConfigDict(extra="forbid")
-
 
 class QuotaConfig(BaseModel):
     """Quota configuration."""
+
+    model_config = ConfigDict(extra="forbid")
 
     default: QuotaGrant = Field(
         ..., title="Default quota", description="Default quotas for all users"
@@ -710,17 +712,15 @@ class QuotaConfig(BaseModel):
         description="Additional quota grants by group name",
     )
 
-    model_config = ConfigDict(extra="forbid")
-
 
 class GitHubGroupTeam(BaseModel):
     """Specification for a GitHub team."""
 
+    model_config = ConfigDict(extra="forbid")
+
     organization: str = Field(..., title="Name of the organization")
 
     team: str = Field(..., title="Slug of the team")
-
-    model_config = ConfigDict(extra="forbid")
 
     def __str__(self) -> str:
         return group_name_for_github_team(self.organization, self.team)
@@ -729,9 +729,9 @@ class GitHubGroupTeam(BaseModel):
 class GitHubGroup(BaseModel):
     """An individual GitHub team."""
 
-    github: GitHubGroupTeam = Field(..., title="Details of the GitHub team")
-
     model_config = ConfigDict(extra="forbid")
+
+    github: GitHubGroupTeam = Field(..., title="Details of the GitHub team")
 
     def __str__(self) -> str:
         return str(self.github)

--- a/src/gafaelfawr/models/admin.py
+++ b/src/gafaelfawr/models/admin.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, Field
 
 __all__ = ["Admin"]
 
@@ -16,5 +16,3 @@ class Admin(BaseModel):
         description="Username of the token administrator",
         examples=["adminuser"],
     )
-
-    model_config = ConfigDict(from_attributes=True)

--- a/src/gafaelfawr/models/history.py
+++ b/src/gafaelfawr/models/history.py
@@ -8,7 +8,7 @@ from enum import Enum
 from typing import Any, Generic, Self, TypeVar
 from urllib.parse import parse_qs, urlencode
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator
+from pydantic import BaseModel, Field, field_validator
 from safir.datetime import current_datetime
 from starlette.datastructures import URL
 
@@ -75,8 +75,6 @@ class AdminHistoryEntry(BaseModel):
         description="When the change was made",
         examples=[1614986130],
     )
-
-    model_config = ConfigDict(from_attributes=True)
 
     _normalize_ip_address = field_validator("ip_address", mode="before")(
         normalize_ip_address
@@ -335,8 +333,6 @@ class TokenChangeHistoryEntry(BaseModel):
         title="Whent he change was made",
         examples=[1614985631],
     )
-
-    model_config = ConfigDict(from_attributes=True)
 
     _normalize_scopes = field_validator("scopes", "old_scopes", mode="before")(
         normalize_scopes

--- a/src/gafaelfawr/models/kubernetes.py
+++ b/src/gafaelfawr/models/kubernetes.py
@@ -65,6 +65,8 @@ __all__ = [
 class KubernetesMetadata(BaseModel):
     """The metadata section of a Kubernetes resource."""
 
+    model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
+
     name: str
     """The name of the object."""
 
@@ -82,8 +84,6 @@ class KubernetesMetadata(BaseModel):
 
     generation: int
     """The generation of the object."""
-
-    model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
 
     @field_validator("annotations")
     @classmethod
@@ -108,10 +108,10 @@ class KubernetesResource(BaseModel):
     be extended with resource-specific data.
     """
 
+    model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
+
     metadata: KubernetesMetadata
     """Metadata section of the Kubernetes resource."""
-
-    model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
 
     @property
     def key(self) -> str:
@@ -122,13 +122,13 @@ class KubernetesResource(BaseModel):
 class GafaelfawrIngressDelegateInternal(BaseModel):
     """Configuration for a delegated internal token."""
 
+    model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
+
     service: str
     """The name of the service to which the token is being delegated."""
 
     scopes: list[str]
     """The requested scopes of the delegated token."""
-
-    model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
 
 
 class GafaelfawrIngressDelegateNotebook(BaseModel):
@@ -148,6 +148,8 @@ class GafaelfawrIngressDelegateNotebook(BaseModel):
 class GafaelfawrIngressDelegate(BaseModel):
     """Configuration for delegated tokens requested for a service."""
 
+    model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
+
     notebook: GafaelfawrIngressDelegateNotebook | None = None
     """Whether the delegated token requested is a notebook token."""
 
@@ -159,8 +161,6 @@ class GafaelfawrIngressDelegate(BaseModel):
 
     use_authorization: bool = False
     """Whether to put the delegated token in the ``Authorization`` header."""
-
-    model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
 
     _normalize_minimum_lifetime = field_validator(
         "minimum_lifetime", mode="before"
@@ -180,6 +180,10 @@ class GafaelfawrIngressScopesBase(BaseModel, metaclass=ABCMeta):
     rest of Gafaelfawr.
     """
 
+    model_config = ConfigDict(
+        alias_generator=to_camel, extra="forbid", populate_by_name=True
+    )
+
     @property
     @abstractmethod
     def satisfy(self) -> Satisfy:
@@ -193,10 +197,6 @@ class GafaelfawrIngressScopesBase(BaseModel, metaclass=ABCMeta):
     @abstractmethod
     def is_anonymous(self) -> bool:
         """Whether this ingress is anonymous."""
-
-    model_config = ConfigDict(
-        alias_generator=to_camel, extra="forbid", populate_by_name=True
-    )
 
 
 class GafaelfawrIngressScopesAll(GafaelfawrIngressScopesBase):
@@ -274,6 +274,8 @@ class GafaelfawrIngressScopesAnonymous(GafaelfawrIngressScopesBase):
 class GafaelfawrIngressConfig(BaseModel):
     """Configuration settings for an ingress using Gafaelfawr for auth."""
 
+    model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
+
     auth_cache_duration: str | None = None
     """How long NGINX should cache the Gafaelfawr authorization response."""
 
@@ -307,8 +309,6 @@ class GafaelfawrIngressConfig(BaseModel):
 
     username: str | None = None
     """Restrict access to the given user."""
-
-    model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
 
     @model_validator(mode="after")
     def _validate_conflicts(self) -> Self:
@@ -391,6 +391,8 @@ class GafaelfawrIngressConfig(BaseModel):
 class GafaelfawrIngressMetadata(BaseModel):
     """Metadata used to create an ``Ingress`` object."""
 
+    model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
+
     name: str
     """Name of the ingress."""
 
@@ -399,8 +401,6 @@ class GafaelfawrIngressMetadata(BaseModel):
 
     labels: dict[str, str] | None = None
     """Labels to add to the ingress."""
-
-    model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
 
 
 class PathType(Enum):
@@ -419,12 +419,12 @@ class PathType(Enum):
 class GafaelfawrServicePortName(BaseModel):
     """Port for a service."""
 
-    name: str
-    """Port name."""
-
     model_config = ConfigDict(
         alias_generator=to_camel, extra="forbid", populate_by_name=True
     )
+
+    name: str
+    """Port name."""
 
     def to_kubernetes(self) -> V1ServiceBackendPort:
         """Convert to the Kubernetes API object."""
@@ -434,12 +434,12 @@ class GafaelfawrServicePortName(BaseModel):
 class GafaelfawrServicePortNumber(BaseModel):
     """Port for a service."""
 
-    number: int
-    """Port number."""
-
     model_config = ConfigDict(
         alias_generator=to_camel, extra="forbid", populate_by_name=True
     )
+
+    number: int
+    """Port number."""
 
     def to_kubernetes(self) -> V1ServiceBackendPort:
         """Convert to the Kubernetes API object."""
@@ -449,13 +449,13 @@ class GafaelfawrServicePortNumber(BaseModel):
 class GafaelfawrIngressPathService(BaseModel):
     """Service that serves a given path."""
 
+    model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
+
     name: str
     """Name of the service to which to route the request."""
 
     port: GafaelfawrServicePortName | GafaelfawrServicePortNumber
     """Port to which to route the request."""
-
-    model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
 
     def to_kubernetes(self) -> V1IngressServiceBackend:
         """Convert to the Kubernetes API object."""
@@ -467,10 +467,10 @@ class GafaelfawrIngressPathService(BaseModel):
 class GafaelfawrIngressPathBackend(BaseModel):
     """Backend that serves a given path."""
 
+    model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
+
     service: GafaelfawrIngressPathService
     """The underlying service that serves this path."""
-
-    model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
 
     def to_kubernetes(self) -> V1IngressBackend:
         """Convert to the Kubernetes API object."""
@@ -480,6 +480,8 @@ class GafaelfawrIngressPathBackend(BaseModel):
 class GafaelfawrIngressPath(BaseModel):
     """A path routing rule for an ingress."""
 
+    model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
+
     path: str
     """Path match, interpreted based on the ``path_type`` field."""
 
@@ -488,8 +490,6 @@ class GafaelfawrIngressPath(BaseModel):
 
     backend: GafaelfawrIngressPathBackend
     """Backend that serves this path."""
-
-    model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
 
     def to_kubernetes(self) -> V1HTTPIngressPath:
         """Convert to the Kubernetes API object."""
@@ -503,10 +503,10 @@ class GafaelfawrIngressPath(BaseModel):
 class GafaelfawrIngressRuleHTTP(BaseModel):
     """Routing rules for HTTP access."""
 
+    model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
+
     paths: list[GafaelfawrIngressPath]
     """Path routing rules for this host."""
-
-    model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
 
     def to_kubernetes(self) -> V1HTTPIngressRuleValue:
         """Convert to the Kubernetes API object."""
@@ -518,13 +518,13 @@ class GafaelfawrIngressRuleHTTP(BaseModel):
 class GafaelfawrIngressRule(BaseModel):
     """A routing rule for an ingress."""
 
+    model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
+
     host: str
     """Hostname to which to attach the rule."""
 
     http: GafaelfawrIngressRuleHTTP
     """Path routing rules for this host."""
-
-    model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
 
     def to_kubernetes(self) -> V1IngressRule:
         """Convert to the Kubernetes API object."""
@@ -534,6 +534,8 @@ class GafaelfawrIngressRule(BaseModel):
 class GafaelfawrIngressTLS(BaseModel):
     """A TLS certificate rule for an ingress."""
 
+    model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
+
     hosts: list[str]
     """The hosts to which this certificate applies.
 
@@ -541,8 +543,6 @@ class GafaelfawrIngressTLS(BaseModel):
 
     secret_name: str
     """The name of the secret containing the TLS certificate."""
-
-    model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
 
     def to_kubernetes(self) -> V1IngressTLS:
         """Convert to the Kubernetes API object."""
@@ -552,25 +552,25 @@ class GafaelfawrIngressTLS(BaseModel):
 class GafaelfawrIngressSpec(BaseModel):
     """Template for ``spec`` portion of ``Ingress`` resource."""
 
+    model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
+
     rules: list[GafaelfawrIngressRule]
     """The ingress routing rules."""
 
     tls: list[GafaelfawrIngressTLS] | None = None
     """The TLS certificate rules."""
 
-    model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
-
 
 class GafaelfawrIngressTemplate(BaseModel):
     """Template for ``Ingress`` created from ``GafaelfawrIngress`` resource."""
+
+    model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
 
     metadata: GafaelfawrIngressMetadata
     """Template for the metadata of the created ``Ingress``."""
 
     spec: GafaelfawrIngressSpec
     """Template for the ``spec`` of the created ``Ingress``."""
-
-    model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
 
 
 class GafaelfawrIngress(KubernetesResource):
@@ -586,13 +586,13 @@ class GafaelfawrIngress(KubernetesResource):
 class GafaelfawrServiceTokenSpec(BaseModel):
     """Holds the ``spec`` section of a ``GafaelfawrServiceToken`` resource."""
 
+    model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
+
     service: str
     """The username of the service token."""
 
     scopes: list[str]
     """The scopes to grant to the service token."""
-
-    model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
 
 
 class GafaelfawrServiceToken(KubernetesResource):

--- a/src/gafaelfawr/models/token.py
+++ b/src/gafaelfawr/models/token.py
@@ -6,13 +6,7 @@ from datetime import datetime
 from enum import Enum
 from typing import Any, Self
 
-from pydantic import (
-    BaseModel,
-    ConfigDict,
-    Field,
-    ValidationInfo,
-    field_validator,
-)
+from pydantic import BaseModel, Field, ValidationInfo, field_validator
 from safir.datetime import current_datetime
 
 from ..constants import USERNAME_REGEX
@@ -241,8 +235,6 @@ class TokenInfo(TokenBase):
         min_length=22,
         max_length=22,
     )
-
-    model_config = ConfigDict(from_attributes=True)
 
 
 class TokenUserInfo(BaseModel):

--- a/src/gafaelfawr/storage/admin.py
+++ b/src/gafaelfawr/storage/admin.py
@@ -62,4 +62,6 @@ class AdminStore:
         """
         stmt = select(SQLAdmin).order_by(SQLAdmin.username)
         result = await self._session.scalars(stmt)
-        return [Admin.model_validate(a) for a in result.all()]
+        return [
+            Admin.model_validate(a, from_attributes=True) for a in result.all()
+        ]

--- a/src/gafaelfawr/storage/history.py
+++ b/src/gafaelfawr/storage/history.py
@@ -180,7 +180,8 @@ class TokenChangeHistoryStore:
         entries = result.all()
         return PaginatedHistory[TokenChangeHistoryEntry](
             entries=[
-                TokenChangeHistoryEntry.model_validate(e) for e in entries
+                TokenChangeHistoryEntry.model_validate(e, from_attributes=True)
+                for e in entries
             ],
             count=len(entries),
             prev_cursor=None,
@@ -249,7 +250,8 @@ class TokenChangeHistoryStore:
         # Return the results.
         return PaginatedHistory[TokenChangeHistoryEntry](
             entries=[
-                TokenChangeHistoryEntry.model_validate(e) for e in entries
+                TokenChangeHistoryEntry.model_validate(e, from_attributes=True)
+                for e in entries
             ],
             count=count,
             prev_cursor=prev_cursor,

--- a/src/gafaelfawr/storage/token.py
+++ b/src/gafaelfawr/storage/token.py
@@ -157,7 +157,7 @@ class TokenDatabaseStore:
         )
         tokens = await self._session.execute(stmt)
         for token, parent in tokens.all():
-            info = TokenInfo.model_validate(token)
+            info = TokenInfo.model_validate(token, from_attributes=True)
             info.parent = parent
             deleted.append(info)
 
@@ -226,7 +226,7 @@ class TokenDatabaseStore:
         if not result:
             return None
         token, parent = result
-        info = TokenInfo.model_validate(token)
+        info = TokenInfo.model_validate(token, from_attributes=True)
         info.parent = parent
         return info
 
@@ -336,7 +336,10 @@ class TokenDatabaseStore:
         if limit:
             stmt = stmt.limit(limit)
         result = await self._session.scalars(stmt)
-        return [TokenInfo.model_validate(t) for t in result.all()]
+        return [
+            TokenInfo.model_validate(t, from_attributes=True)
+            for t in result.all()
+        ]
 
     async def list_orphaned(self) -> list[TokenInfo]:
         """List all orphaned tokens.
@@ -355,7 +358,10 @@ class TokenDatabaseStore:
             .where(Subtoken.parent.is_(None))
         )
         result = await self._session.scalars(stmt)
-        return [TokenInfo.model_validate(t) for t in result.all()]
+        return [
+            TokenInfo.model_validate(t, from_attributes=True)
+            for t in result.all()
+        ]
 
     async def list_with_parents(self) -> list[TokenInfo]:
         """List all tokens including parent information.
@@ -381,7 +387,7 @@ class TokenDatabaseStore:
         token_info = []
         for result in results.all():
             token, parent = result
-            info = TokenInfo.model_validate(token)
+            info = TokenInfo.model_validate(token, from_attributes=True)
             info.parent = parent
             token_info.append(info)
         return token_info
@@ -434,7 +440,7 @@ class TokenDatabaseStore:
             token.expires = None
         elif expires:
             token.expires = datetime_to_db(expires)
-        return TokenInfo.model_validate(token)
+        return TokenInfo.model_validate(token, from_attributes=True)
 
     async def _check_name_conflict(
         self, username: str, token_name: str


### PR DESCRIPTION
Where `model_config` settings for Pydantic models are needed, move them to the top of the class to make them more obvious. Remove the ones that enable parsing from object attributes in favor of passing that flag directly into `model_validate` in the storage layer.