### PR TITLE
DM-48786: Allow regular users to get quota overrides

### DIFF
--- a/changelog.d/20250204_143146_rra_DM_48786.md
+++ b/changelog.d/20250204_143146_rra_DM_48786.md
@@ -1,0 +1,3 @@
+### Bug fixes
+
+- Allow any authenticated user to see the current quota overrides, rather than restricting them to admins. Changing the quota overrides still requires an admin scope.

--- a/src/gafaelfawr/handlers/api.py
+++ b/src/gafaelfawr/handlers/api.py
@@ -311,7 +311,7 @@ async def get_login(
 )
 async def get_quota_overrides(
     *,
-    auth_data: Annotated[TokenData, Depends(authenticate_admin_read)],
+    auth_data: Annotated[TokenData, Depends(authenticate_read)],
     context: Annotated[RequestContext, Depends(context_dependency)],
 ) -> QuotaConfig:
     user_info_service = context.factory.create_user_info_service()


### PR DESCRIPTION
The longer-term plan is for squareone to warn if any quota overrides are in place, which will require the ability to retrieve the overrides for any authenticated user. Change the permissions on `GET` of the overrides to any authenticated user, keeping the admin permissions on `PUT` and `DELETE`, and add a test.