### PR TITLE
DM-47716: Move all session management to service layer

### DIFF
--- a/src/gafaelfawr/cli.py
+++ b/src/gafaelfawr/cli.py
@@ -97,8 +97,7 @@ async def audit(*, fix: bool, config_path: Path | None) -> None:
             msg = "Slack alerting required for audit but not configured"
             raise click.UsageError(msg)
         token_service = factory.create_token_service()
-        async with factory.session.begin():
-            alerts = await token_service.audit(fix=fix)
+        alerts = await token_service.audit(fix=fix)
         if alerts:
             message = (
                 "Gafaelfawr data inconsistencies found:\n• "
@@ -141,7 +140,7 @@ async def delete_all_data(*, config_path: Path | None) -> None:
             stmt = text(f'TRUNCATE TABLE {", ".join(tables)}')
             logger.info("Truncating all tables")
             await factory.session.execute(stmt)
-            await admin_service.add_initial_admins(config.initial_admins)
+        await admin_service.add_initial_admins(config.initial_admins)
         token_service = factory.create_token_service()
         logger.info("Deleting all tokens from Redis")
         await token_service.delete_all_tokens()
@@ -256,17 +255,15 @@ async def maintenance(*, config_path: Path | None) -> None:
     logger.debug("Starting background maintenance")
     async with Factory.standalone(config, engine, check_db=True) as factory:
         token_service = factory.create_token_service()
-        async with factory.session.begin():
-            logger.info("Marking expired tokens in database")
-            await token_service.expire_tokens()
-            logger.info("Truncating token history")
-            await token_service.truncate_history()
+        logger.info("Marking expired tokens in database")
+        await token_service.expire_tokens()
+        logger.info("Truncating token history")
+        await token_service.truncate_history()
         event_manager = config.metrics.make_manager()
         await event_manager.initialize()
         events = StateEvents()
         await events.initialize(event_manager)
-        async with factory.session.begin():
-            await token_service.gather_state_metrics(events)
+        await token_service.gather_state_metrics(events)
     await engine.dispose()
     logger.debug("Finished background maintenance")
 

--- a/src/gafaelfawr/database.py
+++ b/src/gafaelfawr/database.py
@@ -78,8 +78,7 @@ async def initialize_gafaelfawr_database(
     async with Factory.standalone(config, engine) as factory:
         admin_service = factory.create_admin_service()
         logger.debug("Adding initial administrators")
-        async with factory.session.begin():
-            await admin_service.add_initial_admins(config.initial_admins)
+        await admin_service.add_initial_admins(config.initial_admins)
         if config.firestore:
             firestore = factory.create_firestore_storage()
             logger.debug("Initializing Firestore")

--- a/src/gafaelfawr/factory.py
+++ b/src/gafaelfawr/factory.py
@@ -291,8 +291,7 @@ class Factory:
 
            async with Factory.standalone(config, engine) as factory:
                token_service = factory.create_token_service()
-               async with factory.session.begin():
-                   alerts = await token_service.audit(fix=fix)
+               alerts = await token_service.audit(fix=fix)
         """
         factory = await cls.create(config, engine, check_db=check_db)
         async with aclosing(factory):
@@ -334,7 +333,12 @@ class Factory:
         """
         admin_store = AdminStore(self.session)
         admin_history_store = AdminHistoryStore(self.session)
-        return AdminService(admin_store, admin_history_store, self._logger)
+        return AdminService(
+            admin_store=admin_store,
+            admin_history_store=admin_history_store,
+            session=self.session,
+            logger=self._logger,
+        )
 
     def create_firestore_service(self) -> FirestoreService:
         """Create the Firestore service layer.
@@ -378,6 +382,7 @@ class Factory:
             user_info_service=self.create_user_info_service(),
             token_db_store=TokenDatabaseStore(self.session),
             token_redis_store=self.create_token_redis_store(),
+            session=self.session,
         )
 
     def create_kubernetes_ingress_service(
@@ -420,7 +425,6 @@ class Factory:
         return KubernetesTokenService(
             token_service=token_service,
             storage=storage,
-            session=self.session,
             logger=self._logger,
         )
 
@@ -592,6 +596,8 @@ class Factory:
             token_db_store=token_db_store,
             token_redis_store=token_redis_store,
             token_change_store=token_change_store,
+            admin_store=AdminStore(self.session),
+            session=self.session,
             logger=self._logger,
         )
 

--- a/src/gafaelfawr/handlers/api.py
+++ b/src/gafaelfawr/handlers/api.py
@@ -86,8 +86,7 @@ async def get_admins(
     context: Annotated[RequestContext, Depends(context_dependency)],
 ) -> list[Admin]:
     admin_service = context.factory.create_admin_service()
-    async with context.session.begin():
-        return await admin_service.get_admins()
+    return await admin_service.get_admins()
 
 
 @router.post(
@@ -103,12 +102,11 @@ async def add_admin(
     context: Annotated[RequestContext, Depends(context_dependency)],
 ) -> None:
     admin_service = context.factory.create_admin_service()
-    async with context.session.begin():
-        await admin_service.add_admin(
-            admin.username,
-            actor=auth_data.username,
-            ip_address=context.ip_address,
-        )
+    await admin_service.add_admin(
+        admin.username,
+        actor=auth_data.username,
+        ip_address=context.ip_address,
+    )
 
 
 @router.delete(
@@ -138,10 +136,9 @@ async def delete_admin(
     context: Annotated[RequestContext, Depends(context_dependency)],
 ) -> None:
     admin_service = context.factory.create_admin_service()
-    async with context.session.begin():
-        success = await admin_service.delete_admin(
-            username, actor=auth_data.username, ip_address=context.ip_address
-        )
+    success = await admin_service.delete_admin(
+        username, actor=auth_data.username, ip_address=context.ip_address
+    )
     if not success:
         msg = "Specified user is not an administrator"
         raise NotFoundError(msg, ErrorLocation.path, ["username"])
@@ -250,19 +247,18 @@ async def get_admin_token_change_history(
     response: Response,
 ) -> list[dict[str, Any]]:
     token_service = context.factory.create_token_service()
-    async with context.session.begin():
-        results = await token_service.get_change_history(
-            auth_data,
-            cursor=cursor,
-            limit=limit,
-            since=since,
-            until=until,
-            username=username,
-            actor=actor,
-            key=key,
-            token_type=token_type,
-            ip_or_cidr=ip_address,
-        )
+    results = await token_service.get_change_history(
+        auth_data,
+        cursor=cursor,
+        limit=limit,
+        since=since,
+        until=until,
+        username=username,
+        actor=actor,
+        key=key,
+        token_type=token_type,
+        ip_or_cidr=ip_address,
+    )
     if limit:
         response.headers["Link"] = results.link_header(context.request.url)
         response.headers["X-Total-Count"] = str(results.count)
@@ -314,10 +310,7 @@ async def get_token_info(
     context: Annotated[RequestContext, Depends(context_dependency)],
 ) -> TokenInfo:
     token_service = context.factory.create_token_service()
-    async with context.session.begin():
-        info = await token_service.get_token_info_unchecked(
-            auth_data.token.key
-        )
+    info = await token_service.get_token_info_unchecked(auth_data.token.key)
     if info:
         return info
     else:
@@ -354,10 +347,9 @@ async def post_admin_tokens(
     response: Response,
 ) -> NewToken:
     token_service = context.factory.create_token_service()
-    async with context.session.begin():
-        token = await token_service.create_token_from_admin_request(
-            token_request, auth_data, ip_address=context.ip_address
-        )
+    token = await token_service.create_token_from_admin_request(
+        token_request, auth_data, ip_address=context.ip_address
+    )
     response.headers["Location"] = quote(
         f"/auth/api/v1/users/{token_request.username}/tokens/{token.key}"
     )
@@ -484,18 +476,17 @@ async def get_user_token_change_history(
     response: Response,
 ) -> list[dict[str, Any]]:
     token_service = context.factory.create_token_service()
-    async with context.session.begin():
-        results = await token_service.get_change_history(
-            auth_data,
-            cursor=cursor,
-            username=username,
-            limit=limit,
-            since=since,
-            until=until,
-            key=key,
-            token_type=token_type,
-            ip_or_cidr=ip_address,
-        )
+    results = await token_service.get_change_history(
+        auth_data,
+        cursor=cursor,
+        username=username,
+        limit=limit,
+        since=since,
+        until=until,
+        key=key,
+        token_type=token_type,
+        ip_or_cidr=ip_address,
+    )
     if limit:
         response.headers["Link"] = results.link_header(context.request.url)
         response.headers["X-Total-Count"] = str(results.count)
@@ -525,8 +516,7 @@ async def get_tokens(
     context: Annotated[RequestContext, Depends(context_dependency)],
 ) -> list[TokenInfo]:
     token_service = context.factory.create_token_service()
-    async with context.session.begin():
-        return await token_service.list_tokens(auth_data, username)
+    return await token_service.list_tokens(auth_data, username)
 
 
 @router.post(
@@ -565,13 +555,12 @@ async def post_tokens(
 ) -> NewToken:
     token_service = context.factory.create_token_service()
     token_params = token_request.model_dump()
-    async with context.session.begin():
-        token = await token_service.create_user_token(
-            auth_data,
-            username,
-            ip_address=context.ip_address,
-            **token_params,
-        )
+    token = await token_service.create_user_token(
+        auth_data,
+        username,
+        ip_address=context.ip_address,
+        **token_params,
+    )
     response.headers["Location"] = quote(
         f"/auth/api/v1/users/{username}/tokens/{token.key}"
     )
@@ -611,8 +600,7 @@ async def get_token(
     context: Annotated[RequestContext, Depends(context_dependency)],
 ) -> TokenInfo:
     token_service = context.factory.create_token_service()
-    async with context.session.begin():
-        info = await token_service.get_token_info(key, auth_data, username)
+    info = await token_service.get_token_info(key, auth_data, username)
     if info:
         return info
     else:
@@ -651,10 +639,9 @@ async def delete_token(
     context: Annotated[RequestContext, Depends(context_dependency)],
 ) -> None:
     token_service = context.factory.create_token_service()
-    async with context.session.begin():
-        success = await token_service.delete_token(
-            key, auth_data, username, ip_address=context.ip_address
-        )
+    success = await token_service.delete_token(
+        key, auth_data, username, ip_address=context.ip_address
+    )
     if not success:
         raise NotFoundError("Token not found", ErrorLocation.path, ["key"])
 
@@ -704,14 +691,9 @@ async def patch_token(
     update = token_request.model_dump(exclude_unset=True)
     if "expires" in update and update["expires"] is None:
         update["no_expire"] = True
-    async with context.session.begin():
-        info = await token_service.modify_token(
-            key,
-            auth_data,
-            username,
-            ip_address=context.ip_address,
-            **update,
-        )
+    info = await token_service.modify_token(
+        key, auth_data, username, ip_address=context.ip_address, **update
+    )
     if not info:
         raise NotFoundError("Token not found", ErrorLocation.path, ["key"])
     return info
@@ -751,10 +733,9 @@ async def get_token_change_history(
     context: Annotated[RequestContext, Depends(context_dependency)],
 ) -> list[dict[str, Any]]:
     token_service = context.factory.create_token_service()
-    async with context.session.begin():
-        results = await token_service.get_change_history(
-            auth_data, username=username, key=key
-        )
+    results = await token_service.get_change_history(
+        auth_data, username=username, key=key
+    )
     if not results.entries:
         raise NotFoundError("Token not found", ErrorLocation.path, ["key"])
     return [r.model_dump_reduced() for r in results.entries]

--- a/src/gafaelfawr/handlers/login.py
+++ b/src/gafaelfawr/handlers/login.py
@@ -284,7 +284,6 @@ async def _construct_token(
         Raised if the user's username is invalid.
     """
     user_info_service = context.factory.create_user_info_service()
-    admin_service = context.factory.create_admin_service()
     token_service = context.factory.create_token_service()
 
     # Get the user's scopes.
@@ -295,12 +294,9 @@ async def _construct_token(
         raise NoScopesError(msg)
 
     # Construct a token.
-    async with context.session.begin():
-        if await admin_service.is_admin(user_info.username):
-            scopes = sorted([*scopes, "admin:token"])
-        return await token_service.create_session_token(
-            user_info, scopes=scopes, ip_address=context.ip_address
-        )
+    return await token_service.create_session_token(
+        user_info, scopes=scopes, ip_address=context.ip_address
+    )
 
 
 async def _error_system(

--- a/src/gafaelfawr/handlers/oidc.py
+++ b/src/gafaelfawr/handlers/oidc.py
@@ -258,25 +258,24 @@ async def post_token(
     if credentials:
         client_id = credentials.username
         client_secret = credentials.password
-    async with context.session.begin():
-        try:
-            reply = await oidc_service.redeem_code(
-                grant_type=grant_type,
-                client_id=client_id,
-                client_secret=client_secret,
-                redirect_uri=redirect_uri,
-                code=code,
-                ip_address=context.ip_address,
-            )
-        except OAuthError as e:
-            context.logger.warning("%s", e.message, error=str(e))
-            content = {
-                "error": e.error,
-                "error_description": e.message if e.hide_error else str(e),
-            }
-            return JSONResponse(
-                status_code=status.HTTP_400_BAD_REQUEST, content=content
-            )
+    try:
+        reply = await oidc_service.redeem_code(
+            grant_type=grant_type,
+            client_id=client_id,
+            client_secret=client_secret,
+            redirect_uri=redirect_uri,
+            code=code,
+            ip_address=context.ip_address,
+        )
+    except OAuthError as e:
+        context.logger.warning("%s", e.message, error=str(e))
+        content = {
+            "error": e.error,
+            "error_description": e.message if e.hide_error else str(e),
+        }
+        return JSONResponse(
+            status_code=status.HTTP_400_BAD_REQUEST, content=content
+        )
 
     # Return the token to the caller.  The headers are mandated by RFC 6749.
     response.headers["Cache-Control"] = "no-store"

--- a/src/gafaelfawr/services/health.py
+++ b/src/gafaelfawr/services/health.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from sqlalchemy.ext.asyncio import async_scoped_session
+
 from ..models.token import TokenType
 from ..storage.token import TokenDatabaseStore, TokenRedisStore
 from .userinfo import UserInfoService
@@ -23,6 +25,8 @@ class HealthCheckService:
         Redis backing store for tokens.
     user_info_service
         Service for retrieving user information from LDAP and Firestore.
+    session
+        Database session.
     """
 
     def __init__(
@@ -31,10 +35,12 @@ class HealthCheckService:
         token_db_store: TokenDatabaseStore,
         token_redis_store: TokenRedisStore,
         user_info_service: UserInfoService,
+        session: async_scoped_session,
     ) -> None:
         self._db = token_db_store
         self._redis = token_redis_store
         self._userinfo = user_info_service
+        self._session = session
 
     async def check(self, *, check_user_info: bool = True) -> None:
         """Check the health of the underlying database and Redis.
@@ -49,9 +55,10 @@ class HealthCheckService:
             This is disabled for the Kubernetes operator, which doesn't need
             access to those.
         """
-        tokens = await self._db.list_tokens(
-            token_type=TokenType.session, limit=1
-        )
+        async with self._session.begin():
+            tokens = await self._db.list_tokens(
+                token_type=TokenType.session, limit=1
+            )
 
         # If we can't find a user session token, we don't have a token key for
         # Redis or a username for LDAP, and thus unfortunately can't test the

--- a/tests/handlers/api_admins_test.py
+++ b/tests/handlers/api_admins_test.py
@@ -40,10 +40,9 @@ async def test_admins(
     assert r.json() == [{"username": "admin"}]
 
     admin_service = factory.create_admin_service()
-    async with factory.session.begin():
-        await admin_service.add_admin(
-            "example", actor="admin", ip_address="127.0.0.1"
-        )
+    await admin_service.add_admin(
+        "example", actor="admin", ip_address="127.0.0.1"
+    )
 
     r = await client.get(
         "/auth/api/v1/admins",
@@ -67,7 +66,7 @@ async def test_add_delete(client: AsyncClient, factory: Factory) -> None:
     assert r.status_code == 401
 
     # Adding or deleting without the appropriate scopes should fail.
-    token_data = await create_session_token(factory, username="admin")
+    token_data = await create_session_token(factory, username="not-admin")
     csrf = await set_session_cookie(client, token_data.token)
     r = await client.post(
         "/auth/api/v1/admins",
@@ -90,9 +89,7 @@ async def test_add_delete(client: AsyncClient, factory: Factory) -> None:
 
     # Adding without the appropriate CSRF token should fail, but with a CSRF
     # token should succeed.
-    token_data = await create_session_token(
-        factory, username="admin", scopes=["admin:token"]
-    )
+    token_data = await create_session_token(factory, username="admin")
     csrf = await set_session_cookie(client, token_data.token)
     r = await client.post(
         "/auth/api/v1/admins", json={"username": "new-admin"}

--- a/tests/handlers/api_tokens_test.py
+++ b/tests/handlers/api_tokens_test.py
@@ -39,12 +39,11 @@ async def test_create_delete_modify(
         groups=[Group(name="foo", id=12313)],
     )
     token_service = factory.create_token_service()
-    async with factory.session.begin():
-        session_token = await token_service.create_session_token(
-            user_info,
-            scopes=["read:all", "exec:admin", "user:token"],
-            ip_address="127.0.0.1",
-        )
+    session_token = await token_service.create_session_token(
+        user_info,
+        scopes=["read:all", "exec:admin", "user:token"],
+        ip_address="127.0.0.1",
+    )
     csrf = await set_session_cookie(client, session_token)
 
     caplog.clear()
@@ -157,10 +156,9 @@ async def test_create_delete_modify(
     assert r.json()["detail"][0]["type"] == "permission_denied"
 
     # Get a token admin token, which will be allowed to modify the token.
-    async with factory.session.begin():
-        admin_token = await token_service.create_session_token(
-            user_info, scopes=["admin:token"], ip_address="127.0.0.1"
-        )
+    admin_token = await token_service.create_session_token(
+        user_info, scopes=["admin:token"], ip_address="127.0.0.1"
+    )
     csrf = await set_session_cookie(client, admin_token)
 
     # Change the name, scope, and expiration of the token.
@@ -303,12 +301,11 @@ async def test_token_info(
         groups=[Group(name="foo", id=12313)],
     )
     token_service = factory.create_token_service()
-    async with factory.session.begin():
-        session_token = await token_service.create_session_token(
-            user_info,
-            scopes=["exec:admin", "user:token"],
-            ip_address="127.0.0.1",
-        )
+    session_token = await token_service.create_session_token(
+        user_info,
+        scopes=["exec:admin", "user:token"],
+        ip_address="127.0.0.1",
+    )
 
     r = await client.get(
         "/auth/api/v1/token-info",
@@ -349,15 +346,14 @@ async def test_token_info(
     # data.
     expires = now + timedelta(days=100)
     data = await token_service.get_data(session_token)
-    async with factory.session.begin():
-        user_token = await token_service.create_user_token(
-            data,
-            data.username,
-            token_name="some-token",
-            scopes=["exec:admin"],
-            expires=expires,
-            ip_address="127.0.0.1",
-        )
+    user_token = await token_service.create_user_token(
+        data,
+        data.username,
+        token_name="some-token",
+        scopes=["exec:admin"],
+        expires=expires,
+        ip_address="127.0.0.1",
+    )
 
     r = await client.get(
         "/auth/api/v1/token-info",
@@ -450,14 +446,13 @@ async def test_csrf_required(
     token_data = await create_session_token(factory, scopes=["admin:token"])
     csrf = await set_session_cookie(client, token_data.token)
     token_service = factory.create_token_service()
-    async with factory.session.begin():
-        user_token = await token_service.create_user_token(
-            token_data,
-            token_data.username,
-            token_name="foo",
-            scopes=[],
-            ip_address="127.0.0.1",
-        )
+    user_token = await token_service.create_user_token(
+        token_data,
+        token_data.username,
+        token_name="foo",
+        scopes=[],
+        ip_address="127.0.0.1",
+    )
 
     r = await client.post(
         "/auth/api/v1/tokens",
@@ -564,14 +559,13 @@ async def test_no_scope(
 ) -> None:
     token_data = await create_session_token(factory)
     token_service = factory.create_token_service()
-    async with factory.session.begin():
-        token = await token_service.create_user_token(
-            token_data,
-            token_data.username,
-            token_name="user",
-            scopes=[],
-            ip_address="127.0.0.1",
-        )
+    token = await token_service.create_user_token(
+        token_data,
+        token_data.username,
+        token_name="user",
+        scopes=[],
+        ip_address="127.0.0.1",
+    )
 
     r = await client.get(
         f"/auth/api/v1/users/{token_data.username}/tokens",
@@ -639,20 +633,18 @@ async def test_wrong_user(
     user_info = TokenUserInfo(
         username="other-person", name="Some Other Person", uid=137123
     )
-    async with factory.session.begin():
-        other_session_token = await token_service.create_session_token(
-            user_info, scopes=["user:token"], ip_address="127.0.0.1"
-        )
+    other_session_token = await token_service.create_session_token(
+        user_info, scopes=["user:token"], ip_address="127.0.0.1"
+    )
     other_session_data = await token_service.get_data(other_session_token)
     assert other_session_data
-    async with factory.session.begin():
-        other_token = await token_service.create_user_token(
-            other_session_data,
-            "other-person",
-            token_name="foo",
-            scopes=[],
-            ip_address="127.0.0.1",
-        )
+    other_token = await token_service.create_user_token(
+        other_session_data,
+        "other-person",
+        token_name="foo",
+        scopes=[],
+        ip_address="127.0.0.1",
+    )
 
     # Get a token list.
     r = await client.get("/auth/api/v1/users/other-person/tokens")
@@ -1348,12 +1340,11 @@ async def test_no_form_post(
         groups=[Group(name="foo", id=12313)],
     )
     token_service = factory.create_token_service()
-    async with factory.session.begin():
-        session_token = await token_service.create_session_token(
-            user_info,
-            scopes=["read:all", "exec:admin", "user:token"],
-            ip_address="127.0.0.1",
-        )
+    session_token = await token_service.create_session_token(
+        user_info,
+        scopes=["read:all", "exec:admin", "user:token"],
+        ip_address="127.0.0.1",
+    )
     csrf = await set_session_cookie(client, session_token)
 
     expires = current_datetime() + timedelta(days=100)
@@ -1391,12 +1382,11 @@ async def test_scope_modify(
         groups=[Group(name="foo", id=12313)],
     )
     token_service = factory.create_token_service()
-    async with factory.session.begin():
-        session_token = await token_service.create_session_token(
-            user_info,
-            scopes=["admin:token", "read:all", "exec:admin", "user:token"],
-            ip_address="127.0.0.1",
-        )
+    session_token = await token_service.create_session_token(
+        user_info,
+        scopes=["admin:token", "read:all", "exec:admin", "user:token"],
+        ip_address="127.0.0.1",
+    )
     csrf = await set_session_cookie(client, session_token)
 
     expires = current_datetime() + timedelta(days=100)

--- a/tests/handlers/cadc_test.py
+++ b/tests/handlers/cadc_test.py
@@ -30,10 +30,9 @@ async def test_userinfo(
         expires=expires,
     )
     token_service = factory.create_token_service()
-    async with factory.session.begin():
-        token = await token_service.create_token_from_admin_request(
-            request, TokenData.internal_token(), ip_address=None
-        )
+    token = await token_service.create_token_from_admin_request(
+        request, TokenData.internal_token(), ip_address=None
+    )
 
     r = await client.get(
         "/auth/cadc/userinfo", headers={"Authorization": f"bearer {token}"}

--- a/tests/handlers/ingress_test.py
+++ b/tests/handlers/ingress_test.py
@@ -227,10 +227,9 @@ async def test_success(client: AsyncClient, factory: Factory) -> None:
 async def test_success_minimal(client: AsyncClient, factory: Factory) -> None:
     user_info = TokenUserInfo(username="user", uid=1234)
     token_service = factory.create_token_service()
-    async with factory.session.begin():
-        token = await token_service.create_session_token(
-            user_info, scopes=["read:all"], ip_address="127.0.0.1"
-        )
+    token = await token_service.create_session_token(
+        user_info, scopes=["read:all"], ip_address="127.0.0.1"
+    )
 
     r = await client.get(
         "/ingress/auth",
@@ -630,10 +629,9 @@ async def test_success_unicode_name(
 ) -> None:
     user_info = TokenUserInfo(username="user", uid=1234, name="名字")
     token_service = factory.create_token_service()
-    async with factory.session.begin():
-        token = await token_service.create_session_token(
-            user_info, scopes=["read:all"], ip_address="127.0.0.1"
-        )
+    token = await token_service.create_session_token(
+        user_info, scopes=["read:all"], ip_address="127.0.0.1"
+    )
 
     r = await client.get(
         "/ingress/auth",
@@ -650,14 +648,13 @@ async def test_minimum_lifetime(
 ) -> None:
     user_info = TokenUserInfo(username="user", uid=1234, name="Some User")
     token_service = factory.create_token_service()
-    async with factory.session.begin():
-        token = await token_service.create_session_token(
-            user_info,
-            scopes=["read:all", "user:token"],
-            ip_address="127.0.0.1",
-        )
-        token_data = await token_service.get_data(token)
-        assert token_data
+    token = await token_service.create_session_token(
+        user_info,
+        scopes=["read:all", "user:token"],
+        ip_address="127.0.0.1",
+    )
+    token_data = await token_service.get_data(token)
+    assert token_data
 
     # Required lifetime is within MINIMUM_LIFETIME of maximum token lifetime.
     minimum_lifetime = MINIMUM_LIFETIME - timedelta(seconds=1)
@@ -676,16 +673,15 @@ async def test_minimum_lifetime(
     assert r.json()["detail"][0]["type"] == "invalid_minimum_lifetime"
 
     # Create a user token with a short lifetime.
-    async with factory.session.begin():
-        expires = current_datetime() + timedelta(hours=1)
-        token = await token_service.create_user_token(
-            token_data,
-            "user",
-            token_name="token",
-            scopes=["read:all"],
-            expires=expires,
-            ip_address="127.0.0.1",
-        )
+    expires = current_datetime() + timedelta(hours=1)
+    token = await token_service.create_user_token(
+        token_data,
+        "user",
+        token_name="token",
+        scopes=["read:all"],
+        expires=expires,
+        ip_address="127.0.0.1",
+    )
 
     # Try to authenticate with a longer requested lifetime.
     r = await client.get(
@@ -747,14 +743,13 @@ async def test_default_minimum_lifetime(
     # Create a token and then change it to expire in one minute.  We only
     # change Redis, which is canonical; no need to change the database as
     # well.
-    async with factory.session.begin():
-        token = await token_service.create_session_token(
-            user_info, scopes=["user:token"], ip_address="127.0.0.1"
-        )
-        token_data = await token_service.get_data(token)
-        assert token_data
-        token_data.expires = current_datetime() + timedelta(minutes=1)
-        await token_service._token_redis_store.store_data(token_data)
+    token = await token_service.create_session_token(
+        user_info, scopes=["user:token"], ip_address="127.0.0.1"
+    )
+    token_data = await token_service.get_data(token)
+    assert token_data
+    token_data.expires = current_datetime() + timedelta(minutes=1)
+    await token_service._token_redis_store.store_data(token_data)
 
     # Check that one can authenticate with this token.
     r = await client.get(

--- a/tests/handlers/internal_test.py
+++ b/tests/handlers/internal_test.py
@@ -48,10 +48,9 @@ async def test_health(
     # server is responding.
     await reconfigure("oidc")
     token_service = factory.create_token_service()
-    async with factory.session.begin():
-        await token_service.delete_token(
-            token.token.key, token, token.username, ip_address="127.0.0.1"
-        )
+    await token_service.delete_token(
+        token.token.key, token, token.username, ip_address="127.0.0.1"
+    )
     token = await create_session_token(factory)
     r = await client.get("/health")
     assert r.status_code == 200

--- a/tests/handlers/login_github_test.py
+++ b/tests/handlers/login_github_test.py
@@ -367,10 +367,9 @@ async def test_github_admin(
 ) -> None:
     """Test that a token administrator gets the admin:token scope."""
     admin_service = factory.create_admin_service()
-    async with factory.session.begin():
-        await admin_service.add_admin(
-            "someuser", actor="admin", ip_address="127.0.0.1"
-        )
+    await admin_service.add_admin(
+        "someuser", actor="admin", ip_address="127.0.0.1"
+    )
     user_info = GitHubUserInfo(
         name="A User",
         username="someuser",

--- a/tests/handlers/oidc_test.py
+++ b/tests/handlers/oidc_test.py
@@ -661,10 +661,9 @@ async def test_token_errors(
 
     # Delete the underlying token.
     token_service = factory.create_token_service()
-    async with factory.session.begin():
-        await token_service.delete_token(
-            token.key, token_data, token_data.username, ip_address="127.0.0.1"
-        )
+    await token_service.delete_token(
+        token.key, token_data, token_data.username, ip_address="127.0.0.1"
+    )
     request["redirect_uri"] = redirect_uri
     r = await client.post("/auth/openid/token", data=request)
     assert r.status_code == 400

--- a/tests/handlers/quota_test.py
+++ b/tests/handlers/quota_test.py
@@ -19,10 +19,9 @@ async def test_info(client: AsyncClient, factory: Factory) -> None:
         username="example", groups=[Group(name="bar", id=12312)]
     )
     token_service = factory.create_token_service()
-    async with factory.session.begin():
-        token = await token_service.create_session_token(
-            user_info, scopes=["user:token"], ip_address="127.0.0.1"
-        )
+    token = await token_service.create_session_token(
+        user_info, scopes=["user:token"], ip_address="127.0.0.1"
+    )
 
     r = await client.get(
         "/auth/api/v1/user-info", headers={"Authorization": f"bearer {token}"}
@@ -38,10 +37,9 @@ async def test_info(client: AsyncClient, factory: Factory) -> None:
     }
 
     user_info.groups = [Group(name="foo", id=12313)]
-    async with factory.session.begin():
-        token = await token_service.create_session_token(
-            user_info, scopes=["user:token"], ip_address="127.0.0.1"
-        )
+    token = await token_service.create_session_token(
+        user_info, scopes=["user:token"], ip_address="127.0.0.1"
+    )
 
     r = await client.get(
         "/auth/api/v1/user-info", headers={"Authorization": f"bearer {token}"}

--- a/tests/operator/tokens_test.py
+++ b/tests/operator/tokens_test.py
@@ -171,16 +171,15 @@ async def test_secret_verification(
     await assert_secrets_match(factory, api_client, tokens)
 
     # Replace one secret with a valid token for the wrong service.
-    async with factory.session.begin():
-        token = await token_service.create_token_from_admin_request(
-            AdminTokenRequest(
-                username="bot-some-other-service",
-                token_type=TokenType.service,
-                scopes=["admin:token"],
-            ),
-            TokenData.internal_token(),
-            ip_address=None,
-        )
+    token = await token_service.create_token_from_admin_request(
+        AdminTokenRequest(
+            username="bot-some-other-service",
+            token_type=TokenType.service,
+            scopes=["admin:token"],
+        ),
+        TokenData.internal_token(),
+        ip_address=None,
+    )
     secret = V1Secret(
         api_version="v1",
         kind="Secret",
@@ -195,16 +194,15 @@ async def test_secret_verification(
     )
 
     # Replace the other token with a valid token with the wrong scopes.
-    async with factory.session.begin():
-        token = await token_service.create_token_from_admin_request(
-            AdminTokenRequest(
-                username=tokens[1]["spec"]["service"],
-                token_type=TokenType.service,
-                scopes=["read:all"],
-            ),
-            TokenData.internal_token(),
-            ip_address=None,
-        )
+    token = await token_service.create_token_from_admin_request(
+        AdminTokenRequest(
+            username=tokens[1]["spec"]["service"],
+            token_type=TokenType.service,
+            scopes=["read:all"],
+        ),
+        TokenData.internal_token(),
+        ip_address=None,
+    )
     secret = V1Secret(
         api_version="v1",
         kind="Secret",

--- a/tests/services/oidc_test.py
+++ b/tests/services/oidc_test.py
@@ -110,15 +110,14 @@ async def test_redeem_code(
         scopes=[OIDCScope.openid, OIDCScope.profile],
     )
 
-    async with factory.session.begin():
-        reply = await oidc_service.redeem_code(
-            grant_type="authorization_code",
-            client_id="client-2",
-            client_secret="client-2-secret",
-            redirect_uri=redirect_uri,
-            code=str(code),
-            ip_address="127.0.0.1",
-        )
+    reply = await oidc_service.redeem_code(
+        grant_type="authorization_code",
+        client_id="client-2",
+        client_secret="client-2-secret",
+        redirect_uri=redirect_uri,
+        code=str(code),
+        ip_address="127.0.0.1",
+    )
     assert reply.scope == "openid profile"
     assert reply.token_type == "Bearer"
     id_token = oidc_service.verify_token(OIDCToken(encoded=reply.id_token))
@@ -158,10 +157,9 @@ async def test_redeem_code(
 
     # If the parent session token is revoked, the oidc token returned as an
     # access token should also be revoked.
-    async with factory.session.begin():
-        await token_service.delete_token(
-            token.key, token_data, token_data.username, ip_address="127.0.0.1"
-        )
+    await token_service.delete_token(
+        token.key, token_data, token_data.username, ip_address="127.0.0.1"
+    )
     assert await token_service.get_data(access_token) is None
 
 
@@ -190,96 +188,94 @@ async def test_redeem_code_errors(
         scopes=[OIDCScope.openid],
     )
 
-    async with factory.session.begin():
-        with pytest.raises(InvalidRequestError):
-            await oidc_service.redeem_code(
-                grant_type=None,
-                client_id="some-client",
-                client_secret="some-secret",
-                redirect_uri=redirect_uri,
-                code=str(code),
-                ip_address="127.0.0.1",
-            )
-        with pytest.raises(UnsupportedGrantTypeError):
-            await oidc_service.redeem_code(
-                grant_type="something_else",
-                client_id="some-client",
-                client_secret="some-secret",
-                redirect_uri=redirect_uri,
-                code=str(code),
-                ip_address="127.0.0.1",
-            )
-        with pytest.raises(InvalidClientError):
-            await oidc_service.redeem_code(
-                grant_type="authorization_code",
-                client_id="some-client",
-                client_secret="some-secret",
-                redirect_uri=redirect_uri,
-                code=str(code),
-                ip_address="127.0.0.1",
-            )
-        with pytest.raises(InvalidClientError):
-            await oidc_service.redeem_code(
-                grant_type="authorization_code",
-                client_id="client-2",
-                client_secret="some-secret",
-                redirect_uri=redirect_uri,
-                code=str(code),
-                ip_address="127.0.0.1",
-            )
-        with pytest.raises(InvalidGrantError):
-            await oidc_service.redeem_code(
-                grant_type="authorization_code",
-                client_id="client-2",
-                client_secret="client-2-secret",
-                redirect_uri=redirect_uri,
-                code=str(OIDCAuthorizationCode()),
-                ip_address="127.0.0.1",
-            )
-        with pytest.raises(InvalidGrantError):
-            await oidc_service.redeem_code(
-                grant_type="authorization_code",
-                client_id="client-1",
-                client_secret="client-1-secret",
-                redirect_uri=redirect_uri,
-                code=str(code),
-                ip_address="127.0.0.1",
-            )
-        with pytest.raises(InvalidGrantError):
-            await oidc_service.redeem_code(
-                grant_type="authorization_code",
-                client_id="client-2",
-                client_secret="client-2-secret",
-                redirect_uri="https://foo.example.com/",
-                code=str(code),
-                ip_address="127.0.0.1",
-            )
-        with pytest.raises(InvalidGrantError):
-            wrong_secret = OIDCAuthorizationCode(key=code.key)
-            await oidc_service.redeem_code(
-                grant_type="authorization_code",
-                client_id="client-2",
-                client_secret="client-2-secret",
-                redirect_uri="https://foo.example.com/",
-                code=str(wrong_secret),
-                ip_address="127.0.0.1",
-            )
+    with pytest.raises(InvalidRequestError):
+        await oidc_service.redeem_code(
+            grant_type=None,
+            client_id="some-client",
+            client_secret="some-secret",
+            redirect_uri=redirect_uri,
+            code=str(code),
+            ip_address="127.0.0.1",
+        )
+    with pytest.raises(UnsupportedGrantTypeError):
+        await oidc_service.redeem_code(
+            grant_type="something_else",
+            client_id="some-client",
+            client_secret="some-secret",
+            redirect_uri=redirect_uri,
+            code=str(code),
+            ip_address="127.0.0.1",
+        )
+    with pytest.raises(InvalidClientError):
+        await oidc_service.redeem_code(
+            grant_type="authorization_code",
+            client_id="some-client",
+            client_secret="some-secret",
+            redirect_uri=redirect_uri,
+            code=str(code),
+            ip_address="127.0.0.1",
+        )
+    with pytest.raises(InvalidClientError):
+        await oidc_service.redeem_code(
+            grant_type="authorization_code",
+            client_id="client-2",
+            client_secret="some-secret",
+            redirect_uri=redirect_uri,
+            code=str(code),
+            ip_address="127.0.0.1",
+        )
+    with pytest.raises(InvalidGrantError):
+        await oidc_service.redeem_code(
+            grant_type="authorization_code",
+            client_id="client-2",
+            client_secret="client-2-secret",
+            redirect_uri=redirect_uri,
+            code=str(OIDCAuthorizationCode()),
+            ip_address="127.0.0.1",
+        )
+    with pytest.raises(InvalidGrantError):
+        await oidc_service.redeem_code(
+            grant_type="authorization_code",
+            client_id="client-1",
+            client_secret="client-1-secret",
+            redirect_uri=redirect_uri,
+            code=str(code),
+            ip_address="127.0.0.1",
+        )
+    with pytest.raises(InvalidGrantError):
+        await oidc_service.redeem_code(
+            grant_type="authorization_code",
+            client_id="client-2",
+            client_secret="client-2-secret",
+            redirect_uri="https://foo.example.com/",
+            code=str(code),
+            ip_address="127.0.0.1",
+        )
+    with pytest.raises(InvalidGrantError):
+        wrong_secret = OIDCAuthorizationCode(key=code.key)
+        await oidc_service.redeem_code(
+            grant_type="authorization_code",
+            client_id="client-2",
+            client_secret="client-2-secret",
+            redirect_uri="https://foo.example.com/",
+            code=str(wrong_secret),
+            ip_address="127.0.0.1",
+        )
     assert mock_slack.messages == []
 
     # Malformed data in Redis.
     fernet = Fernet(config.session_secret.get_secret_value().encode())
     raw_data = fernet.encrypt(b"malformed json")
     await factory.redis.set(f"oidc:{code.key}", raw_data, ex=expires)
-    async with factory.session.begin():
-        with pytest.raises(InvalidGrantError):
-            await oidc_service.redeem_code(
-                grant_type="authorization_code",
-                client_id="client-2",
-                client_secret="client-2-secret",
-                redirect_uri=redirect_uri,
-                code=str(code),
-                ip_address="127.0.0.1",
-            )
+    with pytest.raises(InvalidGrantError):
+        await oidc_service.redeem_code(
+            grant_type="authorization_code",
+            client_id="client-2",
+            client_secret="client-2-secret",
+            redirect_uri=redirect_uri,
+            code=str(code),
+            ip_address="127.0.0.1",
+        )
     assert mock_slack.messages == [
         {
             "blocks": [
@@ -330,19 +326,18 @@ async def test_redeem_code_errors(
         scopes=[OIDCScope.openid],
     )
     token_service = factory.create_token_service()
-    async with factory.session.begin():
-        await token_service.delete_token(
-            token.key, token_data, token_data.username, ip_address="127.0.0.1"
+    await token_service.delete_token(
+        token.key, token_data, token_data.username, ip_address="127.0.0.1"
+    )
+    with pytest.raises(InvalidGrantError):
+        await oidc_service.redeem_code(
+            grant_type="authorization_code",
+            client_id="client-2",
+            client_secret="client-2-secret",
+            redirect_uri=redirect_uri,
+            code=str(code),
+            ip_address="127.0.0.1",
         )
-        with pytest.raises(InvalidGrantError):
-            await oidc_service.redeem_code(
-                grant_type="authorization_code",
-                client_id="client-2",
-                client_secret="client-2-secret",
-                redirect_uri=redirect_uri,
-                code=str(code),
-                ip_address="127.0.0.1",
-            )
 
 
 @pytest.mark.asyncio

--- a/tests/services/token_test.py
+++ b/tests/services/token_test.py
@@ -49,10 +49,9 @@ async def test_session_token(config: Config, factory: Factory) -> None:
         groups=[Group(name="group", id=1000), Group(name="another", id=3134)],
     )
 
-    async with factory.session.begin():
-        token = await token_service.create_session_token(
-            user_info, scopes=["user:token"], ip_address="127.0.0.1"
-        )
+    token = await token_service.create_session_token(
+        user_info, scopes=["user:token"], ip_address="127.0.0.1"
+    )
     data = await token_service.get_data(token)
     assert data
     assert data == TokenData(
@@ -70,8 +69,7 @@ async def test_session_token(config: Config, factory: Factory) -> None:
     expires = data.created + config.token_lifetime
     assert data.expires == expires
 
-    async with factory.session.begin():
-        info = await token_service.get_token_info_unchecked(token.key)
+    info = await token_service.get_token_info_unchecked(token.key)
     assert info
     assert info == TokenInfo(
         token=token.key,
@@ -85,10 +83,9 @@ async def test_session_token(config: Config, factory: Factory) -> None:
         parent=None,
     )
 
-    async with factory.session.begin():
-        history = await token_service.get_change_history(
-            data, token=token.key, username=data.username
-        )
+    history = await token_service.get_change_history(
+        data, token=token.key, username=data.username
+    )
     assert history.entries == [
         TokenChangeHistoryEntry(
             token=token.key,
@@ -104,18 +101,17 @@ async def test_session_token(config: Config, factory: Factory) -> None:
     ]
 
     # Test a session token with scopes.
-    async with factory.session.begin():
-        token = await token_service.create_session_token(
-            user_info,
-            scopes=["read:all", "exec:admin"],
-            ip_address="127.0.0.1",
-        )
-        data = await token_service.get_data(token)
-        assert data
-        assert data.scopes == ["exec:admin", "read:all"]
-        info = await token_service.get_token_info_unchecked(token.key)
-        assert info
-        assert info.scopes == ["exec:admin", "read:all"]
+    token = await token_service.create_session_token(
+        user_info,
+        scopes=["read:all", "exec:admin"],
+        ip_address="127.0.0.1",
+    )
+    data = await token_service.get_data(token)
+    assert data
+    assert data.scopes == ["exec:admin", "read:all"]
+    info = await token_service.get_token_info_unchecked(token.key)
+    assert info
+    assert info.scopes == ["exec:admin", "read:all"]
 
 
 @pytest.mark.asyncio
@@ -124,28 +120,26 @@ async def test_user_token(factory: Factory) -> None:
         username="example", name="Example Person", uid=4137
     )
     token_service = factory.create_token_service()
-    async with factory.session.begin():
-        session_token = await token_service.create_session_token(
-            user_info,
-            scopes=["read:all", "exec:admin", "user:token"],
-            ip_address="127.0.0.1",
-        )
+    session_token = await token_service.create_session_token(
+        user_info,
+        scopes=["read:all", "exec:admin", "user:token"],
+        ip_address="127.0.0.1",
+    )
     data = await token_service.get_data(session_token)
     assert data
     expires = current_datetime() + timedelta(days=2)
 
     # Scopes are provided not in sorted order to ensure they're sorted when
     # creating the token.
-    async with factory.session.begin():
-        user_token = await token_service.create_user_token(
-            data,
-            "example",
-            token_name="some-token",
-            scopes=["read:all", "exec:admin"],
-            expires=expires,
-            ip_address="192.168.0.1",
-        )
-        info = await token_service.get_token_info_unchecked(user_token.key)
+    user_token = await token_service.create_user_token(
+        data,
+        "example",
+        token_name="some-token",
+        scopes=["read:all", "exec:admin"],
+        expires=expires,
+        ip_address="192.168.0.1",
+    )
+    info = await token_service.get_token_info_unchecked(user_token.key)
     assert info
     assert info == TokenInfo(
         token=user_token.key,
@@ -170,10 +164,9 @@ async def test_user_token(factory: Factory) -> None:
         uid=user_info.uid,
     )
 
-    async with factory.session.begin():
-        history = await token_service.get_change_history(
-            data, token=user_token.key, username=data.username
-        )
+    history = await token_service.get_change_history(
+        data, token=user_token.key, username=data.username
+    )
     assert history.entries == [
         TokenChangeHistoryEntry(
             token=user_token.key,
@@ -199,18 +192,16 @@ async def test_notebook_token(config: Config, factory: Factory) -> None:
         groups=[Group(name="foo", id=1000)],
     )
     token_service = factory.create_token_service()
-    async with factory.session.begin():
-        session_token = await token_service.create_session_token(
-            user_info,
-            scopes=["read:all", "exec:admin", "user:token"],
-            ip_address="127.0.0.1",
-        )
+    session_token = await token_service.create_session_token(
+        user_info,
+        scopes=["read:all", "exec:admin", "user:token"],
+        ip_address="127.0.0.1",
+    )
     data = await token_service.get_data(session_token)
     assert data
 
     token = await token_service.get_notebook_token(data, ip_address="1.0.0.1")
-    async with factory.session.begin():
-        info = await token_service.get_token_info_unchecked(token.key)
+    info = await token_service.get_token_info_unchecked(token.key)
     assert info
     assert info == TokenInfo(
         token=token.key,
@@ -249,10 +240,9 @@ async def test_notebook_token(config: Config, factory: Factory) -> None:
     )
     assert token == new_token
 
-    async with factory.session.begin():
-        history = await token_service.get_change_history(
-            data, token=token.key, username=data.username
-        )
+    history = await token_service.get_change_history(
+        data, token=token.key, username=data.username
+    )
     assert history.entries == [
         TokenChangeHistoryEntry(
             token=token.key,
@@ -300,23 +290,21 @@ async def test_notebook_token(config: Config, factory: Factory) -> None:
 
     # Check that the expiration time is capped by creating a user token that
     # doesn't expire and then creating a notebook token from it.
-    async with factory.session.begin():
-        user_token = await token_service.create_user_token(
-            data,
-            data.username,
-            token_name="some token",
-            scopes=[],
-            expires=None,
-            ip_address="127.0.0.1",
-        )
+    user_token = await token_service.create_user_token(
+        data,
+        data.username,
+        token_name="some token",
+        scopes=[],
+        expires=None,
+        ip_address="127.0.0.1",
+    )
     data = await token_service.get_data(user_token)
     assert data
     new_token = await token_service.get_notebook_token(
         data, ip_address="127.0.0.1"
     )
     assert new_token != token
-    async with factory.session.begin():
-        info = await token_service.get_token_info_unchecked(new_token.key)
+    info = await token_service.get_token_info_unchecked(new_token.key)
     assert info
     expires = info.created + config.token_lifetime
     assert info.expires == expires
@@ -331,12 +319,11 @@ async def test_internal_token(config: Config, factory: Factory) -> None:
         groups=[Group(name="foo", id=1000)],
     )
     token_service = factory.create_token_service()
-    async with factory.session.begin():
-        session_token = await token_service.create_session_token(
-            user_info,
-            scopes=["read:all", "exec:admin", "user:token"],
-            ip_address="127.0.0.1",
-        )
+    session_token = await token_service.create_session_token(
+        user_info,
+        scopes=["read:all", "exec:admin", "user:token"],
+        ip_address="127.0.0.1",
+    )
     data = await token_service.get_data(session_token)
     assert data
 
@@ -346,8 +333,7 @@ async def test_internal_token(config: Config, factory: Factory) -> None:
         scopes=["read:all"],
         ip_address="2001:db8::45",
     )
-    async with factory.session.begin():
-        info = await token_service.get_token_info_unchecked(internal_token.key)
+    info = await token_service.get_token_info_unchecked(internal_token.key)
     assert info
     assert info == TokenInfo(
         token=internal_token.key,
@@ -403,10 +389,9 @@ async def test_internal_token(config: Config, factory: Factory) -> None:
     )
     assert internal_token == new_internal_token
 
-    async with factory.session.begin():
-        history = await token_service.get_change_history(
-            data, token=internal_token.key, username=data.username
-        )
+    history = await token_service.get_change_history(
+        data, token=internal_token.key, username=data.username
+    )
     assert history.entries == [
         TokenChangeHistoryEntry(
             token=internal_token.key,
@@ -478,25 +463,21 @@ async def test_internal_token(config: Config, factory: Factory) -> None:
     # Check that the expiration time is capped by creating a user token that
     # doesn't expire and then creating a notebook token from it.  Use this to
     # test a token with empty scopes.
-    async with factory.session.begin():
-        user_token = await token_service.create_user_token(
-            data,
-            data.username,
-            token_name="some token",
-            scopes=["exec:admin"],
-            expires=None,
-            ip_address="127.0.0.1",
-        )
+    user_token = await token_service.create_user_token(
+        data,
+        data.username,
+        token_name="some token",
+        scopes=["exec:admin"],
+        expires=None,
+        ip_address="127.0.0.1",
+    )
     data = await token_service.get_data(user_token)
     assert data
     new_internal_token = await token_service.get_internal_token(
         data, service="some-service", scopes=[], ip_address="127.0.0.1"
     )
     assert new_internal_token != internal_token
-    async with factory.session.begin():
-        info = await token_service.get_token_info_unchecked(
-            new_internal_token.key
-        )
+    info = await token_service.get_token_info_unchecked(new_internal_token.key)
     assert info
     assert info.scopes == []
     expires = info.created + config.token_lifetime
@@ -518,15 +499,14 @@ async def test_child_token_lifetime(config: Config, factory: Factory) -> None:
     token_lifetime_minutes = config.token_lifetime.total_seconds() / 60
     delta = timedelta(minutes=(token_lifetime_minutes / 2) - 5)
     expires = current_datetime() + delta
-    async with factory.session.begin():
-        user_token = await token_service.create_user_token(
-            session_token_data,
-            session_token_data.username,
-            token_name="n",
-            expires=expires,
-            scopes=[],
-            ip_address="127.0.0.1",
-        )
+    user_token = await token_service.create_user_token(
+        session_token_data,
+        session_token_data.username,
+        token_name="n",
+        expires=expires,
+        scopes=[],
+        ip_address="127.0.0.1",
+    )
     user_token_data = await token_service.get_data(user_token)
     assert user_token_data
 
@@ -558,14 +538,13 @@ async def test_child_token_lifetime(config: Config, factory: Factory) -> None:
     # internal token lifetime.
     new_delta = timedelta(minutes=token_lifetime_minutes * 2)
     expires = current_datetime() + new_delta
-    async with factory.session.begin():
-        assert await token_service.modify_token(
-            user_token.key,
-            session_token_data,
-            session_token_data.username,
-            ip_address="127.0.0.1",
-            expires=expires,
-        )
+    assert await token_service.modify_token(
+        user_token.key,
+        session_token_data,
+        session_token_data.username,
+        ip_address="127.0.0.1",
+        expires=expires,
+    )
     user_token_data = await token_service.get_data(user_token)
     assert user_token_data
 
@@ -590,15 +569,14 @@ async def test_child_token_lifetime(config: Config, factory: Factory) -> None:
     assert notebook_token_data.expires == notebook_token_data.created + delta
 
     # Change the expiration of the user token to no longer expire.
-    async with factory.session.begin():
-        assert await token_service.modify_token(
-            user_token.key,
-            session_token_data,
-            session_token_data.username,
-            ip_address="127.0.0.1",
-            expires=None,
-            no_expire=True,
-        )
+    assert await token_service.modify_token(
+        user_token.key,
+        session_token_data,
+        session_token_data.username,
+        ip_address="127.0.0.1",
+        expires=None,
+        no_expire=True,
+    )
     user_token_data = await token_service.get_data(user_token)
     assert user_token_data
 
@@ -620,10 +598,9 @@ async def test_token_from_admin_request(factory: Factory) -> None:
         username="example", name="Example Person", uid=4137
     )
     token_service = factory.create_token_service()
-    async with factory.session.begin():
-        token = await token_service.create_session_token(
-            user_info, scopes=[], ip_address="127.0.0.1"
-        )
+    token = await token_service.create_session_token(
+        user_info, scopes=[], ip_address="127.0.0.1"
+    )
     data = await token_service.get_data(token)
     assert data
     expires = current_datetime() + timedelta(days=2)
@@ -646,10 +623,9 @@ async def test_token_from_admin_request(factory: Factory) -> None:
         )
 
     # Get a token with an appropriate scope.
-    async with factory.session.begin():
-        session_token = await token_service.create_session_token(
-            user_info, scopes=["admin:token"], ip_address="127.0.0.1"
-        )
+    session_token = await token_service.create_session_token(
+        user_info, scopes=["admin:token"], ip_address="127.0.0.1"
+    )
     admin_data = await token_service.get_data(session_token)
     assert admin_data
 
@@ -668,10 +644,9 @@ async def test_token_from_admin_request(factory: Factory) -> None:
     request.expires = expires
 
     # Try a successful request.
-    async with factory.session.begin():
-        token = await token_service.create_token_from_admin_request(
-            request, admin_data, ip_address="127.0.0.1"
-        )
+    token = await token_service.create_token_from_admin_request(
+        request, admin_data, ip_address="127.0.0.1"
+    )
     user_data = await token_service.get_data(token)
     assert user_data
     assert user_data == TokenData(
@@ -679,10 +654,9 @@ async def test_token_from_admin_request(factory: Factory) -> None:
     )
     assert_is_now(user_data.created)
 
-    async with factory.session.begin():
-        history = await token_service.get_change_history(
-            admin_data, token=token.key, username=request.username
-        )
+    history = await token_service.get_change_history(
+        admin_data, token=token.key, username=request.username
+    )
     assert history.entries == [
         TokenChangeHistoryEntry(
             token=token.key,
@@ -708,10 +682,9 @@ async def test_token_from_admin_request(factory: Factory) -> None:
     request = AdminTokenRequest(
         username="bot-service", token_type=TokenType.service
     )
-    async with factory.session.begin():
-        token = await token_service.create_token_from_admin_request(
-            request, admin_data, ip_address="127.0.0.1"
-        )
+    token = await token_service.create_token_from_admin_request(
+        request, admin_data, ip_address="127.0.0.1"
+    )
     service_data = await token_service.get_data(token)
     assert service_data
     assert service_data == TokenData(
@@ -719,10 +692,9 @@ async def test_token_from_admin_request(factory: Factory) -> None:
     )
     assert_is_now(service_data.created)
 
-    async with factory.session.begin():
-        history = await token_service.get_change_history(
-            admin_data, token=token.key, username=request.username
-        )
+    history = await token_service.get_change_history(
+        admin_data, token=token.key, username=request.username
+    )
     assert history.entries == [
         TokenChangeHistoryEntry(
             token=token.key,
@@ -744,55 +716,52 @@ async def test_list(factory: Factory) -> None:
         username="example", name="Example Person", uid=4137
     )
     token_service = factory.create_token_service()
-    async with factory.session.begin():
-        session_token = await token_service.create_session_token(
-            user_info, scopes=["user:token"], ip_address="127.0.0.1"
-        )
+    session_token = await token_service.create_session_token(
+        user_info, scopes=["user:token"], ip_address="127.0.0.1"
+    )
     data = await token_service.get_data(session_token)
     assert data
-    async with factory.session.begin():
-        user_token = await token_service.create_user_token(
-            data,
-            data.username,
-            token_name="some-token",
-            scopes=[],
-            ip_address="127.0.0.1",
-        )
-        other_user_info = TokenUserInfo(
-            username="other", name="Other Person", uid=1313
-        )
-        other_session_token = await token_service.create_session_token(
-            other_user_info, scopes=["admin:token"], ip_address="1.1.1.1"
-        )
+    user_token = await token_service.create_user_token(
+        data,
+        data.username,
+        token_name="some-token",
+        scopes=[],
+        ip_address="127.0.0.1",
+    )
+    other_user_info = TokenUserInfo(
+        username="other", name="Other Person", uid=1313
+    )
+    other_session_token = await token_service.create_session_token(
+        other_user_info, scopes=["admin:token"], ip_address="1.1.1.1"
+    )
     admin_data = await token_service.get_data(other_session_token)
     assert admin_data
 
-    async with factory.session.begin():
-        session_info = await token_service.get_token_info_unchecked(
-            session_token.key
-        )
-        assert session_info
-        user_token_info = await token_service.get_token_info_unchecked(
-            user_token.key
-        )
-        assert user_token_info
-        other_session_info = await token_service.get_token_info_unchecked(
-            other_session_token.key
-        )
-        assert other_session_info
-        assert await token_service.list_tokens(data, "example") == sorted(
-            sorted((session_info, user_token_info), key=lambda t: t.token),
-            key=lambda t: t.created,
-            reverse=True,
-        )
-        assert await token_service.list_tokens(admin_data) == sorted(
-            sorted(
-                (session_info, other_session_info, user_token_info),
-                key=lambda t: t.token,
-            ),
-            key=lambda t: t.created,
-            reverse=True,
-        )
+    session_info = await token_service.get_token_info_unchecked(
+        session_token.key
+    )
+    assert session_info
+    user_token_info = await token_service.get_token_info_unchecked(
+        user_token.key
+    )
+    assert user_token_info
+    other_session_info = await token_service.get_token_info_unchecked(
+        other_session_token.key
+    )
+    assert other_session_info
+    assert await token_service.list_tokens(data, "example") == sorted(
+        sorted((session_info, user_token_info), key=lambda t: t.token),
+        key=lambda t: t.created,
+        reverse=True,
+    )
+    assert await token_service.list_tokens(admin_data) == sorted(
+        sorted(
+            (session_info, other_session_info, user_token_info),
+            key=lambda t: t.token,
+        ),
+        key=lambda t: t.created,
+        reverse=True,
+    )
 
     # Regular users can't retrieve all tokens.
     with pytest.raises(PermissionDeniedError):
@@ -805,39 +774,36 @@ async def test_modify(factory: Factory) -> None:
         username="example", name="Example Person", uid=4137
     )
     token_service = factory.create_token_service()
-    async with factory.session.begin():
-        session_token = await token_service.create_session_token(
-            user_info,
-            scopes=["admin:token", "read:all", "user:token"],
-            ip_address="127.0.0.1",
-        )
+    session_token = await token_service.create_session_token(
+        user_info,
+        scopes=["admin:token", "read:all", "user:token"],
+        ip_address="127.0.0.1",
+    )
     data = await token_service.get_data(session_token)
     assert data
-    async with factory.session.begin():
-        user_token = await token_service.create_user_token(
-            data,
-            data.username,
-            token_name="some-token",
-            scopes=[],
-            ip_address="127.0.0.1",
-        )
+    user_token = await token_service.create_user_token(
+        data,
+        data.username,
+        token_name="some-token",
+        scopes=[],
+        ip_address="127.0.0.1",
+    )
 
     expires = current_datetime() + timedelta(days=50)
-    async with factory.session.begin():
-        await token_service.modify_token(
-            user_token.key,
-            data,
-            token_name="happy token",
-            ip_address="127.0.0.1",
-        )
-        await token_service.modify_token(
-            user_token.key,
-            data,
-            scopes=["read:all"],
-            expires=expires,
-            ip_address="192.168.0.4",
-        )
-        info = await token_service.get_token_info_unchecked(user_token.key)
+    await token_service.modify_token(
+        user_token.key,
+        data,
+        token_name="happy token",
+        ip_address="127.0.0.1",
+    )
+    await token_service.modify_token(
+        user_token.key,
+        data,
+        scopes=["read:all"],
+        expires=expires,
+        ip_address="192.168.0.4",
+    )
+    info = await token_service.get_token_info_unchecked(user_token.key)
     assert info
     assert info == TokenInfo(
         token=user_token.key,
@@ -850,19 +816,17 @@ async def test_modify(factory: Factory) -> None:
         last_used=None,
         parent=None,
     )
-    async with factory.session.begin():
-        await token_service.modify_token(
-            user_token.key,
-            data,
-            expires=None,
-            no_expire=True,
-            ip_address="127.0.4.5",
-        )
+    await token_service.modify_token(
+        user_token.key,
+        data,
+        expires=None,
+        no_expire=True,
+        ip_address="127.0.4.5",
+    )
 
-    async with factory.session.begin():
-        history = await token_service.get_change_history(
-            data, token=user_token.key, username=data.username
-        )
+    history = await token_service.get_change_history(
+        data, token=user_token.key, username=data.username
+    )
     assert history.entries == [
         TokenChangeHistoryEntry(
             token=user_token.key,
@@ -923,34 +887,29 @@ async def test_modify(factory: Factory) -> None:
 async def test_delete(factory: Factory) -> None:
     data = await create_session_token(factory)
     token_service = factory.create_token_service()
-    async with factory.session.begin():
-        token = await token_service.create_user_token(
-            data,
-            data.username,
-            token_name="some token",
-            scopes=[],
-            ip_address="127.0.0.1",
-        )
+    token = await token_service.create_user_token(
+        data,
+        data.username,
+        token_name="some token",
+        scopes=[],
+        ip_address="127.0.0.1",
+    )
 
-    async with factory.session.begin():
-        assert await token_service.delete_token(
-            token.key, data, data.username, ip_address="127.0.0.1"
-        )
+    assert await token_service.delete_token(
+        token.key, data, data.username, ip_address="127.0.0.1"
+    )
 
     assert await token_service.get_data(token) is None
-    async with factory.session.begin():
-        assert await token_service.get_token_info_unchecked(token.key) is None
-        assert await token_service.get_data(token) is None
+    assert await token_service.get_token_info_unchecked(token.key) is None
+    assert await token_service.get_data(token) is None
 
-    async with factory.session.begin():
-        assert not await token_service.delete_token(
-            token.key, data, data.username, ip_address="127.0.0.1"
-        )
+    assert not await token_service.delete_token(
+        token.key, data, data.username, ip_address="127.0.0.1"
+    )
 
-    async with factory.session.begin():
-        history = await token_service.get_change_history(
-            data, token=token.key, username=data.username
-        )
+    history = await token_service.get_change_history(
+        data, token=token.key, username=data.username
+    )
     assert history.entries == [
         TokenChangeHistoryEntry(
             token=token.key,
@@ -979,30 +938,27 @@ async def test_delete(factory: Factory) -> None:
     ]
 
     # Cannot delete someone else's token.
-    async with factory.session.begin():
-        token = await token_service.create_user_token(
-            data,
-            data.username,
-            token_name="some token",
-            scopes=[],
-            ip_address="127.0.0.1",
-        )
+    token = await token_service.create_user_token(
+        data,
+        data.username,
+        token_name="some token",
+        scopes=[],
+        ip_address="127.0.0.1",
+    )
     other_data = await create_session_token(factory, username="other")
-    async with factory.session.begin():
-        with pytest.raises(PermissionDeniedError):
-            await token_service.delete_token(
-                token.key, other_data, data.username, ip_address="127.0.0.1"
-            )
+    with pytest.raises(PermissionDeniedError):
+        await token_service.delete_token(
+            token.key, other_data, data.username, ip_address="127.0.0.1"
+        )
 
     # Admins can delete soemone else's token.
     admin_data = await create_session_token(
         factory, username="admin", scopes=["admin:token"]
     )
     assert await token_service.get_data(token)
-    async with factory.session.begin():
-        assert await token_service.delete_token(
-            token.key, admin_data, data.username, ip_address="127.0.0.1"
-        )
+    assert await token_service.delete_token(
+        token.key, admin_data, data.username, ip_address="127.0.0.1"
+    )
     assert await token_service.get_data(token) is None
 
 
@@ -1013,27 +969,26 @@ async def test_delete_cascade(factory: Factory) -> None:
     session_token_data = await create_session_token(
         factory, scopes=["admin:token", "read:all", "user:token"]
     )
-    async with factory.session.begin():
-        user_token = await token_service.create_user_token(
-            session_token_data,
-            session_token_data.username,
-            token_name="user-token",
-            scopes=["user:token"],
-            ip_address="127.0.0.1",
-        )
-        user_token_data = await token_service.get_data(user_token)
-        assert user_token_data
-        admin_request = AdminTokenRequest(
-            username="bot-service",
-            token_type=TokenType.service,
-            scopes=["read:all", "user:token"],
-            name="Some Service",
-        )
-        service_token = await token_service.create_token_from_admin_request(
-            admin_request, session_token_data, ip_address="127.0.0.1"
-        )
-        service_token_data = await token_service.get_data(service_token)
-        assert service_token_data
+    user_token = await token_service.create_user_token(
+        session_token_data,
+        session_token_data.username,
+        token_name="user-token",
+        scopes=["user:token"],
+        ip_address="127.0.0.1",
+    )
+    user_token_data = await token_service.get_data(user_token)
+    assert user_token_data
+    admin_request = AdminTokenRequest(
+        username="bot-service",
+        token_type=TokenType.service,
+        scopes=["read:all", "user:token"],
+        name="Some Service",
+    )
+    service_token = await token_service.create_token_from_admin_request(
+        admin_request, session_token_data, ip_address="127.0.0.1"
+    )
+    service_token_data = await token_service.get_data(service_token)
+    assert service_token_data
 
     # Build a tree of tokens hung off of the session token.
     notebook_token = await token_service.get_notebook_token(
@@ -1083,13 +1038,12 @@ async def test_delete_cascade(factory: Factory) -> None:
     ]
 
     # Deleting the session token should invalidate all of its children.
-    async with factory.session.begin():
-        assert await token_service.delete_token(
-            session_token_data.token.key,
-            session_token_data,
-            session_token_data.username,
-            ip_address="127.0.0.1",
-        )
+    assert await token_service.delete_token(
+        session_token_data.token.key,
+        session_token_data,
+        session_token_data.username,
+        ip_address="127.0.0.1",
+    )
     for token in session_children:
         assert await token_service.get_data(token) is None
 
@@ -1099,22 +1053,20 @@ async def test_delete_cascade(factory: Factory) -> None:
     assert await token_service.get_data(service_token_data.token)
 
     # Deleting those tokens should cascade to their children.
-    async with factory.session.begin():
-        assert await token_service.delete_token(
-            user_token_data.token.key,
-            user_token_data,
-            user_token_data.username,
-            ip_address="127.0.0.1",
-        )
+    assert await token_service.delete_token(
+        user_token_data.token.key,
+        user_token_data,
+        user_token_data.username,
+        ip_address="127.0.0.1",
+    )
     for token in user_children:
         assert await token_service.get_data(token) is None
-    async with factory.session.begin():
-        assert await token_service.delete_token(
-            service_token_data.token.key,
-            service_token_data,
-            service_token_data.username,
-            ip_address="127.0.0.1",
-        )
+    assert await token_service.delete_token(
+        service_token_data.token.key,
+        service_token_data,
+        service_token_data.username,
+        ip_address="127.0.0.1",
+    )
     for token in service_children:
         assert await token_service.get_data(token) is None
 
@@ -1129,14 +1081,13 @@ async def test_modify_expires(config: Config, factory: Factory) -> None:
 
     # Create a user token with no expiration and some additional tokens
     # chained off of it.
-    async with factory.session.begin():
-        user_token = await token_service.create_user_token(
-            session_token_data,
-            session_token_data.username,
-            token_name="user-token",
-            scopes=["user:token"],
-            ip_address="127.0.0.1",
-        )
+    user_token = await token_service.create_user_token(
+        session_token_data,
+        session_token_data.username,
+        token_name="user-token",
+        scopes=["user:token"],
+        ip_address="127.0.0.1",
+    )
     user_token_data = await token_service.get_data(user_token)
     assert user_token_data
     notebook_token = await token_service.get_notebook_token(
@@ -1170,13 +1121,12 @@ async def test_modify_expires(config: Config, factory: Factory) -> None:
     # Change the expiration of the user token.
     new_delta = timedelta(seconds=config.token_lifetime.total_seconds() / 2)
     new_expires = user_token_data.created + new_delta
-    async with factory.session.begin():
-        await token_service.modify_token(
-            user_token.key,
-            session_token_data,
-            expires=new_expires,
-            ip_address="127.0.0.1",
-        )
+    await token_service.modify_token(
+        user_token.key,
+        session_token_data,
+        expires=new_expires,
+        ip_address="127.0.0.1",
+    )
 
     # Check that all of the tokens have been updated.
     notebook_token_data = await token_service.get_data(notebook_token)
@@ -1382,12 +1332,11 @@ async def test_invalid_username(factory: Factory) -> None:
         groups=[Group(name="foo", id=1000)],
     )
     token_service = factory.create_token_service()
-    async with factory.session.begin():
-        session_token = await token_service.create_session_token(
-            user_info,
-            scopes=["read:all", "admin:token"],
-            ip_address="127.0.0.1",
-        )
+    session_token = await token_service.create_session_token(
+        user_info,
+        scopes=["read:all", "admin:token"],
+        ip_address="127.0.0.1",
+    )
     data = await token_service.get_data(session_token)
     assert data
 
@@ -1528,55 +1477,54 @@ async def test_expire_tokens(factory: Factory) -> None:
         await token_store.add(service_token_data)
 
     # Run the expiration.
-    async with factory.session.begin():
-        await token_service.expire_tokens()
+    await token_service.expire_tokens()
 
     # Check that all of the tokens that should be expired have been expired,
     # that ones that shouldn't be expired are still present, and that history
     # entries were created as appropriate for each token.
-    async with factory.session.begin():
-        for token_data in (
-            session_token_data,
-            user_token_data,
-            notebook_token_data,
-            internal_token_data,
-            notebook_internal_token_data,
-            service_token_data,
-        ):
+    for token_data in (
+        session_token_data,
+        user_token_data,
+        notebook_token_data,
+        internal_token_data,
+        notebook_internal_token_data,
+        service_token_data,
+    ):
+        async with factory.session.begin():
             assert await token_store.get_info(token_data.token.key) is None
-            history = await token_service.get_change_history(
-                unexpired_user_token_data,
-                username=token_data.username,
+        history = await token_service.get_change_history(
+            unexpired_user_token_data,
+            username=token_data.username,
+            token=token_data.token.key,
+        )
+        assert history.entries == [
+            TokenChangeHistoryEntry(
                 token=token_data.token.key,
+                username=token_data.username,
+                token_type=token_data.token_type,
+                token_name=history.entries[0].token_name,
+                parent=history.entries[0].parent,
+                scopes=token_data.scopes,
+                service=history.entries[0].service,
+                expires=token_data.expires,
+                actor="<internal>",
+                action=TokenChange.expire,
+                event_time=history.entries[0].event_time,
             )
-            assert history.entries == [
-                TokenChangeHistoryEntry(
-                    token=token_data.token.key,
-                    username=token_data.username,
-                    token_type=token_data.token_type,
-                    token_name=history.entries[0].token_name,
-                    parent=history.entries[0].parent,
-                    scopes=token_data.scopes,
-                    service=history.entries[0].service,
-                    expires=token_data.expires,
-                    actor="<internal>",
-                    action=TokenChange.expire,
-                    event_time=history.entries[0].event_time,
-                )
-            ]
+        ]
 
-        unexpired = await token_store.get_info(
-            unexpired_user_token_data.token.key
-        )
-        assert unexpired == TokenInfo(
-            token=unexpired_user_token_data.token.key,
-            username=unexpired_user_token_data.username,
-            token_type=unexpired_user_token_data.token_type,
-            token_name="new",
-            scopes=unexpired_user_token_data.scopes,
-            created=unexpired_user_token_data.created,
-            expires=unexpired_user_token_data.expires,
-        )
+    async with factory.session.begin():
+        unexpired_key = unexpired_user_token_data.token.key
+        unexpired = await token_store.get_info(unexpired_key)
+    assert unexpired == TokenInfo(
+        token=unexpired_user_token_data.token.key,
+        username=unexpired_user_token_data.username,
+        token_type=unexpired_user_token_data.token_type,
+        token_name="new",
+        scopes=unexpired_user_token_data.scopes,
+        created=unexpired_user_token_data.created,
+        expires=unexpired_user_token_data.expires,
+    )
 
 
 @pytest.mark.asyncio
@@ -1615,14 +1563,12 @@ async def test_truncate_history(factory: Factory) -> None:
         await history_store.add(old_entry)
         await history_store.add(new_entry)
 
-    async with factory.session.begin():
-        await token_service.truncate_history()
+    await token_service.truncate_history()
 
-    async with factory.session.begin():
-        history = await token_service.get_change_history(
-            auth_data=session_token_data, username="other-user"
-        )
-        assert history.entries == [new_entry]
+    history = await token_service.get_change_history(
+        auth_data=session_token_data, username="other-user"
+    )
+    assert history.entries == [new_entry]
 
 
 @pytest.mark.asyncio
@@ -1737,8 +1683,7 @@ async def test_audit(factory: Factory) -> None:
 
     # Run the audit.  This should result in a Slack message about all of the
     # problems found.
-    async with factory.session.begin():
-        alerts = await token_service.audit()
+    alerts = await token_service.audit()
     expected = [
         f"Token `{db_session_token_data.token.key}` for `some-user`"
         " found in database but not Redis",
@@ -1756,8 +1701,7 @@ async def test_audit(factory: Factory) -> None:
     assert sorted(alerts) == sorted(expected)
 
     # Run the audit again with fixing enabled.
-    async with factory.session.begin():
-        alerts = await token_service.audit(fix=True)
+    alerts = await token_service.audit(fix=True)
     expected[0] += " (fixed)"
     expected[1] += " (fixed)"
     expected[2] = (
@@ -1768,12 +1712,10 @@ async def test_audit(factory: Factory) -> None:
 
     # Remove expired tokens from the database, since a token present in the
     # database and not in Redis is addressed by expiring it.
-    async with factory.session.begin():
-        await token_service.expire_tokens()
+    await token_service.expire_tokens()
 
     # Run the audit again, which should show fewer issues.
-    async with factory.session.begin():
-        alerts = await token_service.audit()
+    alerts = await token_service.audit()
     expected = expected[2:]
     expected[0] = (
         f"Token `{db_user_token_data.token.key}` for `some-user` does"
@@ -1788,19 +1730,17 @@ async def test_state_metrics(config: Config, factory: Factory) -> None:
     await create_session_token(factory, username="someone")
     await create_session_token(factory, username="someone")
     token_data = await create_session_token(factory, username="other")
-    async with factory.session.begin():
-        await token_service.create_user_token(
-            token_data,
-            token_data.username,
-            token_name="something",
-            scopes=[],
-            ip_address="127.0.0.1",
-        )
+    await token_service.create_user_token(
+        token_data,
+        token_data.username,
+        token_name="something",
+        scopes=[],
+        ip_address="127.0.0.1",
+    )
 
     event_manager = config.metrics.make_manager()
     await event_manager.initialize()
     events = StateEvents()
     await events.initialize(event_manager)
-    async with factory.session.begin():
-        await token_service.gather_state_metrics(events)
+    await token_service.gather_state_metrics(events)
     await event_manager.aclose()

--- a/tests/storage/token_test.py
+++ b/tests/storage/token_test.py
@@ -23,13 +23,12 @@ async def test_metrics(factory: Factory) -> None:
     async with factory.session.begin():
         assert await token_db_store.count_user_tokens() == 0
     token_service = factory.create_token_service()
-    async with factory.session.begin():
-        await token_service.create_user_token(
-            token_data,
-            "someuser",
-            token_name="some-token",
-            scopes=[],
-            ip_address="192.168.0.1",
-        )
+    await token_service.create_user_token(
+        token_data,
+        "someuser",
+        token_name="some-token",
+        scopes=[],
+        ip_address="192.168.0.1",
+    )
     async with factory.session.begin():
         assert await token_db_store.count_user_tokens() == 1

--- a/tests/support/selenium.py
+++ b/tests/support/selenium.py
@@ -107,11 +107,11 @@ async def _selenium_startup(token_path: Path) -> None:
                 session=factory.session,
             )
 
-            # Add the valid session token.
-            token_service = factory.create_token_service()
-            token = await token_service.create_session_token(
-                user_info, scopes=scopes, ip_address="127.0.0.1"
-            )
+        # Add the valid session token.
+        token_service = factory.create_token_service()
+        token = await token_service.create_session_token(
+            user_info, scopes=scopes, ip_address="127.0.0.1"
+        )
     await engine.dispose()
 
     token_path.write_text(str(token))

--- a/tests/support/tokens.py
+++ b/tests/support/tokens.py
@@ -129,10 +129,9 @@ async def create_session_token(
     if not scopes:
         scopes = ["user:token"]
     token_service = factory.create_token_service()
-    async with factory.session.begin():
-        token = await token_service.create_session_token(
-            user_info, scopes=scopes, ip_address="127.0.0.1"
-        )
+    token = await token_service.create_session_token(
+        user_info, scopes=scopes, ip_address="127.0.0.1"
+    )
     data = await token_service.get_data(token)
     assert data
     return data


### PR DESCRIPTION
Stop doing database transaction management in the handlers and instead move all transaction management into the service layer. This simplifies the test suite considerably and makes the handlers simpler and cleaner.

This requires moving the addition of the `admin:token` scope to new authentications by admins into the token service layer, which is probably where it always belonged.

In a few cases, the code will open more transactions than it did before, but all of those cases should be slow paths.