### PR TITLE
DM-48432: Add support for quota overrides

### DIFF
--- a/changelog.d/20250116_152452_rra_DM_48432.md
+++ b/changelog.d/20250116_152452_rra_DM_48432.md
@@ -1,0 +1,3 @@
+### New features
+
+- Add support for quota overrides. Overrides can be set via a new REST API at `/auth/api/v1/quota-overrides` and take precedence over the configured quotas if present and applicable.

--- a/docs/dev/internals.rst
+++ b/docs/dev/internals.rst
@@ -159,6 +159,9 @@ Python internal API
 .. automodapi:: gafaelfawr.storage.oidc
    :include-all-objects:
 
+.. automodapi:: gafaelfawr.storage.quota
+   :include-all-objects:
+
 .. automodapi:: gafaelfawr.storage.token
    :include-all-objects:
 

--- a/src/gafaelfawr/models/quota.py
+++ b/src/gafaelfawr/models/quota.py
@@ -1,0 +1,124 @@
+"""Models for user quotas."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+__all__ = [
+    "NotebookQuota",
+    "Quota",
+    "QuotaConfig",
+]
+
+
+class NotebookQuota(BaseModel):
+    """Notebook Aspect quota information for a user."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    cpu: float = Field(..., title="CPU equivalents", examples=[4.0])
+
+    memory: float = Field(
+        ..., title="Maximum memory use (GiB)", examples=[16.0]
+    )
+
+    spawn: bool = Field(
+        True,
+        title="Spawning allowed",
+        description="Whether the user is allowed to spawn a notebook",
+    )
+
+
+class Quota(BaseModel):
+    """Quota information for a user."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    api: dict[str, int] = Field(
+        {},
+        title="API quotas",
+        description=(
+            "Mapping of service names to allowed requests per 15 minutes."
+        ),
+        examples=[
+            {
+                "datalinker": 500,
+                "hips": 2000,
+                "tap": 500,
+                "vo-cutouts": 100,
+            }
+        ],
+    )
+
+    notebook: NotebookQuota | None = Field(
+        None, title="Notebook Aspect quotas"
+    )
+
+
+class QuotaConfig(BaseModel):
+    """Quota configuration."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    default: Quota = Field(
+        ..., title="Default quota", description="Default quotas for all users"
+    )
+
+    groups: dict[str, Quota] = Field(
+        {},
+        title="Quota grants by group",
+        description="Additional quota grants by group name",
+    )
+
+    bypass: set[str] = Field(
+        set(),
+        title="Groups without quotas",
+        description="Groups whose members bypass all quota restrictions",
+    )
+
+    def calculate_quota(self, groups: set[str]) -> Quota | None:
+        """Calculate user's quota given their group membership.
+
+        Parameters
+        ----------
+        groups
+            Group membership of the user.
+
+        Returns
+        -------
+        Quota or None
+            Quota information for that user or `None` if no quotas apply. If
+            the user bypasses quotas, a `~gafaelfawr.models.quota.Quota` model
+            with quotas set to `None` or an empty dictionary is returned rather
+            than `None`.
+        """
+        if groups & self.bypass:
+            return Quota()
+
+        # Start with the defaults.
+        api = dict(self.default.api)
+        notebook = None
+        if self.default.notebook:
+            notebook = self.default.notebook.model_copy()
+
+        # Look for group-specific rules.
+        for group in groups & set(self.groups.keys()):
+            extra = self.groups[group]
+            if extra.notebook:
+                if notebook:
+                    notebook.cpu += extra.notebook.cpu
+                    notebook.memory += extra.notebook.memory
+                    notebook.spawn &= extra.notebook.spawn
+                else:
+                    notebook = extra.notebook.model_copy()
+            for service, quota in extra.api.items():
+                if service in api:
+                    api[service] += quota
+                else:
+                    api[service] = quota
+
+        # Return the results.
+        if not notebook and not api:
+            return None
+        else:
+            return Quota(api=api, notebook=notebook)

--- a/src/gafaelfawr/models/userinfo.py
+++ b/src/gafaelfawr/models/userinfo.py
@@ -5,15 +5,15 @@ from __future__ import annotations
 from dataclasses import dataclass
 from datetime import datetime
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, Field
 
 from ..constants import GROUPNAME_REGEX
 from ..pydantic import Timestamp
