### PR TITLE
DM-48802: Treat an API quota of 0 as an administrative block

### DIFF
--- a/changelog.d/20250205_161516_rra_DM_48802.md
+++ b/changelog.d/20250205_161516_rra_DM_48802.md
@@ -1,0 +1,3 @@
+### New features
+
+- Treat an API quota of 0 as an administrative block and return a 403 error instead of a 429 error. This allows quotas to be used as an emergency way to block access to a specific service without changing scopes.

--- a/docs/user-guide/quotas.rst
+++ b/docs/user-guide/quotas.rst
@@ -33,6 +33,14 @@ These headers are based on the rate limiting used by GitHub.
 If the user exceeds their quota, subsequent requests will be rejected with an HTTP 429 response code.
 That response will include the same ``X-RateLimit-*`` headers, as well as the HTTP-standard ``Retry-After`` header, which specifies the time at which the user's quota will reset.
 
+Blocking a service
+^^^^^^^^^^^^^^^^^^
+
+Setting the API quota to zero is a special case.
+This is treated as an administrative block of the accesses to the service that it affects, and all requests are rejected with a 403 error (not a 429 error).
+
+This is normally only useful when done in quota overrides (see :ref:`quota-overrides`).
+
 Notebook quotas
 ---------------
 
@@ -41,6 +49,8 @@ The notebook quota also includes a boolean flag, ``spawn``, which controls wheth
 
 Notebook quotas are only calculated by Gafaelfawr, not tracked.
 Normally, they are enforced by Nublado_.
+
+.. _quota-overrides:
 
 Overriding quotas
 =================

--- a/src/gafaelfawr/handlers/api.py
+++ b/src/gafaelfawr/handlers/api.py
@@ -342,7 +342,9 @@ async def delete_quota_overrides(
 ) -> None:
     user_info_service = context.factory.create_user_info_service()
     success = await user_info_service.delete_quota_overrides()
-    if not success:
+    if success:
+        context.logger.info("Deleted quota overrides")
+    else:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=[{"type": "not_found", "msg": "No quota overrides set"}],
@@ -364,6 +366,10 @@ async def put_quota_overrides(
 ) -> QuotaConfig:
     user_info_service = context.factory.create_user_info_service()
     await user_info_service.set_quota_overrides(overrides)
+    context.logger.info(
+        "Updated quota overrides",
+        quota_overrides=overrides.model_dump(mode="json"),
+    )
     return overrides
 
 


### PR DESCRIPTION
If the API quota for the user for the target service is 0, treat that as an administrative block and reject the access with a 403 error instead of a 429 error.