### PR TITLE
DM-47986: Fix JSON serialization of Kopf healt probe

### DIFF
--- a/changelog.d/20241210_164212_rra_DM_47986.md
+++ b/changelog.d/20241210_164212_rra_DM_47986.md
@@ -1,0 +1,3 @@
+### Bug fixes
+
+- Return a JSON-serializable object from the health probe for the Kubernetes operator.

--- a/src/gafaelfawr/operator/health.py
+++ b/src/gafaelfawr/operator/health.py
@@ -29,4 +29,4 @@ async def get_health(memo: kopf.Memo, **_: Any) -> dict[str, Any]:
     health_check_service = factory.create_health_check_service()
     await health_check_service.check(check_user_info=False)
     await factory.session.remove()
-    return HealthCheck(status=HealthStatus.HEALTHY).model_dump()
+    return HealthCheck(status=HealthStatus.HEALTHY).model_dump(mode="json")


### PR DESCRIPTION
The object returned from the health probe for Kopf couldn't be serialized as JSON. This was harmless but produced error messages in the logs. Return the model dumped in JSON format instead.