### PR TITLE
DM-49149: Check the hosts of ingress rules

### DIFF
--- a/changelog.d/20250303_180647_rra_DM_49149.md
+++ b/changelog.d/20250303_180647_rra_DM_49149.md
@@ -1,0 +1,3 @@
+### Backwards-incompatible changes
+
+- Reject with an error any `GafaelfawrIngress` Kubernetes resource that creates rules for a hostname that does not match the hostname of the base URL or, if `allowSubdomains` is enabled, is a subdomain of it, unless that ingress is anonymous or disables cookie authentication. Such ingresses will never work with web browsers and could create confusing redirect loops.

--- a/docs/user-guide/gafaelfawringress.rst
+++ b/docs/user-guide/gafaelfawringress.rst
@@ -49,6 +49,9 @@ The ``apiVersion`` and ``kind`` keys must always have those values.
 The ``metadata`` section is standard Kubernetes resource metadata.
 You can add labels and annotations here if you wish, but they will have no effect on the generated ``Ingress`` resource.
 
+For the configuration options discussed in the rest of this page, only the relevant portion of the ``GafaelfawrIngress`` resource is shown.
+Add the example configuration to the above full resource to get a valid ``GafaelfawrIngress`` resource.
+
 ``config`` section
 ------------------
 
@@ -80,8 +83,7 @@ Gafaelfawr will always add the ``app.kubernetes.io/managed-by`` label with the v
 Only the above structure is supported, but all standard ``pathType`` options are supported, as is using either ``name`` or ``number`` for the port.
 ``template.spec.tls`` may also be given and, if present, uses the same schema as the normal ``tls`` section of an ``Ingress``.
 
-For the configuration options discussed in the rest of this page, only the relevant portion of the ``GafaelfawrIngress`` resource is shown.
-Add the example configuration to the above full resource to get a valid ``GafaelfawrIngress`` resource.
+Unless the ingress is anonymous or disables cookie authentication, the hosts listed in all ingress rules must either match the host of the configured Gafaelfawr base URL or (only if ``config.allowSubdomains`` is enabled) be a subdomain of that host.
 
 .. _login-redirect:
 

--- a/src/gafaelfawr/exceptions.py
+++ b/src/gafaelfawr/exceptions.py
@@ -46,6 +46,7 @@ __all__ = [
     "InvalidTokenClaimsError",
     "InvalidTokenError",
     "KubernetesError",
+    "KubernetesIngressError",
     "KubernetesObjectError",
     "LDAPError",
     "MissingGIDClaimError",
@@ -415,6 +416,10 @@ class LDAPError(ExternalUserInfoError):
 
 class KubernetesError(kopf.TemporaryError):
     """An error occurred during Kubernetes secret processing."""
+
+
+class KubernetesIngressError(kopf.PermanentError):
+    """The ``GafaelfawrIngress`` configuration is invalid."""
 
 
 class KubernetesObjectError(kopf.PermanentError):

--- a/tests/data/kubernetes/input/ingress-error-host.yaml
+++ b/tests/data/kubernetes/input/ingress-error-host.yaml
@@ -5,13 +5,13 @@ metadata:
   namespace: {namespace}
 config:
   scopes:
-    all: ["invalid:scope"]
+    all: ["read:all"]
 template:
   metadata:
     name: small
   spec:
     rules:
-      - host: example.com
+      - host: foo.example.com
         http:
           paths:
             - path: /foo

--- a/tests/data/kubernetes/input/ingresses.yaml
+++ b/tests/data/kubernetes/input/ingresses.yaml
@@ -13,7 +13,7 @@ template:
     name: small
   spec:
     rules:
-      - host: foo.example.com
+      - host: example.com
         http:
           paths:
             - path: /foo
@@ -49,7 +49,7 @@ template:
       another.annotation.example.com: bar
   spec:
     rules:
-      - host: foo.example.com
+      - host: example.com
         http:
           paths:
             - path: /bar
@@ -61,7 +61,7 @@ template:
                     number: 80
     tls:
       - hosts:
-          - foo.example.com
+          - example.com
         secretName: tls-secret
 ---
 apiVersion: gafaelfawr.lsst.io/v1alpha1
@@ -87,7 +87,7 @@ template:
     name: internal
   spec:
     rules:
-      - host: foo.example.com
+      - host: example.com
         http:
           paths:
             - path: /baz
@@ -149,7 +149,7 @@ template:
       some.annotation: foo
   spec:
     rules:
-      - host: foo.example.com
+      - host: example.org
         http:
           paths:
             - path: /foo/baz
@@ -175,7 +175,7 @@ template:
     name: username
   spec:
     rules:
-      - host: foo.example.com
+      - host: example.com
         http:
           paths:
             - path: /username
@@ -203,7 +203,7 @@ template:
     name: service
   spec:
     rules:
-      - host: foo.example.com
+      - host: example.com
         http:
           paths:
             - path: /service
@@ -230,7 +230,7 @@ template:
     name: service-any
   spec:
     rules:
-      - host: foo.example.com
+      - host: example.com
         http:
           paths:
             - path: /service/any

--- a/tests/data/kubernetes/output/ingresses.yaml
+++ b/tests/data/kubernetes/output/ingresses.yaml
@@ -26,7 +26,7 @@ metadata:
 spec:
   ingressClassName: nginx
   rules:
-    - host: foo.example.com
+    - host: example.com
       http:
         paths:
           - path: /foo
@@ -71,7 +71,7 @@ metadata:
 spec:
   ingressClassName: nginx
   rules:
-    - host: foo.example.com
+    - host: example.com
       http:
         paths:
           - path: /bar
@@ -83,7 +83,7 @@ spec:
                   number: 80
   tls:
     - hosts:
-        - foo.example.com
+        - example.com
       secretName: tls-secret
 status: {any}
 ---
@@ -115,7 +115,7 @@ metadata:
 spec:
   ingressClassName: nginx
   rules:
-    - host: foo.example.com
+    - host: example.com
       http:
         paths:
           - path: /baz
@@ -195,7 +195,7 @@ metadata:
 spec:
   ingressClassName: nginx
   rules:
-    - host: foo.example.com
+    - host: example.org
       http:
         paths:
           - path: /foo/baz
@@ -235,7 +235,7 @@ metadata:
 spec:
   ingressClassName: nginx
   rules:
-    - host: foo.example.com
+    - host: example.com
       http:
         paths:
           - path: /username
@@ -275,7 +275,7 @@ metadata:
 spec:
   ingressClassName: nginx
   rules:
-    - host: foo.example.com
+    - host: example.com
       http:
         paths:
           - path: /service
@@ -315,7 +315,7 @@ metadata:
 spec:
   ingressClassName: nginx
   rules:
-    - host: foo.example.com
+    - host: example.com
       http:
         paths:
           - path: /service/any


### PR DESCRIPTION
Unless the `GafaelfawrIngress` is anonymous or disables cookie authentication, reject hosts in ingress rules that do not match the host of the Gafaelfawr base URL or, if `config.allowSubdomains` is set, is a subdomain of that host. Such ingresses will never work with browser cookies and may produce confusing redirect loops.