### PR TITLE
DM-48088: Allow an empty list of required scopes

### DIFF
--- a/changelog.d/20241211_105613_rra_DM_47986.md
+++ b/changelog.d/20241211_105613_rra_DM_47986.md
@@ -1,0 +1,3 @@
+### New features
+
+- Allow an authenticated `GafaelfawrIngress` with no required scopes. This is useful for an `onlyService` case where the token may have any scope but must be delegated to one of the listed services.

--- a/tests/data/kubernetes/input/ingresses.yaml
+++ b/tests/data/kubernetes/input/ingresses.yaml
@@ -124,7 +124,7 @@ template:
       - host: foo.example.com
         http:
           paths:
-            - path: /foo
+            - path: /foo/bar
               pathType: Prefix
               backend:
                 service:
@@ -151,7 +151,7 @@ template:
       - host: foo.example.com
         http:
           paths:
-            - path: /foo
+            - path: /foo/baz
               pathType: Prefix
               backend:
                 service:
@@ -177,7 +177,7 @@ template:
       - host: foo.example.com
         http:
           paths:
-            - path: /foo
+            - path: /username
               pathType: Prefix
               backend:
                 service:
@@ -205,7 +205,34 @@ template:
       - host: foo.example.com
         http:
           paths:
-            - path: /foo
+            - path: /service
+              pathType: Prefix
+              backend:
+                service:
+                  name: something
+                  port:
+                    name: http
+---
+apiVersion: gafaelfawr.lsst.io/v1alpha1
+kind: GafaelfawrIngress
+metadata:
+  name: service-any-ingress
+  namespace: {namespace}
+config:
+  scopes:
+    all: []
+  onlyServices:
+    - vo-cutouts
+  service: uws
+template:
+  metadata:
+    name: service-any
+  spec:
+    rules:
+      - host: foo.example.com
+        http:
+          paths:
+            - path: /service/any
               pathType: Prefix
               backend:
                 service:

--- a/tests/data/kubernetes/output/ingresses.yaml
+++ b/tests/data/kubernetes/output/ingresses.yaml
@@ -159,7 +159,7 @@ spec:
     - host: foo.example.com
       http:
         paths:
-          - path: /foo
+          - path: /foo/bar
             pathType: Prefix
             backend:
               service:
@@ -198,7 +198,7 @@ spec:
     - host: foo.example.com
       http:
         paths:
-          - path: /foo
+          - path: /foo/baz
             pathType: Prefix
             backend:
               service:
@@ -238,7 +238,7 @@ spec:
     - host: foo.example.com
       http:
         paths:
-          - path: /foo
+          - path: /username
             pathType: Prefix
             backend:
               service:
@@ -278,7 +278,47 @@ spec:
     - host: foo.example.com
       http:
         paths:
-          - path: /foo
+          - path: /service
+            pathType: Prefix
+            backend:
+              service:
+                name: something
+                port:
+                  name: http
+status: {any}
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: service-any
+  namespace: {namespace}
+  annotations:
+    nginx.ingress.kubernetes.io/auth-method: GET
+    nginx.ingress.kubernetes.io/auth-response-headers: "Authorization,Cookie,X-Auth-Request-Email,X-Auth-Request-Service,X-Auth-Request-Token,X-Auth-Request-User"
+    nginx.ingress.kubernetes.io/auth-url: "http://gafaelfawr.gafaelfawr.svc.cluster.local:8080/ingress/auth?only_service=vo-cutouts&service=uws"
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      {snippet}
+  creationTimestamp: {any}
+  generation: {any}
+  labels:
+    app.kubernetes.io/managed-by: Gafaelfawr
+  managedFields: {any}
+  ownerReferences:
+    - apiVersion: gafaelfawr.lsst.io/v1alpha1
+      blockOwnerDeletion: true
+      controller: true
+      kind: GafaelfawrIngress
+      name: service-any-ingress
+      uid: {any}
+  resourceVersion: {any}
+  uid: {any}
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: foo.example.com
+      http:
+        paths:
+          - path: /service/any
             pathType: Prefix
             backend:
               service:


### PR DESCRIPTION
Allow an authenticated `GafaelfawrIngress` to have an empty list of required scopes. This is useful for the `onlyService` use case when any scope is permitted but the requesting token must be a delegated token for one of the listed services. This was already valid in the CRD, but previously resulted in a 422 error from Gafaelfawr and a 500 error from ingress-nginx.