### PR TITLE
DM-49149: Drop support for the realm config option

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -123,6 +123,8 @@ jobs:
       docs-specific: ${{ steps.filter.outputs.docs-specific }}
 
     steps:
+      - uses: actions/checkout@v4
+
       - uses: dorny/paths-filter@v3
         id: filter
         with:

--- a/alembic/gafaelfawr.yaml
+++ b/alembic/gafaelfawr.yaml
@@ -4,7 +4,6 @@
 # actually work. Do not use the secrets contained in this file for any other
 # purpose; they are completely insecure.
 
-realm: "localhost"
 logLevel: "DEBUG"
 
 # Dummy secrets so that Gafaelfawr will start.

--- a/changelog.d/20250226_180120_rra_DM_49149.md
+++ b/changelog.d/20250226_180120_rra_DM_49149.md
@@ -1,0 +1,3 @@
+### Backwards-incompatible changes
+
+- Drop support for configuring the HTTP authentication realm. This support was not being used in Phalanx. The realm is now always the hostname of the base URL at which Gafaelfawr is installed.

--- a/docs/user-guide/helm.rst
+++ b/docs/user-guide/helm.rst
@@ -122,12 +122,6 @@ The default limits and requests were set based on a fairly lightly loaded deploy
 For a heavily-loaded environment, you may need to increase the resource requests to reflect the expected resource consumption of your instance of Gafaelfawr and allow Kubernetes to do better scheduling.
 You will hopefully not need to increase the limits, which are generous.
 
-Authentication realm
---------------------
-
-The default authentication realm for ``WWW-Authenticate`` headers, which is displayed as part of the HTTP Basic Authentication prompt in browsers, is the hostname of the Phalanx environment in which Gafaelfawr is installed.
-This default can be overridden by setting ``config.realm``.
-
 Base internal URL
 -----------------
 

--- a/docs/user-guide/ingress-overview.rst
+++ b/docs/user-guide/ingress-overview.rst
@@ -19,6 +19,8 @@ If the user is already authenticated but does not have the desired scope, Gafael
 If the user's authentication is syntactically invalid, Gafaelfawr will still return a 403 error, but with additional HTTP headers that will be converted to a 400 error by the NGINX configuration.
 See :ref:`error-handling` for more details.
 
+If a challenge is presented, either 401 or 403, the realm of the challenge will be the hostname of the base public URL at which Gafaelfawr is installed.
+
 If the user is authenticated and authorized, Gafaelfawr will return a 200 response with some additional headers containing information about the user and (optionally) a delegated token.
 See :ref:`auth-headers` for the complete list.
 NGINX will then send the user's HTTP request along to the protected service, including those headers in the request.

--- a/src/gafaelfawr/config.py
+++ b/src/gafaelfawr/config.py
@@ -801,13 +801,6 @@ class Config(EnvFirstSettings):
         ),
     )
 
