### PR TITLE
DM-47789: Move IP address normalization into a type

### DIFF
--- a/src/gafaelfawr/models/health.py
+++ b/src/gafaelfawr/models/health.py
@@ -13,7 +13,7 @@ __all__ = [
 ]
 
 
-class HealthStatus(str, Enum):
+class HealthStatus(Enum):
     """Status of health check.
 
     Since errors are returned as HTTP 500 errors, currently the only status is

--- a/src/gafaelfawr/models/history.py
+++ b/src/gafaelfawr/models/history.py
@@ -11,9 +11,9 @@ from safir.database import DatetimeIdCursor, PaginatedList, PaginationCursor
 from safir.datetime import current_datetime
 from sqlalchemy.orm import InstrumentedAttribute
 
-from ..pydantic import Timestamp
+from ..pydantic import IpAddress, Timestamp
 from ..schema import TokenChangeHistory
-from ..util import normalize_ip_address, normalize_scopes
+from ..util import normalize_scopes
 from .enums import AdminChange, TokenChange, TokenType
 
 # Not used directly but needed to prevent documentation build errors because
@@ -57,7 +57,7 @@ class AdminHistoryEntry(BaseModel):
         max_length=64,
     )
 
-    ip_address: str | None = Field(
+    ip_address: IpAddress | None = Field(
         None,
         title="IP address",
         description=(
@@ -71,10 +71,6 @@ class AdminHistoryEntry(BaseModel):
         title="Timestamp",
         description="When the change was made",
         examples=[1614986130],
-    )
-
-    _normalize_ip_address = field_validator("ip_address", mode="before")(
-        normalize_ip_address
     )
 
 
@@ -192,7 +188,7 @@ class TokenChangeHistoryEntry(BaseModel):
     #
     # We don't gain very much from the Pydantic validation since these entries
     # are created either in code or sourced from a trusted database.
-    ip_address: str | None = Field(
+    ip_address: IpAddress | None = Field(
         None,
         title="IP address from which the change was made",
         description=(
@@ -210,9 +206,6 @@ class TokenChangeHistoryEntry(BaseModel):
 
     _normalize_scopes = field_validator("scopes", "old_scopes", mode="before")(
         normalize_scopes
-    )
-    _normalize_ip_address = field_validator("ip_address", mode="before")(
-        normalize_ip_address
     )
 
     def model_dump_reduced(self) -> dict[str, Any]:

--- a/src/gafaelfawr/pydantic.py
+++ b/src/gafaelfawr/pydantic.py
@@ -2,12 +2,47 @@
 
 from __future__ import annotations
 
+from ipaddress import IPv4Address, IPv6Address
 from typing import Annotated, TypeAlias
 
-from pydantic import PlainSerializer
+from pydantic import BeforeValidator, PlainSerializer
 from safir.pydantic import UtcDatetime
 
-__all__ = ["Timestamp"]
+__all__ = [
+    "IpAddress",
+    "Timestamp",
+]
+
+
+def _normalize_ip_address(v: str | IPv4Address | IPv6Address) -> str:
+    """Pydantic validator for IP address fields.
+
+    Convert the PostgreSQL INET type to `str` to support reading entries from
+    a PostgreSQL database.
+
+    Parameters
+    ----------
+    v
+        Field representing an IP address.
+
+    Returns
+    -------
+    str
+        Converted IP address.
+    """
+    if isinstance(v, IPv4Address | IPv6Address):
+        return str(v)
+    else:
+        return v
+
+
+IpAddress: TypeAlias = Annotated[str, BeforeValidator(_normalize_ip_address)]
+"""Type for an IP address.
+
+Used instead of ``pydantic.networks.IPvAnyAddress`` because most of Gafaelfawr
+deals with IP addresses as strings and the type conversion is tedious and
+serves no real purpose.
+"""
 
 
 Timestamp: TypeAlias = Annotated[

--- a/src/gafaelfawr/util.py
+++ b/src/gafaelfawr/util.py
@@ -6,7 +6,6 @@ import base64
 import hashlib
 import os
 import re
-from ipaddress import IPv4Address, IPv6Address
 
 from .constants import BOT_USERNAME_REGEX
 
@@ -15,7 +14,6 @@ __all__ = [
     "base64_to_number",
     "group_name_for_github_team",
     "is_bot_user",
-    "normalize_ip_address",
     "normalize_scopes",
     "number_to_base64",
     "random_128_bits",
@@ -104,32 +102,6 @@ def group_name_for_github_team(organization: str, team: str) -> str:
         suffix = base64.urlsafe_b64encode(name_hash).decode()[:6]
         group_name = group_name[:25] + "-" + suffix
     return group_name
-
-
-def normalize_ip_address(
-    v: str | IPv4Address | IPv6Address | None,
-) -> str | None:
-    """Pydantic validator for IP address fields.
-
-    Convert the PostgreSQL INET type to `str` to support reading entries from
-    a PostgreSQL database.
-
-    Parameters
-    ----------
-    v
-        The field representing an IP address.
-
-    Returns
-    -------
-    str or None
-        The converted IP address.
-    """
-    if v is None:
-        return v
-    elif isinstance(v, IPv4Address | IPv6Address):
-        return str(v)
-    else:
-        return v
 
 
 def normalize_scopes(v: str | list[str] | None) -> list[str] | None:

--- a/tests/handlers/api_tokens_test.py
+++ b/tests/handlers/api_tokens_test.py
@@ -943,7 +943,7 @@ async def test_create_admin(
     # Intentionally pass in a datetime with microseconds. They should be
     # stripped off so that the expiration is rounded to seconds, which we will
     # check when examining the log message.
-    now = current_datetime(microseconds=True)
+    now = datetime.now(tz=UTC)
     expires = now + timedelta(days=2)
     caplog.clear()
     r = await client.post(

--- a/tests/support/logging.py
+++ b/tests/support/logging.py
@@ -7,7 +7,6 @@ from datetime import UTC, datetime, timedelta
 from typing import Any
 
 import pytest
-from safir.datetime import current_datetime
 
 __all__ = ["parse_log"]
 
@@ -33,7 +32,7 @@ def parse_log(
         List of parsed JSON dictionaries with the common log attributes
         removed (after validation).
     """
-    now = current_datetime(microseconds=True)
+    now = datetime.now(tz=UTC)
     messages = []
 
     for log_tuple in caplog.record_tuples:


### PR DESCRIPTION
Using Pydantic `IPvAnyAddress` still appears to be more trouble than it's worth, but at least the internal IP address handling that produces a `str` can be moved into a Pydantic type rather than needing the more awkward field validator syntax.
