### PR TITLE
DM-48786: Log quota information

### DIFF
--- a/changelog.d/20250205_133812_rra_DM_48786.md
+++ b/changelog.d/20250205_133812_rra_DM_48786.md
@@ -1,0 +1,6 @@
+### Other changes
+
+- Include the name of the service, if known, in authorization log messages.
+- Include API quota information in the log messages for successful authorization if an API quota applies.
+- Log the successful authorization message after any messages about creating new notebook or internal tokens, reflecting the true order of operations.
+- Log requests rejected due to rate limiting.

--- a/docs/user-guide/logging.rst
+++ b/docs/user-guide/logging.rst
@@ -36,11 +36,18 @@ The ``/ingress/auth`` route adds the following attributes:
     The URL being authenticated.
     This is the URL (withough the scheme and host) of the original request that Gafaelfawr is being asked to authenticate via a subrequest.
 
+``quota``
+    Information about the API quota, if there is any.
+    If set, this will be a dictionary with three keys: ``limit``, set to the API quota limit applied to this user and service; ``used``, set to the number of requests in the current quota interval; and ``reset``, set to the time at which the current quota interval ends.
+
 ``required_scope``
     The list of scopes required, taken from the ``scope`` query parameter
 
 ``satisfy``
     The authorization strategy, taken from the ``satisfy`` query parameter.
+
+``service``
+    The name of the underlying service, if known.
 
 The ``/login`` route adds the following attributes:
 


### PR DESCRIPTION
Add quota information to successful authorization log messages, if applicable. Change the order of logging so that creation of internal and notebook tokens is logged before the successful authorization, reflecting the true order of events. Add the service to the logging context.

Add a log message when a request is rejected due to rate limiting.