### PR TITLE
DM-48786: Add quota information to metrics events

### DIFF
--- a/changelog.d/20250204_164948_rra_DM_48786.md
+++ b/changelog.d/20250204_164948_rra_DM_48786.md
@@ -1,0 +1,4 @@
+### New features
+
+- Include information on total quota and requests within the current window in ``auth_user`` and ``auth_bot`` metrics events if the request was subject to an API quota.
+- Record a ``rate_limit`` metrics event when a request is rejected due to API rate limits.

--- a/docs/user-guide/metrics.rst
+++ b/docs/user-guide/metrics.rst
@@ -19,11 +19,13 @@ auth_bot
     A bot user was successfully authenticated to a service.
     The username is present as the ``username`` tag.
     The service name is present as the ``service`` tag, if known.
+    If the request was affected by an API quota, the quota limit is included in the ``quota`` field (an integer number of requests allowed per 15 minutes) and the number of requests seen in that window is included in the ``quota_used`` field.
 
 auth_user
     A non-bot user was successfully authenticated to a service.
     The username is present as the ``username`` tag.
     The service name is present as the ``service`` tag, if known.
+    If the request was affected by an API quota, the quota limit is included in the ``quota`` field (an integer number of requests allowed per 15 minutes) and the number of requests seen in that window is included in the ``quota_used`` field.
 
 login_attempt
     Gafaelfawr sent a user to the identity provider to authenticate, not including duplicate redirects when the user already has an authentication in progress.
@@ -41,6 +43,13 @@ login_successe
     Gafaelfawr successfully authenticated a user and created a new session.
     The username is present as the ``username`` tag.
     The length of time from initial redirect to successful authentication is present as the ``elapsed`` field, as a float number of seconds.
+
+rate_limit
+    A request was rejected due to API rate limiting.
+    The username is present as the ``username`` tag.
+    The ``is_bot`` field will be set to true if the user is a bot and false otherwise.
+    The service name is present as the ``service`` tag.
+    The applicable API quota (in number of requests per 15 minutes) is present as the ``quota`` field.
 
 State metrics
 =============

--- a/src/gafaelfawr/models/userinfo.py
+++ b/src/gafaelfawr/models/userinfo.py
@@ -138,6 +138,9 @@ class RateLimitStatus:
     limit: int
     """Total number of API requests allowed to this service."""
 
+    used: int
+    """Number of API requests used in the rate limit period."""
+
     remaining: int
     """Number of API requests remaining in the rate limit period."""
 
@@ -156,7 +159,7 @@ class RateLimitStatus:
         return {
             "X-RateLimit-Limit": str(self.limit),
             "X-RateLimit-Remaining": str(self.remaining),
-            "X-RateLimit-Used": str(self.limit - self.remaining),
             "X-RateLimit-Reset": str(int(self.reset.timestamp())),
             "X-RateLimit-Resource": self.resource,
+            "X-RateLimit-Used": str(self.used),
         }

--- a/tests/data/config/github-quota.yaml
+++ b/tests/data/config/github-quota.yaml
@@ -42,3 +42,4 @@ quota:
 metrics:
   enabled: false
   application: "gafaelfawr"
+  mock: true


### PR DESCRIPTION
In the `auth_user` and `auth_bot` metrics events, add the total quota and the number of requests within the current time window if the request is subject to an API quota. If the request is rejected due to exceeding an API quota, log a new `rate_limit` metrics event.