### PR TITLE
DM-48495: Return a list of errors from auth failures

### DIFF
--- a/src/gafaelfawr/auth.py
+++ b/src/gafaelfawr/auth.py
@@ -170,7 +170,7 @@ def generate_challenge(
         error_description=str(exc),
         scope=" ".join(sorted(scopes)) if scopes else None,
     )
-    detail = {"msg": str(exc), "type": exc.error}
+    detail = [{"msg": str(exc), "type": exc.error}]
     headers = {
         "Cache-Control": "no-cache, no-store",
         "WWW-Authenticate": challenge.to_header(),


### PR DESCRIPTION
In `generate_challenge`, change the body of the error to be a list of errors rather than a single error, following the error model used and declared elsewhere in Gafaelfawr.