### PR TITLE
DM-48390: Add support for bypassing quota

### DIFF
--- a/changelog.d/20250114_135624_rra_DM_48390.md
+++ b/changelog.d/20250114_135624_rra_DM_48390.md
@@ -1,0 +1,3 @@
+### New features
+
+- Add a `bypass` key to the quota configuration containing a group list. Any member of one of those groups ignores all quota restrictions.

--- a/src/gafaelfawr/config.py
+++ b/src/gafaelfawr/config.py
@@ -712,6 +712,12 @@ class QuotaConfig(BaseModel):
         description="Additional quota grants by group name",
     )
 
+    bypass: set[str] = Field(
+        set(),
+        title="Groups without quotas",
+        description="Groups whose members bypass all quota restrictions",
+    )
+
 
 class GitHubGroupTeam(BaseModel):
     """Specification for a GitHub team."""

--- a/tests/data/config/github-quota.yaml
+++ b/tests/data/config/github-quota.yaml
@@ -32,6 +32,8 @@ quota:
       notebook:
         cpu: 0.0
         memory: 4.0
+  bypass:
+    - "admin"
 metrics:
   enabled: false
   application: "gafaelfawr"

--- a/tests/handlers/ingress_rate_test.py
+++ b/tests/handlers/ingress_rate_test.py
@@ -67,3 +67,26 @@ async def test_rate_limit(client: AsyncClient, factory: Factory) -> None:
     assert r.headers["X-RateLimit-Resource"] == "test"
     reset = int(r.headers["X-RateLimit-Reset"])
     assert expected.timestamp() <= reset <= expected.timestamp() + 5
+
+
+@pytest.mark.asyncio
+async def test_rate_limit_bypass(
+    client: AsyncClient, factory: Factory
+) -> None:
+    await reconfigure("github-quota", factory)
+    token_data = await create_session_token(
+        factory, group_names=["admin"], scopes={"read:all"}
+    )
+    r = await client.get(
+        "/ingress/auth",
+        params={"scope": "read:all", "service": "test"},
+        headers={"Authorization": f"Bearer {token_data.token}"},
+    )
+    assert r.status_code == 200
+
+    # There should be no quota set since the user is in the bypass group.
+    assert "X-RateLimit-Limit" not in r.headers
+    assert "X-RateLimit-Remaining" not in r.headers
+    assert "X-RateLimit-Used" not in r.headers
+    assert "X-RateLimit-Resource" not in r.headers
+    assert "X-RateLimit-Reset" not in r.headers


### PR DESCRIPTION
Add a `bypass` key to the quota configuration that lists one or more groups. Any member of one of those groups ignores all quotas and will never have a quota set.