### PR TITLE
DM-48319: Catch ValueError exceptions from Firestore

### DIFF
--- a/docs/documenteer.toml
+++ b/docs/documenteer.toml
@@ -8,17 +8,13 @@ doc_path = "api"
 
 [project.openapi.generator]
 function = "gafaelfawr.main:create_openapi"
-keyword_args = {add_back_link = true}
+keyword_args = { add_back_link = true }
 
 [project.python]
 package = "gafaelfawr"
 
 [sphinx]
-disable_primary_sidebars = [
-    "**/index",
-    "changelog",
-    "dev/internals",
-]
+disable_primary_sidebars = ["**/index", "changelog", "dev/internals"]
 extensions = [
     "sphinx_click",
     "sphinx_diagrams",
@@ -36,6 +32,7 @@ nitpick_ignore = [
     # caught documentation bugs by having Sphinx complain about a new symbol.
     ["py:class", "dataclasses_avroschema.pydantic.main.AvroBaseModel"],
     ["py:class", "dataclasses_avroschema.main.AvroModel"],
+    ["py:class", "google.api_core.exceptions.GoogleAPICallError"],
     ["py:class", "google.cloud.firestore_v1.async_client.AsyncClient"],
     ["py:class", "fastapi.applications.FastAPI"],
     ["py:class", "fastapi.datastructures.DefaultPlaceholder"],
@@ -76,13 +73,13 @@ nitpick_ignore = [
     ["py:class", "asyncio.locks.Lock"],
     # See https://github.com/sphinx-doc/sphinx/issues/13178
     ["py:class", "pathlib._local.Path"],
-    # Cannot be represented by intersphinx.
-    ["py:obj", "safir.pydantic._validators.validate_exactly_one_of.<locals>.validator"],
 ]
 nitpick_ignore_regex = [
     ["py:class", "kubernetes_asyncio\\.client\\.models\\..*"],
     # Bug in autodoc_pydantic.
     ["py:obj", ".*\\.all fields"],
+    # Cannot be represented by intersphinx.
+    ["py:obj", "safir\\.pydantic\\._validators\\.validate_exactly_one_of.*"],
 ]
 python_api_dir = "dev/internals"
 rst_epilog_file = "_rst_epilog.rst"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,10 +111,11 @@ warn_untyped_fields = true
 asyncio_default_fixture_loop_scope = "function"
 asyncio_mode = "strict"
 filterwarnings = [
-    # Google modules use PyType_Spec in a deprecated way.
-    "ignore:Type google\\..*metaclass.* custom tp_new:DeprecationWarning",
     # Bug in seleniumwire.
     "ignore:.*X509Extension support in pyOpenSSL:DeprecationWarning",
+    "ignore:.*Passing PyOpenSSL PKey objects:DeprecationWarning",
+    "ignore:.*Passing PyOpenSSL X509 objects:DeprecationWarning",
+    "ignore:.*removed in a future version of pyOpenSSL:DeprecationWarning",
     # Some sphinxcontrib package and seleniumwire use pkg_resources.
     "ignore:pkg_resources is deprecated as an API:DeprecationWarning",
     "ignore:.*pkg_resources\\.declare_namespace:DeprecationWarning",

--- a/src/gafaelfawr/exceptions.py
+++ b/src/gafaelfawr/exceptions.py
@@ -24,6 +24,7 @@ __all__ = [
     "DuplicateTokenNameError",
     "ExternalUserInfoError",
     "FetchKeysError",
+    "FirestoreAPIError",
     "FirestoreError",
     "FirestoreNotInitializedError",
     "GitHubError",
@@ -383,7 +384,7 @@ class FirestoreAPIError(FirestoreError):
 
         Returns
         -------
-        SlackMessage
+        safir.slack.blockkit.SlackMessage
             Message suitable for sending to Slack.
         """
         result = super().to_slack()


### PR DESCRIPTION
The Firestore library sometimes throws `ValueError` when trying to roll back a transaction, claiming there is no transaction ID. It's not clear what's causing this, but at least catch the error and transform it into a `FirestoreError` so that the reporting is better.