### PR TITLE
Prepare 12.3.2 release

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.8.6
+    rev: v0.9.0
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ Gafaelfawr does not support direct upgrades from versions older than 10.0.0. Whe
 
 <!-- scriv-insert-here -->
 
+<a id='changelog-12.3.2'></a>
+## 12.3.2 (2025-01-09)
+
+### Bug fixes
+
+- Pass multiple delegate scopes to the `/auth` route by repeating the `delegate_scope` query parameter instead of passing a comma-separated list as a single value. ingress-nginx 4.12.0 no longer allows `%` in the `auth-url` annotation and `,` was not initially allowed, and this matches how `scope` was handled.
+
 <a id='changelog-12.3.1'></a>
 ## 12.3.1 (2025-01-08)
 

--- a/changelog.d/20250108_223210_rra_DM_48326.md
+++ b/changelog.d/20250108_223210_rra_DM_48326.md
@@ -1,3 +1,0 @@
-### Bug fixes
-
-- Pass multiple delegate scopes to the `/auth` route by repeating the `delegate_scope` query parameter instead of passing a comma-separated list as a single value. ingress-nginx 4.12.0 no longer allows `%` in the `auth-url` annotation and `,` was not initially allowed, and this matches how `scope` was handled.

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -933,9 +933,9 @@ pycparser==2.22 \
     # via
     #   -c requirements/main.txt
     #   cffi
-pydantic==2.10.4 \
-    --hash=sha256:597e135ea68be3a37552fb524bc7d0d66dcf93d395acd93a00682f1efcb8ee3d \
-    --hash=sha256:82f12e9723da6de4fe2ba888b5971157b3be7ad914267dea8f05f82b28254f06
+pydantic==2.10.5 \
+    --hash=sha256:278b38dbbaec562011d659ee05f63346951b3a248a6f3642e1bc68894ea2b4ff \
+    --hash=sha256:4dd4e322dbe55472cb7ca7e73f4b63574eecccf2835ffa2af9021ce113c83c53
     # via
     #   -c requirements/main.txt
     #   autodoc-pydantic

--- a/requirements/main.txt
+++ b/requirements/main.txt
@@ -1171,9 +1171,9 @@ pycparser==2.22 ; platform_python_implementation != 'PyPy' \
     --hash=sha256:491c8be9c040f5390f5bf44a5b07752bd07f56edf992381b05c701439eec10f6 \
     --hash=sha256:c3702b6d3dd8c7abc1afa565d7e63d53a1d0bd86cdc24edd75470f4de499cfcc
     # via cffi
-pydantic==2.10.4 \
-    --hash=sha256:597e135ea68be3a37552fb524bc7d0d66dcf93d395acd93a00682f1efcb8ee3d \
-    --hash=sha256:82f12e9723da6de4fe2ba888b5971157b3be7ad914267dea8f05f82b28254f06
+pydantic==2.10.5 \
+    --hash=sha256:278b38dbbaec562011d659ee05f63346951b3a248a6f3642e1bc68894ea2b4ff \
+    --hash=sha256:4dd4e322dbe55472cb7ca7e73f4b63574eecccf2835ffa2af9021ce113c83c53
     # via
     #   gafaelfawr (pyproject.toml)
     #   fast-depends

--- a/ruff-shared.toml
+++ b/ruff-shared.toml
@@ -27,6 +27,7 @@ docstring-code-format = true
 
 [lint]
 ignore = [
+    "A005",     # we always use relative imports so this is not ambiguous
     "ANN401",   # sometimes Any is the right type
     "ARG001",   # unused function arguments are often legitimate
     "ARG002",   # unused method arguments are often legitimate

--- a/src/gafaelfawr/cli.py
+++ b/src/gafaelfawr/cli.py
@@ -137,7 +137,7 @@ async def delete_all_data(*, config_path: Path | None) -> None:
     async with Factory.standalone(config, engine) as factory:
         admin_service = factory.create_admin_service()
         async with factory.session.begin():
-            stmt = text(f'TRUNCATE TABLE {", ".join(tables)}')
+            stmt = text(f"TRUNCATE TABLE {', '.join(tables)}")
             logger.info("Truncating all tables")
             await factory.session.execute(stmt)
         await admin_service.add_initial_admins(config.initial_admins)

--- a/src/gafaelfawr/services/token.py
+++ b/src/gafaelfawr/services/token.py
@@ -1132,7 +1132,7 @@ class TokenService:
             )
             alerts.append(
                 f"Token `{key}` for `{redis.username}` does not match"
-                f' between database and Redis ({", ".join(mismatches)})'
+                f" between database and Redis ({', '.join(mismatches)})"
             )
         if parent:
             exp = db.expires

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -5831,9 +5831,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001690",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001690.tgz",
-      "integrity": "sha512-5ExiE3qQN6oF8Clf8ifIDcMRCRE/dMGcETG/XGMD8/XiXm6HXQgQTh1yZYLXXpSOsEUlJm1Xr7kGULZTuGtP/w==",
+      "version": "1.0.30001692",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001692.tgz",
+      "integrity": "sha512-A95VKan0kdtrsnMubMKxEKUKImOPSuCpYgxSQBo036P5YYgVIcOYJEgt/txJWqObiRQeISNCfef9nvlQ0vbV7A==",
       "funding": [
         {
           "type": "opencollective",
@@ -7439,9 +7439,9 @@
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.79",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.79.tgz",
-      "integrity": "sha512-nYOxJNxQ9Om4EC88BE4pPoNI8xwSFf8pU/BAeOl4Hh/b/i6V4biTAzwV7pXi3ARKeoYO5JZKMIXTryXSVer5RA=="
+      "version": "1.5.80",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.80.tgz",
+      "integrity": "sha512-LTrKpW0AqIuHwmlVNV+cjFYTnXtM9K37OGhpe0ZI10ScPSxqVSryZHIY3WnCS5NSYbBODRTZyhRMS2h5FAEqAw=="
     },
     "node_modules/emoji-regex": {
       "version": "9.2.2",


### PR DESCRIPTION
Update Python, pre-commit, and JavaScript dependencies and the shared Ruff configuration file. Apply new Ruff fixes. Collect change log entries for the 12.3.2 release.