### PR TITLE
DM-47716: Avoid creating Firestore clients on every request

### DIFF
--- a/changelog.d/20241120_164500_rra_DM_47716_queue.md
+++ b/changelog.d/20241120_164500_rra_DM_47716_queue.md
@@ -1,0 +1,3 @@
+### Bug fixes
+
+- Avoid creating a Google Firestore client for every request, since it does authentication setup on creation. Instead, create a single client that will be used for all requests.

--- a/docs/documenteer.toml
+++ b/docs/documenteer.toml
@@ -35,6 +35,7 @@ nitpick_ignore = [
     # by having Sphinx complain about a new symbol.
     ["py:class", "dataclasses_avroschema.pydantic.main.AvroBaseModel"],
     ["py:class", "dataclasses_avroschema.main.AvroModel"],
+    ["py:class", "google.cloud.firestore_v1.async_client.AsyncClient"],
     ["py:class", "fastapi.applications.FastAPI"],
     ["py:class", "fastapi.datastructures.DefaultPlaceholder"],
     ["py:class", "fastapi.exceptions.HTTPException"],


### PR DESCRIPTION
Stop creating a Google Firestore client for every request, since creating the client does some authentication setup. Instead, create a single client and reuse it for the lifetime of the process.