### PR TITLE
DM-47646: Remove unnecessary Black configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,20 +71,6 @@ gafaelfawr = "gafaelfawr.cli:main"
 [tool.black]
 line-length = 79
 target-version = ["py312"]
-exclude = '''
-/(
-    \.eggs
-  | \.git
-  | \.mypy_cache
-  | \.tox
-  | \.venv
-  | _build
-  | build
-  | dist
-)/
-'''
-# Use single-quoted strings so TOML treats the string like a Python r-string
-# Multi-line strings are implicitly treated by black as regular expressions
 
 [tool.coverage.run]
 parallel = true


### PR DESCRIPTION
Black is never used recursively for reformatting any more since Gafaelfawr has switched to Ruff, so the file exclusion list is no longer needed.