### PR TITLE
DM-48870: Fix escaping of Redis passwords

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ Gafaelfawr does not support direct upgrades from versions older than 10.0.0. Whe
 
 <!-- scriv-insert-here -->
 
+<a id='changelog-12.5.2'></a>
+## 12.5.2 (2025-02-10)
+
+### Bug fixes
+
+- Fix escaping of the Redis password to use the correct library function.
+
 <a id='changelog-12.5.1'></a>
 ## 12.5.1 (2025-02-10)
 

--- a/src/gafaelfawr/config.py
+++ b/src/gafaelfawr/config.py
@@ -25,7 +25,7 @@ from datetime import timedelta
 from ipaddress import IPv4Network, IPv6Network
 from pathlib import Path
 from typing import Annotated, Any, Self
-from urllib.parse import urlencode
+from urllib.parse import quote
 
 import yaml
 from pydantic import (
@@ -1096,7 +1096,7 @@ class Config(EnvFirstSettings):
         netloc = f"{host}:{port}" if port else host
         path = self.redis_ephemeral_url.path
         if self.redis_password:
-            password = urlencode(self.redis_password.get_secret_value())
+            password = quote(self.redis_password.get_secret_value(), safe="")
             return f"async+redis://:{password}@{netloc}{path}"
         else:
             return f"async+redis://{netloc}{path}"

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -136,3 +136,20 @@ def test_config_cilogon_test(monkeypatch: pytest.MonkeyPatch) -> None:
         }
     )
     assert str(config.oidc.redirect_url) == "https://example.com/login"
+
+
+def test_redis_rate_limit_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    ephemeral = "redis://gafaelfawr-redis-ephemeral.gafaelfawr:6370/1"
+    persistent = "redis://gafaelfawr-redis.gafaelfawr:6370/0"
+    monkeypatch.delenv("REDIS_6379_TCP_PORT")
+    monkeypatch.delenv("REDIS_HOST")
+    monkeypatch.setenv("GAFAELFAWR_REDIS_EPHEMERAL_URL", ephemeral)
+    monkeypatch.setenv("GAFAELFAWR_REDIS_PERSISTENT_URL", persistent)
+    monkeypatch.setenv("GAFAELFAWR_REDIS_PASSWORD", "f:b/b@c")
+    config = parse_config(config_path("github"))
+    assert str(config.redis_ephemeral_url) == ephemeral
+    assert str(config.redis_persistent_url) == persistent
+    assert config.redis_rate_limit_url == (
+        "async+redis://:f%3Ab%2Fb%40c@gafaelfawr-redis-ephemeral.gafaelfawr"
+        ":6370/1"
+    )


### PR DESCRIPTION
Correct a serious bug in escaping of Redis passwords introduced in the previous release and add a change log for the 12.5.2 release.