+from .quota import Quota
 
 __all__ = [
     "CADCUserInfo",
     "Group",
-    "NotebookQuota",
     "Quota",
     "RateLimitStatus",
     "UserInfo",
@@ -71,50 +71,6 @@ class Group(BaseModel):
         ...,
         title="Numeric GID of the group",
         examples=[123181],
-    )
-
-
-class NotebookQuota(BaseModel):
-    """Notebook Aspect quota information for a user."""
-
-    model_config = ConfigDict(extra="forbid")
-
-    cpu: float = Field(..., title="CPU equivalents", examples=[4.0])
-
-    memory: float = Field(
-        ..., title="Maximum memory use (GiB)", examples=[16.0]
-    )
-
-    spawn: bool = Field(
-        True,
-        title="Spawning allowed",
-        description="Whether the user is allowed to spawn a notebook",
-    )
-
-
-class Quota(BaseModel):
-    """Quota information for a user."""
-
-    model_config = ConfigDict(extra="forbid")
-
-    api: dict[str, int] = Field(
-        {},
-        title="API quotas",
-        description=(
-            "Mapping of service names to allowed requests per 15 minutes."
-        ),
-        examples=[
-            {
-                "datalinker": 500,
-                "hips": 2000,
-                "tap": 500,
-                "vo-cutouts": 100,
-            }
-        ],
-    )
-
-    notebook: NotebookQuota | None = Field(
-        None, title="Notebook Aspect quotas"
     )
 
 

--- a/src/gafaelfawr/storage/quota.py
+++ b/src/gafaelfawr/storage/quota.py
@@ -1,0 +1,73 @@
+"""Storage layer for quota overrides."""
+
+from __future__ import annotations
+
+from safir.redis import DeserializeError, PydanticRedisStorage
+from safir.slack.webhook import SlackWebhookClient
+from structlog.stdlib import BoundLogger
+
+from ..models.quota import QuotaConfig
+
+__all__ = ["QuotaOverridesStore"]
+
+
+class QuotaOverridesStore:
+    """Stores and retrieves quota overrides in Redis.
+
+    Parameters
+    ----------
+    storage
+        Underlying storage for quota overrides.
+    slack_client
+        If provided, Slack webhook client to report deserialization errors of
+        Redis data.
+    logger
+        Logger for diagnostics.
+    """
+
+    def __init__(
+        self,
+        storage: PydanticRedisStorage[QuotaConfig],
+        slack_client: SlackWebhookClient | None,
+        logger: BoundLogger,
+    ) -> None:
+        self._storage = storage
+        self._slack = slack_client
+        self._logger = logger
+
+    async def delete(self) -> bool:
+        """Delete any stored quota overrides.
+
+        Returns
+        -------
+        bool
+            `True` if there were quota overrides to delete, `False` otherwise.
+        """
+        return await self._storage.delete("quota-overrides")
+
+    async def get(self) -> QuotaConfig | None:
+        """Retrieve quota overrides from Redis, if any.
+
+        Returns
+        -------
+        QuotaConfig or None
+            Quota overrides if any are set, or `None` if there are none.
+        """
+        try:
+            return await self._storage.get("quota-overrides")
+        except DeserializeError as e:
+            msg = "Cannot retrieve quota overrides"
+            self._logger.exception(msg, error=str(e))
+            if self._slack:
+                await self._slack.post_exception(e)
+            return None
+
+    async def store(self, overrides: QuotaConfig) -> None:
+        """Store quota overrides in Redis.
+
+        Parameters
+        ----------
+        overrides
+            Overrides to store, replacing any existing overrides.
+        """
+        await self._storage.store("quota-overrides", overrides)

--- a/tests/handlers/ingress_rate_test.py
+++ b/tests/handlers/ingress_rate_test.py
@@ -20,6 +20,7 @@ async def test_rate_limit(client: AsyncClient, factory: Factory) -> None:
     token_data = await create_session_token(
         factory, group_names=["foo"], scopes={"read:all"}
     )
