### PR TITLE
DM-47760: Allow internal tokens on the OIDC userinfo route

### DIFF
--- a/changelog.d/20241122_115147_rra_DM_47760.md
+++ b/changelog.d/20241122_115147_rra_DM_47760.md
@@ -1,0 +1,3 @@
+### New features
+
+- Allow a client to present an internal token to the `/auth/openid/userinfo` endpoint. CADC's authenticator finds the userinfo endpoint via OpenID Connect configuration and presents whatever token it has to that endpoint, so this allows it to use the regular userinfo endpoint.

--- a/src/gafaelfawr/handlers/oidc.py
+++ b/src/gafaelfawr/handlers/oidc.py
@@ -310,7 +310,7 @@ async def get_userinfo(
     token_data: Annotated[TokenData, Depends(authenticate_token)],
     context: Annotated[RequestContext, Depends(context_dependency)],
 ) -> Mapping[str, Any]:
-    if token_data.token_type != TokenType.oidc:
+    if token_data.token_type not in (TokenType.internal, TokenType.oidc):
         msg = f"Token of type {token_data.token_type.value} not allowed"
         exc = InvalidTokenError(msg)
         raise generate_challenge(context, AuthType.Bearer, exc)


### PR DESCRIPTION
Allow a client to present an internal token to the `/auth/openid/userinfo` endpoint. CADC's authenticator finds the userinfo endpoint via OpenID Connect configuration and presents whatever token it has to that endpoint, so this allows it to use the regular userinfo endpoint.

This will hopefully allow us to drop the `/auth/cadc/userinfo` route in a future release.