### PR TITLE
DM-49149: Allow rejecting cookie authentication to ingresses

### DIFF
--- a/changelog.d/20250226_150901_rra_DM_49149.md
+++ b/changelog.d/20250226_150901_rra_DM_49149.md
@@ -1,0 +1,3 @@
+### New features
+
+- Add `config.allowCookies` setting for `GafaelfawrIngress` that can be set to false to disallow cookie authentication to that ingress and require use of the `Authorization` header.

--- a/crds/ingress.yaml
+++ b/crds/ingress.yaml
@@ -57,6 +57,11 @@ spec:
               type: object
               description: "Configuration for the ingress to create."
               properties:
+                allowCookies:
+                  type: boolean
+                  description: >-
+                    Whether to allow cookie authentication or only token
+                    authentication via the `Authorization` header.
                 authCacheDuration:
                   type: string
                   description: >-

--- a/docs/user-guide/gafaelfawringress.rst
+++ b/docs/user-guide/gafaelfawringress.rst
@@ -97,10 +97,34 @@ If you want unauthorized users to be redirected to the login page instead, use t
    config:
      loginRedirect: true
 
-This setting should be used for services that are accessed interactively from a web browser.
+This setting should be used for services that are normally accessed interactively from a web browser.
+It cannot be used with the ``config.allowCookies`` parameter set to false (see :ref:`allow-cookies`).
 
 Do not set this to true if the ingress is not running under the same host and port as the Gafaelfawr base URL for the environment.
 It will not work correctly.
+
+.. _allow-cookies:
+
+Disallowing cookie authentication
+=================================
+
+Normally, Gafaelfawr supports either cookie authentication (set for users who log in interactively with a web browser) or token authentication (using the ``Authorization`` header, normally used by programs).
+Both are treated equivalently.
+
+In some cases, it may be desirable to disallow cookie authentication.
+This protects that ingress from many :abbr:`CSRF (Cross-Site Request Forgery)` attacks, for example, since the attacker cannot make use of browser cookies and must somehow obtain a token to put into the ``Authorization`` header.
+
+Enabling this option blocks normal access from a web browser and therefore should only be used for ingresses that are only accessed via programs and other tools that use user tokens.
+
+To disallow cookie authentication, set the ``config.allowCookies`` parameter to false:
+
+.. code-block:: yaml
+
+   config:
+     allowCookies: false
+
+This setting cannot be used in conjunction with ``config.loginRedirect`` (see :ref:`login-redirect`), since the purpose of a login redirect is to set a cookie and return.
+That combination of settings would create a redirect loop that would never allow access.
 
 Changing the challenge type
 ===========================

--- a/src/gafaelfawr/dependencies/auth.py
+++ b/src/gafaelfawr/dependencies/auth.py
@@ -39,6 +39,9 @@ class Authenticate:
 
     Parameters
     ----------
+    allow_cookies
+        Whether to allow cookie authentication. If set to `False`, only
+        authentication via an ``Authorization`` header is allowed.
     require_session
         Require that the credentials come from a cookie, not an
         ``Authorization`` header.
@@ -63,6 +66,7 @@ class Authenticate:
     def __init__(
         self,
         *,
+        allow_cookies: bool = True,
         require_session: bool = False,
         require_bearer_token: bool = False,
         require_scope: str | None = None,
@@ -71,6 +75,7 @@ class Authenticate:
         auth_type: AuthType = AuthType.Bearer,
         ajax_forbidden: bool = False,
     ) -> None:
+        self.allow_cookies = allow_cookies
         self.require_session = require_session
         self.require_bearer_token = require_bearer_token
         self.require_scope = require_scope