-    realm: str = Field(
-        ...,
-        title="Authentication realm",
-        description="Realm for HTTP authentication",
-        validation_alias="GAFAELFAWR_REALM",
-    )
-
     redis_ephemeral_url: EnvRedisDsn = Field(
         ...,
         title="Ephemeral Redis DSN",
@@ -1097,6 +1090,13 @@ class Config(EnvFirstSettings):
     def cookie_parameters(self) -> CookieParameters:
         """Parameters to pass to `fastapi.Response.set_cookie`."""
         return CookieParameters(secure=True, httponly=True)
+
+    @property
+    def realm(self) -> str:
+        """Realm to use for HTTP authentication."""
+        if not self.base_url.host:
+            raise RuntimeError("baseUrl does not contain a hostname")
+        return self.base_url.host
 
     @property
     def redis_rate_limit_url(self) -> str:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -48,7 +48,7 @@ every configuration file.
 @pytest.fixture(autouse=True)
 def environment(monkeypatch: pytest.MonkeyPatch) -> None:
     """Set default values of environment variables for testing."""
-    monkeypatch.setenv("GAFAELFAWR_BASE_URL", "https://foo.example.com")
+    monkeypatch.setenv("GAFAELFAWR_BASE_URL", f"https://{TEST_HOSTNAME}")
     monkeypatch.setenv(
         "GAFAELFAWR_BASE_INTERNAL_URL",
         "http://gafaelfawr.gafaelfawr.svc.cluster.local:8080",

--- a/tests/data/config/bad-admin.yaml
+++ b/tests/data/config/bad-admin.yaml
@@ -1,6 +1,5 @@
 # Bad configuration file with invalid admin.
 
-realm: "testing"
 initialAdmins: ["admin", "weird:admin"]
 afterLogoutUrl: "https://example.com/landing"
 groupMapping:

--- a/tests/data/config/bad-groups.yaml
+++ b/tests/data/config/bad-groups.yaml
@@ -1,6 +1,5 @@
 # Configuration with an invalid group mapping.
 
-realm: "example.com"
 initialAdmins: ["admin"]
 afterLogoutUrl: "https://example.com/landing"
 groupMapping:

--- a/tests/data/config/bad-lifetime.yaml
+++ b/tests/data/config/bad-lifetime.yaml
@@ -1,6 +1,5 @@
 # Test too short of a token lifetime.
 
-realm: "example.com"
 slackAlerts: true
 initialAdmins: ["admin"]
 afterLogoutUrl: "https://example.com/landing"

--- a/tests/data/config/bad-log-level.yaml
+++ b/tests/data/config/bad-log-level.yaml
@@ -1,6 +1,5 @@
 # Bad configuration file with invalid logLevel setting.
 
-realm: "testing"
 logLevel: "INVALID"
 initialAdmins: ["admin"]
 afterLogoutUrl: "https://example.com/landing"

--- a/tests/data/config/bad-scope.yaml
+++ b/tests/data/config/bad-scope.yaml
@@ -1,6 +1,5 @@
 # Bad configuration file with invalid scope.
 
-realm: "testing"
 initialAdmins: ["admin"]
 afterLogoutUrl: "https://example.com/landing"
 groupMapping:

--- a/tests/data/config/both-providers.yaml
+++ b/tests/data/config/both-providers.yaml
@@ -1,4 +1,3 @@
-realm: "testing"
 initialAdmins: ["admin"]
 afterLogoutUrl: "https://example.com/landing"
 groupMapping:

--- a/tests/data/config/cilogon-test.yaml
+++ b/tests/data/config/cilogon-test.yaml
@@ -1,6 +1,5 @@
 # Use CILogon test environment as the authentication provider.
 
-realm: "example.com"
 initialAdmins: ["admin"]
 afterLogoutUrl: "https://example.com/landing"
 groupMapping:

--- a/tests/data/config/cilogon.yaml
+++ b/tests/data/config/cilogon.yaml
@@ -1,6 +1,5 @@
 # Use CILogon as the authentication provider.
 
-realm: "example.com"
 initialAdmins: ["admin"]
 afterLogoutUrl: "https://example.com/landing"
 groupMapping:

--- a/tests/data/config/github-oidc-server.yaml
+++ b/tests/data/config/github-oidc-server.yaml
@@ -1,6 +1,5 @@
 # Use GitHub as the provider and configure an OpenID Connect server.
 
-realm: "example.com"
 slackAlerts: true
 afterLogoutUrl: "https://example.com/landing"
 groupMapping:

--- a/tests/data/config/github-quota.yaml
+++ b/tests/data/config/github-quota.yaml
@@ -1,6 +1,5 @@
 # Use GitHub as the provider and configure quota limits.
 
-realm: "example.com"
 afterLogoutUrl: "https://example.com/landing"
 groupMapping:
   "exec:admin": ["admin"]

--- a/tests/data/config/github.yaml
+++ b/tests/data/config/github.yaml
@@ -1,6 +1,5 @@
 # Use GitHub as the authentication provider.
 
-realm: "example.com"
 slackAlerts: true
 initialAdmins: ["admin"]
 proxies:

--- a/tests/data/config/missing-scope.yaml
+++ b/tests/data/config/missing-scope.yaml
@@ -1,6 +1,5 @@
 # Bad configuration file with missing required scope user:token.
 
-realm: "testing"
 afterLogoutUrl: "https://example.com/landing"
 groupMapping:
   "exec:admin": ["admin"]

--- a/tests/data/config/no-provider.yaml
+++ b/tests/data/config/no-provider.yaml
@@ -1,6 +1,5 @@
 # Bad configuration file with no authentication provider section.
 
-realm: "testing"
 afterLogoutUrl: "https://example.com/landing"
 groupMapping:
   "exec:admin": ["admin"]

--- a/tests/data/config/oidc-claims.yaml
+++ b/tests/data/config/oidc-claims.yaml
@@ -1,6 +1,5 @@
 # Use OpenID Connect as the provider and change the username claim.
 
-realm: "example.com"
 afterLogoutUrl: "https://example.com/landing"
 groupMapping:
   "exec:admin": ["admin"]

--- a/tests/data/config/oidc-enrollment.yaml
+++ b/tests/data/config/oidc-enrollment.yaml
@@ -1,6 +1,5 @@
 # Use OpenID Connect as the provider and configure an enrollment URL.
 
-realm: "example.com"
 afterLogoutUrl: "https://example.com/landing"
 groupMapping:
   "exec:admin": ["admin"]

--- a/tests/data/config/oidc-firestore.yaml
+++ b/tests/data/config/oidc-firestore.yaml
@@ -1,6 +1,5 @@
 # Use OpenID Connect with Firestore for UID and GID assignment.
 
-realm: "example.com"
 afterLogoutUrl: "https://example.com/landing"
 groupMapping:
   "exec:admin": ["admin"]

--- a/tests/data/config/oidc-no-attrs.yaml
+++ b/tests/data/config/oidc-no-attrs.yaml
@@ -1,6 +1,5 @@
 # Use OpenID Connect with LDAP but disable optional LDAP attributes.
 
-realm: "example.com"
 logLevel: "DEBUG"
 afterLogoutUrl: "https://example.com/landing"
 groupMapping:

--- a/tests/data/config/oidc-no-memberdn.yaml
+++ b/tests/data/config/oidc-no-memberdn.yaml
@@ -1,6 +1,5 @@
 # Use OpenID Connect with LDAP, but disable groupSearchByDN.
 
-realm: "example.com"
 logLevel: "DEBUG"
 afterLogoutUrl: "https://example.com/landing"
 groupMapping:

--- a/tests/data/config/oidc-subdomain.yaml
+++ b/tests/data/config/oidc-subdomain.yaml
@@ -1,6 +1,5 @@
 # Use OpenID Connect with an issuer that uses a subdomain and URL path.
 
-realm: "example.com"
 afterLogoutUrl: "https://example.com/landing"
 groupMapping:
   "exec:admin": ["admin"]

--- a/tests/data/config/oidc.yaml
+++ b/tests/data/config/oidc.yaml
@@ -1,6 +1,5 @@
 # Use OpenID Connect as the authentication provider.
 
-realm: "example.com"
 logLevel: "DEBUG"
 slackAlerts: true
 initialAdmins: ["admin"]

--- a/tests/data/config/scope-mismatch.yaml
+++ b/tests/data/config/scope-mismatch.yaml
@@ -1,6 +1,5 @@
 # Bad configuration file with assigned scopes not in knownScopes.
 
-realm: "testing"
 initialAdmins: ["admin"]
 afterLogoutUrl: "https://example.com/landing"
 groupMapping:

--- a/tests/data/config/selenium.yaml
+++ b/tests/data/config/selenium.yaml
@@ -1,6 +1,5 @@
 # Configuration for Selenium testing.
 
-realm: "localhost"
 initialAdmins: ["admin"]
 afterLogoutUrl: "https://example.com/landing"
 groupMapping:

--- a/tox.ini
+++ b/tox.ini
@@ -46,7 +46,7 @@ description = Run Alembic against a test database
 commands =
     alembic {posargs}
 setenv =
-    GAFAELFAWR_BASE_URL = https://foo.example.com
+    GAFAELFAWR_BASE_URL = https://example.com
     GAFAELFAWR_BASE_INTERNAL_URL = http://gafaelfawr.gafaelfawr.svc.cluster.local:8080
     GAFAELFAWR_CONFIG_PATH = {toxinidir}/alembic/gafaelfawr.yaml
     GAFAELFAWR_DATABASE_URL = postgresql://gafaelfawr@localhost/gafaelfawr
@@ -91,7 +91,7 @@ commands =
     gafaelfawr {posargs}
 setenv =
     GAFAELFAWR_ALEMBIC_CONFIG_PATH = {toxinidir}/alembic.ini
-    GAFAELFAWR_BASE_URL = https://foo.example.com
+    GAFAELFAWR_BASE_URL = https://example.com
     GAFAELFAWR_BASE_INTERNAL_URL = http://gafaelfawr.gafaelfawr.svc.cluster.local:8080
     GAFAELFAWR_CONFIG_PATH = {toxinidir}/alembic/gafaelfawr.yaml
     GAFAELFAWR_DATABASE_URL = postgresql://gafaelfawr@localhost/gafaelfawr


### PR DESCRIPTION
Stop allowing the HTTP authentication realm to be configured separately, since this was never used in Phalanx. Instead, always set the authentication realm to the hostname of the Gafaelfawr base URL.