### PR TITLE
DM-48390: Add support for disallowing notebook spawns

### DIFF
--- a/changelog.d/20250114_155651_rra_DM_48390.md
+++ b/changelog.d/20250114_155651_rra_DM_48390.md
@@ -1,0 +1,3 @@
+### New features
+
+- Add a flag to notebook quotas, defaulting to true, that indicates whether the user is allowed to spawn a new lab. This is not enforced by Gafaelfawr; it will be read and acted on by [Nublado](https://nublado.lsst.io).

--- a/docs/user-guide/helm.rst
+++ b/docs/user-guide/helm.rst
@@ -523,14 +523,26 @@ Here is an example:
        groups:
          g_developers:
            notebook:
-             cpu: 8.0
+             cpu: 0.0
              memory: 4.0
+        g_limited:
+          notebook:
+            cpu: 0.0
+            memory: 0.0
+            spawn: false
+      bypass:
+        - "g_admins"
 
 API quotas are in requests per 15 minutes.
 Notebook quotas are in CPU equivalents and GiB of memory.
+If spawn is set to false, users should not be allowed to spawn a new user notebook.
+Members of groups listed in ``bypass`` ignore all quota restrictions.
 
 The above example sets an API quota for the ``datalinker`` service of 1000 requests per 15 minutes, and a default quota for user notebooks of 2.0 CPU equivalents and 4.0GiB of memory.
 Users who are members of the ``g_developers`` group get an additional 4.0GiB of memory for their notebooks.
+Users who are members of the ``g_limited`` group are not allowed to spawn notebooks.
+(Note that the CPU and memory quota additions must be specified, even if they are zero.)
+Users who are members of the ``g_admins`` group ignore all quota restrictions.
 
 The keys for API quotas are names of services.
 This is the same name the service should use in the ``config.service`` key of a ``GafaelfawrIngress`` resource (see :ref:`ingress`).

--- a/src/gafaelfawr/config.py
+++ b/src/gafaelfawr/config.py
@@ -706,6 +706,7 @@ class QuotaConfig(BaseModel):
                 if notebook:
                     notebook.cpu += extra.notebook.cpu
                     notebook.memory += extra.notebook.memory
+                    notebook.spawn &= extra.notebook.spawn
                 else:
                     notebook = extra.notebook.model_copy()
             for service, quota in extra.api.items():

--- a/src/gafaelfawr/models/userinfo.py
+++ b/src/gafaelfawr/models/userinfo.py
@@ -85,6 +85,12 @@ class NotebookQuota(BaseModel):
         ..., title="Maximum memory use (GiB)", examples=[16.0]
     )
 
+    spawn: bool = Field(
+        True,
+        title="Spawning allowed",
+        description="Whether the user is allowed to spawn a notebook",
+    )
+
 
 class Quota(BaseModel):
     """Quota information for a user."""

--- a/tests/data/config/github-quota.yaml
+++ b/tests/data/config/github-quota.yaml
@@ -26,6 +26,11 @@ quota:
       cpu: 8
       memory: 4.0
   groups:
+    blocked:
+      notebook:
+        cpu: 0
+        memory: 0
+        spawn: false
     foo:
       api:
         test: 1


### PR DESCRIPTION
Add a flag to the notebook quota indicating whether the user should be allowed to spawn a notebook, defaulting to true. This may be set to false for a specific group (or, later, a quota override) to indicate that user should not be allowed to spawn notebooks.

This field is calculated and returned by Gafaelfawr but is not enforced by it. It will be read by Nublado (specifically the Nublado controller).