### PR TITLE
DM-48495: Add rate limiting integration with nginx

### DIFF
--- a/docs/user-guide/headers.rst
+++ b/docs/user-guide/headers.rst
@@ -1,0 +1,39 @@
+################
+Response headers
+################
+
+The following headers may be added to the response from a service protected by Gafaelfawr.
+They will only be added for services behind an authenticated ``GafaelfawrIngress`` resource, not an anonymous one.
+
+Rate limit headers
+==================
+
+``Retry-After``
+    Only sent on 429 responses once the rate limit has been exceeded.
+    Specifies the time at which the rate limit will reset and the user will be able to make requests again.
+    The value is an HTTP date.
+
+``X-RateLimit-Limit``
+    This request is subject to a rate limit.
+    The value of this header is the total number of requests permitted in each time window, which currently is always fifteen minutes.
+    See ``X-RateLimit-Remaining`` for the number of requests left in that interval.
+
+``X-RateLimit-Remaining``
+    The number of requests to this service remaining in the user's quota.
+    The quota will reset at the time given by ``X-RateLimit-Reset``.
+
+``X-RateLimit-Reset``
+    The time at which the rate limit quota will reset, in seconds since epoch.
+    At this time, the number of requests seen will be reset to zero, and the user will receive another full allotment of their quota.
+
+``X-RateLimit-Resource``
+    The name of the resource being rate-limited.
+    This will match the ``service`` setting of the ``GafaelfawrIngress`` Kubernetes resource.
+    Clients can use this header to understand what requests are subject to a given quota.
+
+``X-RateLimit-Used``
+    The number of requests to this resource seen within the rate limit period.
+    This will be ``X-RateLimit-Limit`` minus ``X-RateLimit-Remaining``.
+
+The ``X-RateLimit`` headers are sent for successful responses, error responses from the underlying service, and 429 responses.
+The ``Retry-After`` header is only sent as part of a 429 response.

--- a/docs/user-guide/index.rst
+++ b/docs/user-guide/index.rst
@@ -27,6 +27,7 @@ Also see the `Phalanx Gafaelfawr application documentation <https://phalanx.lsst
 .. toctree::
    :caption: Reference
 
+   headers
    logging
    cli
    metrics

--- a/src/gafaelfawr/constants.py
+++ b/src/gafaelfawr/constants.py
@@ -106,9 +106,21 @@ deleted entirely if the subrequest doesn't return one of these headers.
 """
 
 NGINX_SNIPPET = """\
+auth_request_set $auth_error_body $upstream_http_x_error_body;
+auth_request_set $auth_ratelimit_limit $upstream_http_x_ratelimit_limit;
+auth_request_set $auth_ratelimit_remaining\
+ $upstream_http_x_ratelimit_remaining;
+auth_request_set $auth_ratelimit_reset $upstream_http_x_ratelimit_reset;
+auth_request_set $auth_ratelimit_resource $upstream_http_x_ratelimit_resource;
+auth_request_set $auth_ratelimit_used $upstream_http_x_ratelimit_used;
+auth_request_set $auth_retry_after $upstream_http_retry_after;
 auth_request_set $auth_www_authenticate $upstream_http_www_authenticate;
 auth_request_set $auth_status $upstream_http_x_error_status;
-auth_request_set $auth_error_body $upstream_http_x_error_body;
+more_set_headers "X-RateLimit-Limit: $auth_ratelimit_limit";
+more_set_headers "X-RateLimit-Remaining: $auth_ratelimit_remaining";
+more_set_headers "X-RateLimit-Reset: $auth_ratelimit_reset";
+more_set_headers "X-RateLimit-Resource: $auth_ratelimit_resource";
+more_set_headers "X-RateLimit-Used: $auth_ratelimit_used";
 error_page 403 = @autherror;
 """
 """Code snippet to put into NGINX configuration for each ingress."""


### PR DESCRIPTION
Add the necessary lines to the ingress-nginx snippet to set variables needed by the rate limiting response. Fix the rate limiting ingress response to use 403 and put the status code and body in the headers to work with the integration.

Document the rate limiting headers set by Gafaelfawr.