### PR TITLE
DM-47646: Updated shared Ruff configuration file

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -141,22 +141,13 @@ python_files = [
     "tests/*/*.py"
 ]
 
-# The rule used with Ruff configuration is to disable every lint that has
-# legitimate exceptions that are not dodgy code, rather than cluttering code
-# with noqa markers. This is therefore a reiatively relaxed configuration that
-# errs on the side of disabling legitimate lints.
-#
-# Reference for settings: https://docs.astral.sh/ruff/settings/
-# Reference for rules: https://docs.astral.sh/ruff/rules/
+# Use the generic Ruff configuration in ruff.toml and extend it with only
+# project-specific settings.
 [tool.ruff]
 extend = "ruff-shared.toml"
 
 [tool.ruff.lint.extend-per-file-ignores]
-"alembic/**" = [
-    "INP001",   # Alembic files are magical
-    "D103",     # no docstrings for Alembic migrations
-]
-"tests/**" = [
+"tests/cli_test.py" = [
     "ASYNC221", # useful to run subprocess in async tests for Alembic
 ]
 

--- a/ruff-shared.toml
+++ b/ruff-shared.toml
@@ -87,6 +87,11 @@ ignore = [
 select = ["ALL"]
 
 [lint.per-file-ignores]
+"alembic/**" = [
+    "INP001",  # Alembic files are magical
+    "D103",    # Alembic methods do not need docstrings
+    "D400",    # Alembic migrations have their own docstring format
+]
 "noxfile.py" = [
     "T201",    # print makes sense as output from nox rules
 ]
@@ -117,6 +122,12 @@ select = ["ALL"]
     "S106",    # tests are allowed to hard-code dummy passwords
     "S301",    # allow tests for whether code can be pickled
     "SLF001",  # tests are allowed to access private members
+]
+"tests/schema_test.py" = [
+    "ASYNC221", # useful to run subprocess in async tests for Alembic
+]
+"*/tests/schema_test.py" = [
+    "ASYNC221", # useful to run subprocess in async tests for Alembic
 ]
 
 # These are too useful as attributes or methods to allow the conflict with the


### PR DESCRIPTION
Drop Alembic overrides from `pyproject.toml` since those are now included in the generic file.