+    headers = {"Authorization": f"bearer {token_data.token}"}
     now = datetime.now(tz=UTC)
     expected = now + timedelta(minutes=15) - timedelta(seconds=1)
 
@@ -28,7 +29,7 @@ async def test_rate_limit(client: AsyncClient, factory: Factory) -> None:
     r = await client.get(
         "/ingress/auth",
         params={"scope": "read:all", "service": "test"},
-        headers={"Authorization": f"Bearer {token_data.token}"},
+        headers=headers,
     )
     assert r.status_code == 200
     assert r.headers["X-RateLimit-Limit"] == "2"
@@ -40,7 +41,7 @@ async def test_rate_limit(client: AsyncClient, factory: Factory) -> None:
     r = await client.get(
         "/ingress/auth",
         params={"scope": "read:all", "service": "test"},
-        headers={"Authorization": f"Bearer {token_data.token}"},
+        headers=headers,
     )
     assert r.status_code == 200
     assert r.headers["X-RateLimit-Limit"] == "2"
@@ -55,7 +56,7 @@ async def test_rate_limit(client: AsyncClient, factory: Factory) -> None:
     r = await client.get(
         "/ingress/auth",
         params={"scope": "read:all", "service": "test"},
-        headers={"Authorization": f"Bearer {token_data.token}"},
+        headers=headers,
     )
     assert r.status_code == 429
     retry_after = parsedate_to_datetime(r.headers["Retry-After"])
@@ -77,10 +78,12 @@ async def test_rate_limit_bypass(
     token_data = await create_session_token(
         factory, group_names=["admin"], scopes={"read:all"}
     )
+    headers = {"Authorization": f"bearer {token_data.token}"}
+
     r = await client.get(
         "/ingress/auth",
         params={"scope": "read:all", "service": "test"},
-        headers={"Authorization": f"Bearer {token_data.token}"},
+        headers=headers,
     )
     assert r.status_code == 200
 

--- a/tests/handlers/quota_test.py
+++ b/tests/handlers/quota_test.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 import pytest
 from httpx import AsyncClient
 
+from gafaelfawr.config import Config
 from gafaelfawr.factory import Factory
 from gafaelfawr.models.token import TokenUserInfo
 from gafaelfawr.models.userinfo import Group
@@ -84,3 +87,156 @@ async def test_no_spawn(client: AsyncClient, factory: Factory) -> None:
             "notebook": {"cpu": 8.0, "memory": 4.0, "spawn": False},
         },
     }
