### PR TITLE
DM-47789: Use Safir timedelta validation types

### DIFF
--- a/docs/documenteer.toml
+++ b/docs/documenteer.toml
@@ -48,6 +48,7 @@ nitpick_ignore = [
     ["py:obj", "fastapi.routing.APIRoute"],
     ["py:class", "kubernetes_asyncio.client.api_client.ApiClient"],
     ["py:class", "pydantic.functional_serializers.PlainSerializer"],
+    ["py:class", "pydantic.functional_validators.AfterValidator"],
     ["py:class", "pydantic.functional_validators.BeforeValidator"],
     ["py:class", "pydantic.main.BaseModel"],
     ["py:class", "pydantic.networks.UrlConstraints"],

--- a/src/gafaelfawr/models/kubernetes.py
+++ b/src/gafaelfawr/models/kubernetes.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from abc import ABCMeta, abstractmethod
 from dataclasses import dataclass, field
-from datetime import datetime, timedelta
+from datetime import datetime
 from enum import Enum
 from typing import Literal, Self, override
 
@@ -26,9 +26,12 @@ from pydantic import (
 )
 from pydantic.alias_generators import to_camel
 from safir.datetime import current_datetime
-from safir.pydantic import to_camel_case, validate_exactly_one_of
+from safir.pydantic import (
+    SecondsTimedelta,
+    to_camel_case,
+    validate_exactly_one_of,
+)
 
-from ..util import normalize_timedelta
 from .auth import AuthType, Satisfy
 
 __all__ = [
@@ -156,15 +159,11 @@ class GafaelfawrIngressDelegate(BaseModel):
     internal: GafaelfawrIngressDelegateInternal | None = None
     """Configuration for a delegated internal token."""
 
-    minimum_lifetime: timedelta | None = None
+    minimum_lifetime: SecondsTimedelta | None = None
     """The minimum lifetime of the delegated token."""
 
     use_authorization: bool = False
     """Whether to put the delegated token in the ``Authorization`` header."""
-
-    _normalize_minimum_lifetime = field_validator(
-        "minimum_lifetime", mode="before"
-    )(normalize_timedelta)
 
     _validate_type = model_validator(mode="after")(
         validate_exactly_one_of("notebook", "internal")

--- a/tests/util_test.py
+++ b/tests/util_test.py
@@ -2,17 +2,11 @@
 
 from __future__ import annotations
 
-from datetime import timedelta
-
-import pytest
-from pydantic import BaseModel, field_validator
-
 from gafaelfawr.keypair import RSAKeyPair
 from gafaelfawr.util import (
     add_padding,
     base64_to_number,
     is_bot_user,
-    normalize_timedelta,
     number_to_base64,
 )
 
@@ -50,20 +44,6 @@ def test_is_bot_user() -> None:
     assert not is_bot_user("bot")
     assert not is_bot_user("botuser")
     assert not is_bot_user("bot-in!valid")
-
-
-def test_normalize_timedelta() -> None:
-    class TestModel(BaseModel):
-        delta: timedelta | None
-
-        _val = field_validator("delta", mode="before")(normalize_timedelta)
-
-    assert TestModel(delta=None).delta is None
-    model = TestModel(delta=10)  # type: ignore[arg-type]
-    assert model.delta == timedelta(seconds=10)
-
-    with pytest.raises(ValueError, match="invalid timedelta"):
-        TestModel(delta="not an int")  # type: ignore[arg-type]
 
 
 def test_number_to_base64() -> None:


### PR DESCRIPTION
Remove `parse_timedelta`, which was dead code since its usage had previously been replaced by the Safir type. Change the one remaining place using `normalize_timedelta` to use `SecondsTimedelta` from Safir and delete that code as well.