### PR TITLE
DM-48387: Send users with no login state to after logout

### DIFF
--- a/changelog.d/20250110_124013_rra_DM_48387.md
+++ b/changelog.d/20250110_124013_rra_DM_48387.md
@@ -1,0 +1,3 @@
+### Bug fixes
+
+- If the user returns to the login route without login state and no return URL is set (which will be the common case), redirect them to the after logout URL instead of returning a 403 error. Often this means the user previously authenticated via another tab and is now logged on, but we have lost the return URL and do not know where to send them. Returning the error is more confusing and often causes the user to attempt to reload the error page, which then fails.

--- a/tests/handlers/login_github_test.py
+++ b/tests/handlers/login_github_test.py
@@ -623,3 +623,14 @@ async def test_invalid_state(
     )
     assert r.status_code == 307
     assert r.headers["Location"] == return_url
+
+    # Also drop the return URL, which is a more realistic case.
+    state.return_url = None
+    client.cookies.set(COOKIE_NAME, state.to_cookie(), domain=TEST_HOSTNAME)
+
+    # Now we should get a redirect to the after logout URL.
+    r = await client.get(
+        "/login", params={"code": "some-code", "state": query["state"][0]}
+    )
+    assert r.status_code == 307
+    assert r.headers["Location"] == str(config.after_logout_url)


### PR DESCRIPTION
If the user returns to the login route without login state and no return URL is set (which will be the common case), redirect them to the after logout URL instead of returning a 403 error. Often this means the user previously authenticated via another tab and is now logged on, but we have lost the return URL and do not know where to send them. Returning the error is more confusing and often causes the user to attempt to reload the error page, which then fails.