### PR TITLE
DM-47716: Move token cache transaction management

### DIFF
--- a/changelog.d/20241120_145516_rra_DM_47716.md
+++ b/changelog.d/20241120_145516_rra_DM_47716.md
@@ -1,0 +1,3 @@
+### Bug fixes
+
+- Avoid opening a database session in the ingress authentication path unless it is necessary to create a new delegated token.

--- a/src/gafaelfawr/factory.py
+++ b/src/gafaelfawr/factory.py
@@ -543,6 +543,7 @@ class Factory:
             token_db_store=TokenDatabaseStore(self.session),
             token_redis_store=self.create_token_redis_store(),
             token_change_store=TokenChangeHistoryStore(self.session),
+            session=self.session,
             logger=self._logger,
         )
 
@@ -582,6 +583,7 @@ class Factory:
             token_db_store=token_db_store,
             token_redis_store=token_redis_store,
             token_change_store=token_change_store,
+            session=self.session,
             logger=self._logger,
         )
         return TokenService(

--- a/src/gafaelfawr/handlers/ingress.py
+++ b/src/gafaelfawr/handlers/ingress.py
@@ -587,12 +587,11 @@ async def build_delegated_token(
     """
     if auth_config.notebook:
         token_service = context.factory.create_token_service()
-        async with context.session.begin():
-            token = await token_service.get_notebook_token(
-                token_data,
-                ip_address=context.ip_address,
-                minimum_lifetime=auth_config.minimum_lifetime,
-            )
+        token = await token_service.get_notebook_token(
+            token_data,
+            ip_address=context.ip_address,
+            minimum_lifetime=auth_config.minimum_lifetime,
+        )
         return str(token)
     elif auth_config.delegate_to:
         # Delegated scopes are optional; if the authenticating token doesn't
@@ -604,14 +603,13 @@ async def build_delegated_token(
         # token.
         delegate_scopes = auth_config.delegate_scopes & set(token_data.scopes)
         token_service = context.factory.create_token_service()
-        async with context.session.begin():
-            token = await token_service.get_internal_token(
-                token_data,
-                service=auth_config.delegate_to,
-                scopes=sorted(delegate_scopes),
-                ip_address=context.ip_address,
-                minimum_lifetime=auth_config.minimum_lifetime,
-            )
+        token = await token_service.get_internal_token(
+            token_data,
+            service=auth_config.delegate_to,
+            scopes=sorted(delegate_scopes),
+            ip_address=context.ip_address,
+            minimum_lifetime=auth_config.minimum_lifetime,
+        )
         return str(token)
     else:
         return None

--- a/tests/handlers/api_history_test.py
+++ b/tests/handlers/api_history_test.py
@@ -42,56 +42,56 @@ async def build_history(
     build enough history that we can make interesting paginated queries of it.
     """
     token_service = factory.create_token_service()
+    user_info_one = TokenUserInfo(username="one")
     async with factory.session.begin():
-        user_info_one = TokenUserInfo(username="one")
         token_one = await token_service.create_session_token(
             user_info_one,
             scopes=["admin:token", "exec:test", "read:all", "user:token"],
             ip_address="192.0.2.3",
         )
-        token_data_one = await token_service.get_data(token_one)
-        assert token_data_one
-        await token_service.get_internal_token(
-            token_data_one,
-            "foo",
-            scopes=["exec:test", "read:all"],
-            ip_address="192.0.2.4",
-        )
-        internal_token_one_bar = await token_service.get_internal_token(
-            token_data_one, "bar", scopes=["read:all"], ip_address="192.0.2.3"
-        )
-        token_data_internal_one_bar = await token_service.get_data(
-            internal_token_one_bar
-        )
-        assert token_data_internal_one_bar
-        await token_service.get_internal_token(
-            token_data_internal_one_bar,
-            "baz",
-            scopes=[],
-            ip_address="10.10.10.10",
-        )
-        notebook_token_one = await token_service.get_notebook_token(
-            token_data_one, ip_address="198.51.100.5"
-        )
-        token_data_notebook_one = await token_service.get_data(
-            notebook_token_one
-        )
-        assert token_data_notebook_one
-        await token_service.get_internal_token(
-            token_data_notebook_one,
-            "foo",
-            scopes=["exec:test"],
-            ip_address="10.10.10.20",
-        )
+    token_data_one = await token_service.get_data(token_one)
+    assert token_data_one
+    await token_service.get_internal_token(
+        token_data_one,
+        "foo",
+        scopes=["exec:test", "read:all"],
+        ip_address="192.0.2.4",
+    )
+    internal_token_one_bar = await token_service.get_internal_token(
+        token_data_one, "bar", scopes=["read:all"], ip_address="192.0.2.3"
+    )
+    token_data_internal_one_bar = await token_service.get_data(
+        internal_token_one_bar
+    )
+    assert token_data_internal_one_bar
+    await token_service.get_internal_token(
+        token_data_internal_one_bar,
+        "baz",
+        scopes=[],
+        ip_address="10.10.10.10",
+    )
+    notebook_token_one = await token_service.get_notebook_token(
+        token_data_one, ip_address="198.51.100.5"
+    )
+    token_data_notebook_one = await token_service.get_data(notebook_token_one)
+    assert token_data_notebook_one
+    await token_service.get_internal_token(
+        token_data_notebook_one,
+        "foo",
+        scopes=["exec:test"],
+        ip_address="10.10.10.20",
+    )
 
-        user_info_two = TokenUserInfo(username="two")
+    user_info_two = TokenUserInfo(username="two")
+    async with factory.session.begin():
         token_two = await token_service.create_session_token(
             user_info_two,
             scopes=["admin:token", "read:some", "user:token"],
             ip_address="192.0.2.20",
         )
-        token_data_two = await token_service.get_data(token_two)
-        assert token_data_two
+    token_data_two = await token_service.get_data(token_two)
+    assert token_data_two
+    async with factory.session.begin():
         user_token_two = await token_service.create_user_token(
             token_data_two,
             token_data_two.username,
@@ -99,14 +99,15 @@ async def build_history(
             scopes=["admin:token", "read:some", "user:token"],
             ip_address="192.0.2.20",
         )
-        token_data_user_two = await token_service.get_data(user_token_two)
-        assert token_data_user_two
-        await token_service.get_internal_token(
-            token_data_user_two,
-            "foo",
-            scopes=["read:some"],
-            ip_address="10.10.10.10",
-        )
+    token_data_user_two = await token_service.get_data(user_token_two)
+    assert token_data_user_two
+    await token_service.get_internal_token(
+        token_data_user_two,
+        "foo",
+        scopes=["read:some"],
+        ip_address="10.10.10.10",
+    )
+    async with factory.session.begin():
         assert await token_service.modify_token(
             user_token_two.key,
             token_data_user_two,
@@ -115,18 +116,20 @@ async def build_history(
             token_name="happy token",
         )
 
-        request = AdminTokenRequest(
-            username="bot-service",
-            token_type=TokenType.service,
-            scopes=["admin:token"],
-        )
+    request = AdminTokenRequest(
+        username="bot-service",
+        token_type=TokenType.service,
+        scopes=["admin:token"],
+    )
+    async with factory.session.begin():
         service_token = await token_service.create_token_from_admin_request(
             request,
             TokenData.bootstrap_token(),
             ip_address="2001:db8:034a:ea78:4278:4562:6578:9876",
         )
-        service_token_data = await token_service.get_data(service_token)
-        assert service_token_data
+    service_token_data = await token_service.get_data(service_token)
+    assert service_token_data
+    async with factory.session.begin():
         assert await token_service.modify_token(
             user_token_two.key,
             service_token_data,

--- a/tests/services/token_cache_test.py
+++ b/tests/services/token_cache_test.py
@@ -22,13 +22,12 @@ async def test_basic(factory: Factory) -> None:
     token_data = await create_session_token(factory, scopes=["read:all"])
     token_service = factory.create_token_service()
     token_cache = factory.create_token_cache_service()
-    async with factory.session.begin():
-        internal_token = await token_service.get_internal_token(
-            token_data, "some-service", ["read:all"], ip_address="127.0.0.1"
-        )
-        notebook_token = await token_service.get_notebook_token(
-            token_data, ip_address="127.0.0.1"
-        )
+    internal_token = await token_service.get_internal_token(
+        token_data, "some-service", ["read:all"], ip_address="127.0.0.1"
+    )
+    notebook_token = await token_service.get_notebook_token(
+        token_data, ip_address="127.0.0.1"
+    )
 
     assert internal_token == await token_cache.get_internal_token(
         token_data, "some-service", ["read:all"], "127.0.0.1"
@@ -38,24 +37,22 @@ async def test_basic(factory: Factory) -> None:
     )
 
     # Requesting different internal tokens doesn't work.
-    async with factory.session.begin():
-        assert internal_token != await token_cache.get_internal_token(
-            token_data, "other-service", ["read:all"], "127.0.0.1"
-        )
-        assert notebook_token != await token_cache.get_internal_token(
-            token_data, "some-service", [], "127.0.0.1"
-        )
+    assert internal_token != await token_cache.get_internal_token(
+        token_data, "other-service", ["read:all"], "127.0.0.1"
+    )
+    assert notebook_token != await token_cache.get_internal_token(
+        token_data, "some-service", [], "127.0.0.1"
+    )
 
     # A different service token for the same user requesting the same
     # information creates a different internal token.
     new_token_data = await create_session_token(factory, scopes=["read:all"])
-    async with factory.session.begin():
-        assert internal_token != await token_cache.get_internal_token(
-            new_token_data, "some-service", ["read:all"], "127.0.0.1"
-        )
-        assert notebook_token != await token_cache.get_notebook_token(
-            new_token_data, "127.0.0.1"
-        )
+    assert internal_token != await token_cache.get_internal_token(
+        new_token_data, "some-service", ["read:all"], "127.0.0.1"
+    )
+    assert notebook_token != await token_cache.get_notebook_token(
+        new_token_data, "127.0.0.1"
+    )
 
     # Changing the scope of the parent token doesn't matter as long as the
     # internal token is requested with the same scope.  Cases where the parent
@@ -65,10 +62,9 @@ async def test_basic(factory: Factory) -> None:
     assert internal_token == await token_cache.get_internal_token(
         token_data, "some-service", ["read:all"], "127.0.0.1"
     )
-    async with factory.session.begin():
-        assert internal_token != await token_cache.get_internal_token(
-            token_data, "some-service", ["admin:token"], "127.0.0.1"
-        )
+    assert internal_token != await token_cache.get_internal_token(
+        token_data, "some-service", ["admin:token"], "127.0.0.1"
+    )
 
 
 @pytest.mark.asyncio
@@ -84,13 +80,12 @@ async def test_invalid(factory: Factory) -> None:
     )
     token_cache._notebook_cache.store(token_data, notebook_token)
 
-    async with factory.session.begin():
-        assert internal_token != await token_cache.get_internal_token(
-            token_data, "some-service", ["read:all"], "127.0.0.1"
-        )
-        assert notebook_token != await token_cache.get_notebook_token(
-            token_data, "127.0.0.1"
-        )
+    assert internal_token != await token_cache.get_internal_token(
+        token_data, "some-service", ["read:all"], "127.0.0.1"
+    )
+    assert notebook_token != await token_cache.get_notebook_token(
+        token_data, "127.0.0.1"
+    )
 
 
 @pytest.mark.asyncio
@@ -141,10 +136,9 @@ async def test_expiration(config: Config, factory: Factory) -> None:
 
     # The cache should now decline to return the token and generate a new one.
     old_token = internal_token_data.token
-    async with factory.session.begin():
-        assert old_token != await token_cache.get_internal_token(
-            token_data, "some-service", ["read:all"], "127.0.0.1"
-        )
+    assert old_token != await token_cache.get_internal_token(
+        token_data, "some-service", ["read:all"], "127.0.0.1"
+    )
 
     # Do the same test with a notebook token.
     notebook_token_data = TokenData(
@@ -163,7 +157,6 @@ async def test_expiration(config: Config, factory: Factory) -> None:
     notebook_token_data.expires = expires - timedelta(seconds=20)
     await token_store.store_data(notebook_token_data)
     old_token = notebook_token_data.token
-    async with factory.session.begin():
-        assert old_token != await token_cache.get_notebook_token(
-            token_data, "127.0.0.1"
-        )
+    assert old_token != await token_cache.get_notebook_token(
+        token_data, "127.0.0.1"
+    )


### PR DESCRIPTION
The pattern of doing database transaction management within the handlers meant that a database transaction was created in the hot path of ingress auth requests if delegated tokens were requested. Move the transaction management into the token cache service so that the transaction is only created if database activity is required.