### PR TITLE
DM-48390: Add rate limiting headers to ingress responses

### DIFF
--- a/docs/_rst_epilog.rst
+++ b/docs/_rst_epilog.rst
@@ -1,4 +1,5 @@
 .. _Alembic: https://alembic.sqlalchemy.org/en/latest/index.html
+.. _Github rate limit implementation: https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api?apiVersion=2022-11-28
 .. _ingress-nginx: https://kubernetes.github.io/ingress-nginx/
 .. _Keycloak: https://www.keycloak.org/
 .. _Kopf: https://kopf.readthedocs.io/en/stable/

--- a/tests/handlers/ingress_test.py
+++ b/tests/handlers/ingress_test.py
@@ -3,8 +3,7 @@
 from __future__ import annotations
 
 import base64
-from datetime import UTC, datetime, timedelta
-from email.utils import parsedate_to_datetime
+from datetime import timedelta
 from unittest.mock import ANY
 
 import pytest
@@ -1151,40 +1150,3 @@ async def test_only_service(client: AsyncClient, factory: Factory) -> None:
     assert isinstance(authenticate, AuthErrorChallenge)
     assert authenticate.auth_type == AuthType.Bearer
     assert authenticate.error == AuthError.insufficient_scope
-
-
-@pytest.mark.asyncio
-async def test_rate_limit(client: AsyncClient, factory: Factory) -> None:
-    await reconfigure("github-quota", factory)
-    token_data = await create_session_token(
-        factory, group_names=["foo"], scopes={"read:all"}
-    )
-
-    # Two requests should be allowed, one from the default quota and a second
-    # from the additional quota from the foo group.
-    r = await client.get(
-        "/ingress/auth",
-        params={"scope": "read:all", "service": "test"},
-        headers={"Authorization": f"Bearer {token_data.token}"},
-    )
-    assert r.status_code == 200
-    r = await client.get(
-        "/ingress/auth",
-        params={"scope": "read:all", "service": "test"},
-        headers={"Authorization": f"Bearer {token_data.token}"},
-    )
-    assert r.status_code == 200
-
-    # The third request should be rejected due to rate limiting, with a
-    # Retry-After header set to approximately fifteen minutes from now.
-    expected = (
-        datetime.now(tz=UTC) + timedelta(minutes=15) - timedelta(seconds=1)
-    )
-    r = await client.get(
-        "/ingress/auth",
-        params={"scope": "read:all", "service": "test"},
-        headers={"Authorization": f"Bearer {token_data.token}"},
-    )
-    assert r.status_code == 429
-    retry_after = parsedate_to_datetime(r.headers["Retry-After"])
-    assert expected <= retry_after <= expected + timedelta(seconds=2)


### PR DESCRIPTION
Return rate limiting information in HTTP headers for all authenticated ingress responses. The headers sent match those used by GitHub's rate limiting implementation.