### PR TITLE
DM-48870: Escape the Redis password in URLs

### DIFF
--- a/changelog.d/20250210_131646_rra_DM_48870.md
+++ b/changelog.d/20250210_131646_rra_DM_48870.md
@@ -1,0 +1,3 @@
+### Bug fixes
+
+- Escape the Redis passsword when constructing a URL for the limits library.

--- a/src/gafaelfawr/config.py
+++ b/src/gafaelfawr/config.py
@@ -25,6 +25,7 @@ from datetime import timedelta
 from ipaddress import IPv4Network, IPv6Network
 from pathlib import Path
 from typing import Annotated, Any, Self
+from urllib.parse import urlencode
 
 import yaml
 from pydantic import (
@@ -1095,7 +1096,7 @@ class Config(EnvFirstSettings):
         netloc = f"{host}:{port}" if port else host
         path = self.redis_ephemeral_url.path
         if self.redis_password:
-            password = self.redis_password.get_secret_value()
+            password = urlencode(self.redis_password.get_secret_value())
             return f"async+redis://:{password}@{netloc}{path}"
         else:
             return f"async+redis://{netloc}{path}"


### PR DESCRIPTION
The introduction of rate limiting support added a new Redis interface via the limits library which requires a URL. When constructing that URL with a Redis password, Gafaelfawr was not properly escaping the password. Add URL encoding.