### PR TITLE
DM-48196: Switch to new generics syntax

### DIFF
--- a/src/gafaelfawr/cache.py
+++ b/src/gafaelfawr/cache.py
@@ -10,12 +10,10 @@ only intended for use via their service layer
 `~gafaelfawr.services.firestore.FirestoreService`).
 """
 
-from __future__ import annotations
-
 import asyncio
 from abc import ABCMeta, abstractmethod
 from types import TracebackType
-from typing import Generic, Literal, TypeVar, override
+from typing import Literal, override
 
 from cachetools import LRUCache, TTLCache
 
@@ -27,9 +25,6 @@ from .constants import (
 )
 from .models.token import Token, TokenData
 
-S = TypeVar("S")
-"""Type of content stored in a cache."""
-
 _LRUTokenCache = LRUCache[tuple[str, ...], Token]
 """Type for the underlying token cache."""
 
@@ -40,7 +35,6 @@ __all__ = [
     "LDAPCache",
     "NotebookTokenCache",
     "PerUserCache",
-    "S",
     "TokenCache",
     "UserLockManager",
 ]
@@ -258,7 +252,7 @@ class PerUserCache(BaseCache):
             return UserLockManager(self._lock, self._user_locks[username])
 
 
-class LDAPCache(PerUserCache, Generic[S]):
+class LDAPCache[S](PerUserCache):
     """A cache of LDAP data.
 
     Parameters

--- a/src/gafaelfawr/middleware/state.py
+++ b/src/gafaelfawr/middleware/state.py
@@ -1,22 +1,16 @@
 """State cookie management."""
 
-from __future__ import annotations
-
 import copy
 from abc import ABCMeta, abstractmethod
 from collections.abc import Awaitable, Callable
-from typing import Generic, Self, TypeVar
+from typing import Self
 
 from fastapi import FastAPI, Request, Response
 from starlette.middleware.base import BaseHTTPMiddleware
 
-T = TypeVar("T", bound="BaseState")
-"""Type of data stored in the state cookie."""
-
 __all__ = [
     "BaseState",
     "StateMiddleware",
-    "T",
 ]
 
 
@@ -58,7 +52,7 @@ class BaseState(metaclass=ABCMeta):
         """
 
 
-class StateMiddleware(BaseHTTPMiddleware, Generic[T]):
+class StateMiddleware[T: BaseState](BaseHTTPMiddleware):
     """Middleware to read and update an encrypted state cookie.
 
     If a cookie by the given name exists, it will be parsed by the given class

--- a/src/gafaelfawr/models/history.py
+++ b/src/gafaelfawr/models/history.py
@@ -4,10 +4,10 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import datetime  # noqa: F401: needed for docs
-from typing import Any, Self, TypeVar
+from typing import Any, Self
 
 from pydantic import BaseModel, Field
-from safir.database import DatetimeIdCursor, PaginationCursor
+from safir.database import DatetimeIdCursor
 from safir.datetime import current_datetime
 from sqlalchemy.orm import InstrumentedAttribute
 
@@ -15,18 +15,8 @@ from ..pydantic import IpAddress, Scopes, Timestamp
 from ..schema import TokenChangeHistory
 from .enums import AdminChange, TokenChange, TokenType
 
-# Not used directly but needed to prevent documentation build errors because
-# Sphinx cannot understand that this inherited type variable is defined in
-# Safir.
-C = TypeVar("C", bound="PaginationCursor")
-"""Type of a cursor for a paginated list."""
-
-E = TypeVar("E", bound="BaseModel")
-"""Type of a history entry in a paginated list."""
-
 __all__ = [
     "AdminHistoryEntry",
-    "E",
     "TokenChangeHistoryCursor",
     "TokenChangeHistoryEntry",
     "TokenChangeHistoryRecord",

--- a/src/gafaelfawr/storage/kubernetes.py
+++ b/src/gafaelfawr/storage/kubernetes.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from base64 import b64encode
 from collections.abc import Callable, Coroutine
 from functools import wraps
-from typing import ParamSpec, TypeVar
 
 from kubernetes_asyncio import client
 from kubernetes_asyncio.client import (
@@ -27,16 +26,13 @@ from ..models.kubernetes import (
 )
 from ..models.token import Token
 
-T = TypeVar("T")
-P = ParamSpec("P")
-
 __all__ = [
     "KubernetesIngressStorage",
     "KubernetesTokenStorage",
 ]
 
 
-def _convert_exception(
+def _convert_exception[**P, T](
     f: Callable[P, Coroutine[None, None, T]],
 ) -> Callable[P, Coroutine[None, None, T]]:
     """Convert Kubernetes ApiException to KubernetesError."""


### PR DESCRIPTION
Convert all generics to the new Python 3.12 syntax, which no longer requires `TypeVar` or `ParamSpec`. Sphinx doesn't like the combination of this syntax and `from __future__ import annotations`, so remove that line from the files that use this syntax.