@@ -166,7 +171,7 @@ class Authenticate:
         fastapi.HTTPException
             Raised if authentication is not provided or is not valid.
         """
-        if not self.require_bearer_token:
+        if self.allow_cookies and not self.require_bearer_token:
             token = context.state.token
             if token:
                 context.rebind_logger(token_source="cookie")

--- a/src/gafaelfawr/handlers/ingress.py
+++ b/src/gafaelfawr/handlers/ingress.py
@@ -286,6 +286,14 @@ def auth_config(
 
 async def authenticate_with_type(
     *,
+    allow_cookies: Annotated[
+        bool,
+        Query(
+            title="Whether to allow cookies",
+            description="Set to false to disallow cookie authentication",
+            examples=[False],
+        ),
+    ] = True,
     auth_type: Annotated[
         AuthType,
         Query(
@@ -299,7 +307,9 @@ async def authenticate_with_type(
     context: Annotated[RequestContext, Depends(context_dependency)],
 ) -> TokenData:
     """Set authentication challenge based on auth_type parameter."""
-    authenticate = AuthenticateRead(auth_type=auth_type, ajax_forbidden=True)
+    authenticate = AuthenticateRead(
+        allow_cookies=allow_cookies, auth_type=auth_type, ajax_forbidden=True
+    )
     return await authenticate(context=context)
 
 

--- a/src/gafaelfawr/operator/ingress.py
+++ b/src/gafaelfawr/operator/ingress.py
@@ -51,7 +51,7 @@ async def create(
     if not name or not namespace:
         return None
 
-    # Parse the GafaelafwrServiceToken resource.
+    # Parse the GafaelafwrIngress resource.
     try:
         ingress = GafaelfawrIngress.model_validate(body)
     except ValidationError as e:

--- a/tests/data/kubernetes/input/ingress-error-cookies.yaml
+++ b/tests/data/kubernetes/input/ingress-error-cookies.yaml
@@ -1,0 +1,24 @@
+apiVersion: gafaelfawr.lsst.io/v1alpha1
+kind: GafaelfawrIngress
+metadata:
+  name: small-ingress
+  namespace: {namespace}
+config:
+  allowCookies: false
+  baseUrl: "https://foo.example.com"
+  loginRedirect: true
+template:
+  metadata:
+    name: small
+  spec:
+    rules:
+      - host: foo.example.com
+        http:
+          paths:
+            - path: /foo
+              pathType: Prefix
+              backend:
+                service:
+                  name: something
+                  port:
+                    name: http

--- a/tests/data/kubernetes/input/ingresses.yaml
+++ b/tests/data/kubernetes/input/ingresses.yaml
@@ -104,6 +104,7 @@ metadata:
   name: authorization-ingress
   namespace: {namespace}
 config:
+  allowCookies: false
   baseUrl: "https://foo.example.com"
   scopes:
     all: ["read:all"]

--- a/tests/data/kubernetes/output/ingresses.yaml
+++ b/tests/data/kubernetes/output/ingresses.yaml
@@ -135,7 +135,7 @@ metadata:
   annotations:
     nginx.ingress.kubernetes.io/auth-method: GET
     nginx.ingress.kubernetes.io/auth-response-headers: "Authorization,Cookie,X-Auth-Request-Email,X-Auth-Request-Service,X-Auth-Request-Token,X-Auth-Request-User"
-    nginx.ingress.kubernetes.io/auth-url: "http://gafaelfawr.gafaelfawr.svc.cluster.local:8080/ingress/auth?delegate_to=some-service&delegate_scope=read:all&use_authorization=true&scope=read:all"
+    nginx.ingress.kubernetes.io/auth-url: "http://gafaelfawr.gafaelfawr.svc.cluster.local:8080/ingress/auth?allow_cookies=false&delegate_to=some-service&delegate_scope=read:all&use_authorization=true&scope=read:all"
     nginx.ingress.kubernetes.io/configuration-snippet: |
       add_header "X-Foo" "bar";
       {snippet}

--- a/tests/handlers/ingress_test.py
+++ b/tests/handlers/ingress_test.py
@@ -224,6 +224,14 @@ async def test_success(client: AsyncClient, factory: Factory) -> None:
     assert r.status_code == 200
     assert r.headers["X-Auth-Request-User"] == token_data.username
 
+    # Cookie authentication works without Authorization header.
+    await set_session_cookie(client, token_data.token)
+    r = await client.get(
+        "/ingress/auth", params={"scope": "exec:admin", "service": "example"}
+    )
+    assert r.status_code == 200
+    assert r.headers["X-Auth-Request-User"] == token_data.username
+
 
 @pytest.mark.asyncio
 async def test_success_minimal(client: AsyncClient, factory: Factory) -> None:
@@ -1150,3 +1158,27 @@ async def test_only_service(client: AsyncClient, factory: Factory) -> None:
     assert isinstance(authenticate, AuthErrorChallenge)
     assert authenticate.auth_type == AuthType.Bearer
     assert authenticate.error == AuthError.insufficient_scope
+
+
+@pytest.mark.asyncio
+async def test_allow_cookies(client: AsyncClient, factory: Factory) -> None:
+    token_data = await create_session_token(
+        factory, group_names=["admin"], scopes={"read:all"}
+    )
+
+    r = await client.get(
+        "/ingress/auth",
+        params={"scope": "read:all", "allow_cookies": "false"},
+        headers={"Authorization": f"Bearer {token_data.token}"},
+    )
+    assert r.status_code == 200
+    assert r.headers["X-Auth-Request-User"] == token_data.username
+
+    await set_session_cookie(client, token_data.token)
+    r = await client.get(
+        "/ingress/auth",
+        params={"scope": "read:all", "allow_cookies": "false"},
+    )
+    assert r.status_code == 401
+    authenticate = parse_www_authenticate(r.headers["WWW-Authenticate"])
+    assert authenticate.auth_type == AuthType.Bearer

--- a/tests/models/kubernetes_test.py
+++ b/tests/models/kubernetes_test.py
@@ -158,7 +158,7 @@ def test_anonymous() -> None:
             }
         )
 
-    # Boolean fields should produce an error if set to True, but not if False.
+    # Boolean fields should produce an error if set to true, but not if false.
     for field in ("loginRedirect", "replace403"):
         GafaelfawrIngressConfig.model_validate(
             {
@@ -175,3 +175,26 @@ def test_anonymous() -> None:
                     "scopes": {"anonymous": True},
                 }
             )
+
+    # allowCookeis should only produce an error if it's set to false.
+    GafaelfawrIngressConfig.model_validate(
+        {"allowCookies": True, "scopes": {"anonymous": True}}
+    )
+    with pytest.raises(ValidationError):
+        GafaelfawrIngressConfig.model_validate(
+            {"allowCookies": False, "scopes": {"anonymous": True}}
+        )
+
+
+def test_allow_cookies() -> None:
+    GafaelfawrIngressConfig.model_validate(
+        {"allowCookies": False, "scopes": {"all": ["read:all"]}}
+    )
+    with pytest.raises(ValidationError):
+        GafaelfawrIngressConfig.model_validate(
+            {
+                "allowCookies": False,
+                "loginRedirect": True,
+                "scopes": {"all": ["read:all"]},
+            }
+        )


### PR DESCRIPTION
Add a new configuration setting, `config.allowCookies`, for a `GafaelfawrIngress`. If set to fale, require token authentication via an `Authorization` header and ignore any cookies. This protects against some CSRF attacks since the attacker cannot use existing browser cookies to make authenticated cross-site requests.