### PR TITLE
Convert state handling to Pydantic models

### DIFF
--- a/src/gafaelfawr/exceptions.py
+++ b/src/gafaelfawr/exceptions.py
@@ -302,7 +302,7 @@ class InvalidRequestError(OAuthBearerError):
     message = "Invalid request"
 
 
-class InvalidTokenError(OAuthBearerError):
+class InvalidTokenError(OAuthBearerError, ValueError):
     """The provided token was invalid.
 
     This corresponds to the ``invalid_token`` error in RFC 6750: "The access

--- a/src/gafaelfawr/models/token.py
+++ b/src/gafaelfawr/models/token.py
@@ -91,16 +91,15 @@ class Token(BaseModel):
         Returns
         -------
         bool
-            Whether that string looks like a Gafaelfawr token.  The token
+            Whether that string looks like a Gafaelfawr token. The token
             isn't checked for validity, only format.
         """
-        if not token.startswith("gt-"):
+        try:
+            cls.from_str(token)
+        except InvalidTokenError:
             return False
-        trimmed_token = token[len("gt-") :]
-        if "." not in trimmed_token:
-            return False
-        key, secret = trimmed_token.split(".", 1)
-        return len(key) == 22 and len(secret) == 22
+        else:
+            return True
 
     def __str__(self) -> str:
         """Return the encoded token."""


### PR DESCRIPTION
The user's state information, stored in a cookie, was previously implemented as a dataclass with hand-written serialization and deserialization code. Replace this with a Pydantic model and validators and let Pydantic do the JSON serialization and deserialization.

This required making `InvalidTokenError` inherit from `ValueError` as well as its current parent so that Pydantic would accept exceptions thrown by validation and process them correctly.