### PR TITLE
DM-47716: Revert "Move auth metrics reporting to a background task"

### DIFF
--- a/changelog.d/20241122_105538_rra_DM_47716.md
+++ b/changelog.d/20241122_105538_rra_DM_47716.md
@@ -1,3 +1,0 @@
-### Bug fixes
-
-- Move metrics reporting for hot-path authentication events to a background task so that it happens in parallel with the HTTP response.


### PR DESCRIPTION
This reverts commit 2d0ea937069a8fe98371a5c19f74b030f0488c11. The problem will be fixed in the next release of Safir in the underlying metrics code by backgrounding the write inside the metrics layer.