### PR TITLE
DM-48390: Separate persistent and ephemeral Redis

### DIFF
--- a/changelog.d/20250110_143131_rra_DM_48390.md
+++ b/changelog.d/20250110_143131_rra_DM_48390.md
@@ -1,0 +1,3 @@
+### Other changes
+
+- OpenID Connect authentication codes are now stored in an ephemeral Redis instance rather than in the same database as data, such as tokens, that should persist.

--- a/src/gafaelfawr/config.py
+++ b/src/gafaelfawr/config.py
@@ -855,17 +855,28 @@ class Config(EnvFirstSettings):
         validation_alias="GAFAELFAWR_REALM",
     )
 
-    redis_url: EnvRedisDsn = Field(
+    redis_ephemeral_url: EnvRedisDsn = Field(
+        ...,
+        title="Ephemeral Redis DSN",
+        description="DSN for the Redis server that stores ephemeral data",
+        validation_alias=AliasChoices(
+            "GAFAELFAWR_REDIS_EPHEMERAL_URL", "redisEphemeralUrl"
+        ),
+    )
+
+    redis_persistent_url: EnvRedisDsn = Field(
         ...,
         title="Persistent Redis DSN",
         description="DSN for the Redis server that stores tokens",
-        validation_alias=AliasChoices("GAFAELFAWR_REDIS_URL", "redisUrl"),
+        validation_alias=AliasChoices(
+            "GAFAELFAWR_REDIS_PERSISTENT_URL", "redisPersistentUrl"
+        ),
     )
 
     redis_password: SecretStr | None = Field(
         None,
-        title="Persistent Redis password",
-        description="Password for the Redis server that stores tokens",
+        title="Redis password",
+        description="Password for both Redis servers",
         validation_alias=AliasChoices(
             "GAFAELFAWR_REDIS_PASSWORD", "redisPassword"
         ),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -134,7 +134,8 @@ async def empty_database(engine: AsyncEngine, config: Config) -> None:
     logger = structlog.get_logger(__name__)
     await initialize_gafaelfawr_database(config, logger, engine, reset=True)
     async with Factory.standalone(config, engine) as factory:
-        await factory._context.redis.flushdb()
+        await factory._context.ephemeral_redis.flushdb()
+        await factory._context.persistent_redis.flushdb()
     await stamp_database_async(engine)
 
 

--- a/tests/handlers/oidc_test.py
+++ b/tests/handlers/oidc_test.py
@@ -626,7 +626,7 @@ async def test_token_errors(
     assert log["error"] == f"Unknown authorization code {bogus_code.key}"
 
     # Corrupt stored data.
-    await factory.redis.set(bogus_code.key, "XXXXXXX")
+    await factory.ephemeral_redis.set(bogus_code.key, "XXXXXXX")
     r = await client.post("/auth/openid/token", data=request)
     assert r.status_code == 400
     assert r.json() == {

--- a/tests/services/token_cache_test.py
+++ b/tests/services/token_cache_test.py
@@ -98,7 +98,7 @@ async def test_expiration(config: Config, factory: Factory) -> None:
     logger = structlog.get_logger("gafaelfawr")
     storage = EncryptedPydanticRedisStorage(
         datatype=TokenData,
-        redis=factory.redis,
+        redis=factory.persistent_redis,
         encryption_key=config.session_secret.get_secret_value(),
         key_prefix="token:",
     )

--- a/tox.ini
+++ b/tox.ini
@@ -39,7 +39,8 @@ setenv =
     GAFAELFAWR_ALEMBIC_CONFIG_PATH = {toxinidir}/alembic.ini
     GAFAELFAWR_DATABASE_URL = postgresql://gafaelfawr@localhost/gafaelfawr
     GAFAELFAWR_DATABASE_PASSWORD = INSECURE-PASSWORD
-    GAFAELFAWR_REDIS_URL = redis://localhost/0
+    GAFAELFAWR_REDIS_EPHEMERAL_URL = redis://localhost/1
+    GAFAELFAWR_REDIS_PERSISTENT_URL = redis://localhost/0
     GAFAELFAWR_UI_PATH = {toxinidir}/ui/public
 
 [testenv:alembic]
@@ -52,7 +53,8 @@ setenv =
     GAFAELFAWR_CONFIG_PATH = {toxinidir}/alembic/gafaelfawr.yaml
     GAFAELFAWR_DATABASE_URL = postgresql://gafaelfawr@localhost/gafaelfawr
     GAFAELFAWR_DATABASE_PASSWORD = INSECURE
-    GAFAELFAWR_REDIS_URL = redis://localhost/0
+    GAFAELFAWR_REDIS_EPHEMERAL_URL = redis://localhost/1
+    GAFAELFAWR_REDIS_PERSISTENT_URL = redis://localhost/0
 
 [testenv:coverage-report]
 description = Compile coverage from each test run.
@@ -93,7 +95,8 @@ setenv =
     GAFAELFAWR_CONFIG_PATH = {toxinidir}/alembic/gafaelfawr.yaml
     GAFAELFAWR_DATABASE_URL = postgresql://gafaelfawr@localhost/gafaelfawr
     GAFAELFAWR_DATABASE_PASSWORD = INSECURE
-    GAFAELFAWR_REDIS_URL = redis://localhost/0
+    GAFAELFAWR_REDIS_EPHEMERAL_URL = redis://localhost/1
+    GAFAELFAWR_REDIS_PERSISTENT_URL = redis://localhost/0
     GAFAELFAWR_REDIS_PASSWORD = TOTALLY-INSECURE-test-password
 
 [testenv:lint]
@@ -130,7 +133,8 @@ setenv =
     GAFAELFAWR_ALEMBIC_CONFIG_PATH = {toxinidir}/alembic.ini
     GAFAELFAWR_DATABASE_URL = postgresql://gafaelfawr@localhost/gafaelfawr
     GAFAELFAWR_DATABASE_PASSWORD = INSECURE-PASSWORD
-    GAFAELFAWR_REDIS_URL = redis://localhost/0
+    GAFAELFAWR_REDIS_EPHEMERAL_URL = redis://localhost/1
+    GAFAELFAWR_REDIS_PERSISTENT_URL = redis://localhost/0
     GAFAELFAWR_UI_PATH = {toxinidir}/ui/public
     TEST_KUBERNETES = 1
 


### PR DESCRIPTION
Add a separate Redis client and connection pool for an ephemeral Redis instance and move OpenID Connect authentication codes into that Redis, rather than storing them in the same Redis as persistent data such as tokens. This ephemeral Redis will soon be used for rate limit data as well.