### PR TITLE
DM-47789: Use drop_database from Safir

### DIFF
--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -19,7 +19,7 @@ import pytest
 import structlog
 from click.testing import CliRunner
 from cryptography.fernet import Fernet
-from safir.database import initialize_database
+from safir.database import drop_database, initialize_database
 from safir.datetime import current_datetime
 from safir.testing.slack import MockSlackWebhook
 from sqlalchemy.ext.asyncio import AsyncEngine
@@ -40,7 +40,7 @@ from gafaelfawr.storage.history import TokenChangeHistoryStore
 from gafaelfawr.storage.token import TokenDatabaseStore
 
 from .support.config import build_oidc_client, configure
-from .support.database import create_old_database, drop_database
+from .support.database import create_old_database
 
 
 def test_audit(
@@ -331,7 +331,7 @@ def test_update_schema(
 
     # Start with an empty database. This should produce exactly the same
     # results as gafaelfawr init.
-    event_loop.run_until_complete(drop_database(engine))
+    event_loop.run_until_complete(drop_database(engine, SchemaBase.metadata))
     result = runner.invoke(
         main,
         [
@@ -363,7 +363,7 @@ def test_validate_schema(
     runner = CliRunner()
 
     # Start with an empty database.
-    event_loop.run_until_complete(drop_database(engine))
+    event_loop.run_until_complete(drop_database(engine, SchemaBase.metadata))
 
     # Validating should fail with an appropriate error message.
     result = runner.invoke(main, ["validate-schema"], catch_exceptions=False)

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -4,18 +4,20 @@ from __future__ import annotations
 
 import pytest
 from asgi_lifespan import LifespanManager
+from safir.database import drop_database
 from sqlalchemy.ext.asyncio import AsyncEngine
 
 from gafaelfawr.config import Config
 from gafaelfawr.exceptions import DatabaseSchemaError
 from gafaelfawr.main import create_app
+from gafaelfawr.schema import SchemaBase
 
-from .support.database import create_old_database, drop_database
+from .support.database import create_old_database
 
 
 @pytest.mark.asyncio
 async def test_out_of_date_schema(config: Config, engine: AsyncEngine) -> None:
-    await drop_database(engine)
+    await drop_database(engine, SchemaBase.metadata)
     await create_old_database(config, engine, "9.6.1")
 
     app = create_app()

--- a/tests/schema_test.py
+++ b/tests/schema_test.py
@@ -6,17 +6,17 @@ import os
 import subprocess
 
 import pytest
+from safir.database import drop_database
 from sqlalchemy.ext.asyncio import AsyncEngine
 
 from gafaelfawr.config import Config
 from gafaelfawr.dependencies.config import config_dependency
-
-from .support.database import drop_database
+from gafaelfawr.schema import SchemaBase
 
 
 @pytest.mark.asyncio
 async def test_schema(config: Config, engine: AsyncEngine) -> None:
-    await drop_database(engine)
+    await drop_database(engine, SchemaBase.metadata)
     env = {
         **os.environ,
         "GAFAELFAWR_CONFIG_PATH": str(config_dependency.config_path),

--- a/tests/support/database.py
+++ b/tests/support/database.py
@@ -4,18 +4,13 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from safir.database import unstamp_database
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncEngine
 
 from gafaelfawr.config import Config
 from gafaelfawr.factory import Factory
-from gafaelfawr.schema import SchemaBase
 
-__all__ = [
-    "create_old_database",
-    "drop_database",
-]
+__all__ = ["create_old_database"]
 
 
 async def create_old_database(
@@ -47,16 +42,3 @@ async def create_old_database(
                     if statement.endswith(";"):
                         await factory.session.execute(text(statement))
                         statement = ""
-
-
-async def drop_database(engine: AsyncEngine) -> None:
-    """Drop all tables from the database.
-
-    Parameters
-    ----------
-    engine
-        Engine to use to issue the SQL commands.
-    """
-    async with engine.begin() as conn:
-        await conn.run_sync(SchemaBase.metadata.drop_all)
-    await unstamp_database(engine)


### PR DESCRIPTION
Now that Safir provides an implementation of `drop_database`, use that version and delete the one in Gafaelfawr.