+
+
+@pytest.mark.asyncio
+async def test_rate_limit_override(
+    client: AsyncClient, factory: Factory
+) -> None:
+    config = await reconfigure("github-quota", factory)
+    assert config.quota
+    token_data = await create_session_token(
+        factory,
+        group_names=["foo"],
+        scopes={"admin:token", "read:all"},
+    )
+    assert token_data.groups
+    default_quota = config.quota.calculate_quota({"foo"})
+    assert default_quota
+    headers = {"Authorization": f"bearer {token_data.token}"}
+
+    overrides: dict[str, Any] = {
+        "bypass": [],
+        "default": {"api": {"test": 10}},
+        "groups": {},
+    }
+    r = await client.put(
+        "/auth/api/v1/quota-overrides", json=overrides, headers=headers
+    )
+    assert r.status_code == 200
+    r = await client.get(
+        "/ingress/auth",
+        params={"scope": "read:all", "service": "test"},
+        headers=headers,
+    )
+    assert r.status_code == 200
+    assert r.headers["X-RateLimit-Limit"] == "10"
+    assert r.headers["X-RateLimit-Remaining"] == "9"
+
+    r = await client.get("/auth/api/v1/user-info", headers=headers)
+    expected_user_info: dict[str, Any] = {
+        "username": token_data.username,
+        "name": token_data.name,
+        "email": token_data.email,
+        "uid": token_data.uid,
+        "gid": token_data.gid,
+        "groups": [
+            g.model_dump(mode="json")
+            for g in sorted(token_data.groups, key=lambda g: g.name)
+        ],
+        "quota": {
+            "api": {"datalinker": 1000, "test": 10},
+            "notebook": {"cpu": 8.0, "memory": 8.0, "spawn": True},
+        },
+    }
+    assert r.json() == expected_user_info
+
+    overrides["default"]["notebook"] = {"cpu": 1, "memory": 1, "spawn": False}
+    r = await client.put(
+        "/auth/api/v1/quota-overrides", json=overrides, headers=headers
+    )
+    assert r.status_code == 200
+    expected_user_info["quota"]["notebook"] = overrides["default"]["notebook"]
+    r = await client.get("/auth/api/v1/user-info", headers=headers)
+    assert r.json() == expected_user_info
+
+    overrides["bypass"] = ["foo"]
+    r = await client.put(
+        "/auth/api/v1/quota-overrides", json=overrides, headers=headers
+    )
+    assert r.status_code == 200
+    expected_user_info["quota"] = {"api": {}}
+    r = await client.get("/auth/api/v1/user-info", headers=headers)
+    assert r.json() == expected_user_info
+
+    # Return to normal behavior by deleting the overrides.
+    r = await client.delete("/auth/api/v1/quota-overrides", headers=headers)
+    assert r.status_code == 204
+    expected_user_info["quota"] = default_quota.model_dump(mode="json")
+    r = await client.get("/auth/api/v1/user-info", headers=headers)
+    assert r.json() == expected_user_info
+
+
+@pytest.mark.asyncio
+async def test_rate_limit_override_only(
+    client: AsyncClient, factory: Factory, config: Config
+) -> None:
+    """Check behavior when there is an override and no base quota."""
+    assert not config.quota
+    token_data = await create_session_token(
+        factory, group_names=["admin"], scopes={"admin:token", "read:all"}
+    )
+    assert token_data.groups
+    headers = {"Authorization": f"bearer {token_data.token}"}
+
+    r = await client.get(
+        "/ingress/auth",
+        params={"scope": "read:all", "service": "test"},
+        headers=headers,
+    )
+    assert r.status_code == 200
+    assert "X-RateLimit-Limit" not in r.headers
+
+    overrides: dict[str, Any] = {
+        "bypass": [],
+        "default": {
+            "notebook": {"cpu": 1.0, "memory": 4.0, "spawn": True},
+            "api": {"test": 10},
+        },
+        "groups": {},
+    }
+    r = await client.put(
+        "/auth/api/v1/quota-overrides", json=overrides, headers=headers
+    )
+    assert r.status_code == 200
+    assert r.json() == overrides
+    r = await client.get(
+        "/ingress/auth",
+        params={"scope": "read:all", "service": "test"},
+        headers=headers,
+    )
+    assert r.status_code == 200
+    assert r.headers["X-RateLimit-Limit"] == "10"
+    assert r.headers["X-RateLimit-Remaining"] == "9"
+    assert r.headers["X-RateLimit-Used"] == "1"
+    assert r.headers["X-RateLimit-Resource"] == "test"
+
+    r = await client.get("/auth/api/v1/user-info", headers=headers)
+    expected_user_info = {
+        "username": token_data.username,
+        "name": token_data.name,
+        "email": token_data.email,
+        "uid": token_data.uid,
+        "gid": token_data.gid,
+        "groups": [
+            g.model_dump(mode="json")
+            for g in sorted(token_data.groups, key=lambda g: g.name)
+        ],
+        "quota": {
+            "api": {"test": 10},
+            "notebook": {"cpu": 1.0, "memory": 4.0, "spawn": True},
+        },
+    }
+    assert r.json() == expected_user_info
+
+    # Add the user's group to bypass.
+    overrides["bypass"] = ["admin"]
+    r = await client.put(
+        "/auth/api/v1/quota-overrides", json=overrides, headers=headers
+    )
+    assert r.status_code == 200
+    assert r.json() == overrides
+    expected_user_info["quota"] = {"api": {}}
+    r = await client.get("/auth/api/v1/user-info", headers=headers)
+    assert r.status_code == 200
+    assert r.json() == expected_user_info


### PR DESCRIPTION
Add a new REST API to set, retrieve, and delete quota overrides. Apply those overrides on top of the configured quotas. The overrides are stored in Redis and retrieved on every request currently; we will see if that's too slow and needs caching.