### PR TITLE
DM-47760: Uniformly handle claim for no data rights

### DIFF
--- a/changelog.d/20241122_102407_rra_DM_47760.md
+++ b/changelog.d/20241122_102407_rra_DM_47760.md
@@ -1,0 +1,3 @@
+### Bug fixes
+
+- Always omit the `data_rights` claim in OpenID Connect server tokens if the user has no data rights, rather than sometimes omitting it and sometimes setting it to the empty string.

--- a/src/gafaelfawr/services/oidc.py
+++ b/src/gafaelfawr/services/oidc.py
@@ -477,6 +477,8 @@ class OIDCService:
             mapping = self._config.data_rights_mapping.get(group.name)
             if mapping:
                 releases.update(mapping)
+        if not releases:
+            return None
         return " ".join(sorted(releases))
 
     def _check_client_secret(


### PR DESCRIPTION
Always omit the `data_rights` claim in OpenID Connect server tokens if the user has no data rights, rather than sometimes omitting it and sometimes setting it to the empty string.