### PR TITLE
DM-49149: Rework obtaining the base hostname internally

### DIFF
--- a/src/gafaelfawr/auth.py
+++ b/src/gafaelfawr/auth.py
@@ -165,7 +165,7 @@ def generate_challenge(
     context.logger.warning(exc.message, error=str(exc))
     challenge = AuthErrorChallenge(
         auth_type=auth_type,
-        realm=context.config.realm,
+        realm=context.config.base_hostname,
         error=AuthError[exc.error],
         error_description=str(exc),
         scope=" ".join(sorted(scopes)) if scopes else None,
@@ -242,7 +242,7 @@ def generate_unauthorized_challenge(
         context.logger.warning(exc.message, error=str(exc))
         challenge: AuthChallenge = AuthErrorChallenge(
             auth_type=auth_type,
-            realm=context.config.realm,
+            realm=context.config.base_hostname,
             error=AuthError[exc.error],
             error_description=str(exc),
         )
@@ -250,7 +250,7 @@ def generate_unauthorized_challenge(
         msg = str(exc)
     else:
         challenge = AuthChallenge(
-            auth_type=auth_type, realm=context.config.realm
+            auth_type=auth_type, realm=context.config.base_hostname
         )
         error_type = "no_authorization"
         msg = "Authentication required"

--- a/src/gafaelfawr/config.py
+++ b/src/gafaelfawr/config.py
@@ -1100,21 +1100,21 @@ class Config(EnvFirstSettings):
         return bool(self.github or (self.ldap and self.ldap.add_user_group))
 
     @property
+    def base_hostname(self) -> str:
+        """Realm to use for HTTP authentication."""
+        # HttpUrl guarantees that the host is not None, but this is not
+        # reflected in the type system so we have to check for mypy purposes.
+        if not self.base_url.host:
+            raise RuntimeError("baseUrl does not contain a hostname")
+        return self.base_url.host
+
+    @property
     def cookie_parameters(self) -> CookieParameters:
         """Parameters to pass to `fastapi.Response.set_cookie`."""
         parameters = CookieParameters(secure=True, httponly=True)
         if self.allow_subdomains:
-            if not self.base_url.host:
-                raise RuntimeError("baseUrl does not contain a hostname")
-            parameters["domain"] = self.base_url.host
+            parameters["domain"] = self.base_hostname
         return parameters
-
-    @property
-    def realm(self) -> str:
-        """Realm to use for HTTP authentication."""
-        if not self.base_url.host:
-            raise RuntimeError("baseUrl does not contain a hostname")
-        return self.base_url.host
 
     @property
     def redis_rate_limit_url(self) -> str:

--- a/src/gafaelfawr/dependencies/return_url.py
+++ b/src/gafaelfawr/dependencies/return_url.py
@@ -43,7 +43,7 @@ def _check_url(url: str, param: str, context: RequestContext) -> ParseResult:
     InvalidReturnURLError
         Raised if the return URL was invalid.
     """
-    domain = context.config.base_url.host
+    domain = context.config.base_hostname
     parsed_url = urlparse(url)
     if context.config.allow_subdomains:
         hostname = parsed_url.hostname
@@ -51,7 +51,7 @@ def _check_url(url: str, param: str, context: RequestContext) -> ParseResult:
     else:
         okay = parsed_url.hostname == domain
     if not okay:
-        msg = f"URL is not at {context.config.base_url.host}"
+        msg = f"URL is not at {context.config.base_hostname}"
         context.logger.warning("Bad return URL", error=msg)
         raise InvalidReturnURLError(msg, param)
 

--- a/src/gafaelfawr/services/kubernetes.py
+++ b/src/gafaelfawr/services/kubernetes.py
@@ -267,9 +267,7 @@ class KubernetesIngressService:
         if not ingress.config.allow_cookies:
             return
         subdomain = self._config.allow_subdomains
-        base_hostname = self._config.base_url.host
-        if not base_hostname:
-            raise RuntimeError("config.baseUrl has no hostname")
+        base_hostname = self._config.base_hostname
         for rule in ingress.template.spec.rules:
             if rule.host == base_hostname:
                 continue

--- a/tests/handlers/ingress_test.py
+++ b/tests/handlers/ingress_test.py
@@ -95,7 +95,7 @@ async def test_invalid_auth(
     authenticate = parse_www_authenticate(r.headers["WWW-Authenticate"])
     assert isinstance(authenticate, AuthErrorChallenge)
     assert authenticate.auth_type == AuthType.Bearer
-    assert authenticate.realm == config.realm
+    assert authenticate.realm == config.base_hostname
     assert authenticate.error == AuthError.invalid_request
 
     r = await client.get(
@@ -109,7 +109,7 @@ async def test_invalid_auth(
     authenticate = parse_www_authenticate(r.headers["WWW-Authenticate"])
     assert isinstance(authenticate, AuthErrorChallenge)
     assert authenticate.auth_type == AuthType.Bearer
-    assert authenticate.realm == config.realm
+    assert authenticate.realm == config.base_hostname
     assert authenticate.error == AuthError.invalid_request
 
     r = await client.get(
@@ -122,7 +122,7 @@ async def test_invalid_auth(
     authenticate = parse_www_authenticate(r.headers["WWW-Authenticate"])
     assert isinstance(authenticate, AuthErrorChallenge)
     assert authenticate.auth_type == AuthType.Bearer
-    assert authenticate.realm == config.realm
+    assert authenticate.realm == config.base_hostname
     assert authenticate.error == AuthError.invalid_token
 
     # Create a nonexistent token.
@@ -137,7 +137,7 @@ async def test_invalid_auth(
     authenticate = parse_www_authenticate(r.headers["WWW-Authenticate"])
     assert isinstance(authenticate, AuthErrorChallenge)
     assert authenticate.auth_type == AuthType.Bearer
-    assert authenticate.realm == config.realm
+    assert authenticate.realm == config.base_hostname
     assert authenticate.error == AuthError.invalid_token
 
     # None of these errors should have resulted in Slack alerts.
@@ -163,7 +163,7 @@ async def test_access_denied(
     authenticate = parse_www_authenticate(r.headers["WWW-Authenticate"])
     assert isinstance(authenticate, AuthErrorChallenge)
     assert authenticate.auth_type == AuthType.Bearer
-    assert authenticate.realm == config.realm
+    assert authenticate.realm == config.base_hostname
     assert authenticate.error == AuthError.insufficient_scope
     assert authenticate.scope == "exec:admin"
     assert "Token missing required scope" in r.text
@@ -191,7 +191,7 @@ async def test_satisfy_all(
     authenticate = parse_www_authenticate(r.headers["WWW-Authenticate"])
     assert isinstance(authenticate, AuthErrorChallenge)
     assert authenticate.auth_type == AuthType.Bearer
-    assert authenticate.realm == config.realm
+    assert authenticate.realm == config.base_hostname
     assert authenticate.error == AuthError.insufficient_scope
     assert authenticate.scope == "exec:admin exec:test"
     assert "Token missing required scope" in r.text
@@ -585,7 +585,7 @@ async def test_basic(
     authenticate = parse_www_authenticate(r.headers["WWW-Authenticate"])
     assert isinstance(authenticate, AuthErrorChallenge)
     assert authenticate.auth_type == AuthType.Bearer
-    assert authenticate.realm == config.realm
+    assert authenticate.realm == config.base_hostname
     assert authenticate.error == AuthError.invalid_request
 
 
@@ -605,7 +605,7 @@ async def test_basic_failure(
     authenticate = parse_www_authenticate(r.headers["WWW-Authenticate"])
     assert isinstance(authenticate, AuthErrorChallenge)
     assert authenticate.auth_type == AuthType.Bearer
-    assert authenticate.realm == config.realm
+    assert authenticate.realm == config.base_hostname
     assert authenticate.error == AuthError.invalid_request
 
     for basic in (b"foo:foo", b"x-oauth-basic:foo", b"foo:x-oauth-basic"):
@@ -633,7 +633,7 @@ async def test_ajax_unauthorized(client: AsyncClient, config: Config) -> None:
     authenticate = parse_www_authenticate(r.headers["WWW-Authenticate"])
     assert not isinstance(authenticate, AuthErrorChallenge)
     assert authenticate.auth_type == AuthType.Bearer
-    assert authenticate.realm == config.realm
+    assert authenticate.realm == config.base_hostname
 
 
 @pytest.mark.asyncio

--- a/tests/handlers/oidc_test.py
+++ b/tests/handlers/oidc_test.py
@@ -720,7 +720,7 @@ async def test_invalid(
     authenticate = parse_www_authenticate(r.headers["WWW-Authenticate"])
     assert isinstance(authenticate, AuthErrorChallenge)
     assert authenticate.auth_type == AuthType.Bearer
-    assert authenticate.realm == config.realm
+    assert authenticate.realm == config.base_hostname
     assert authenticate.error == AuthError.invalid_request
     assert authenticate.error_description == "Unknown Authorization type token"
 
@@ -746,7 +746,7 @@ async def test_invalid(
     authenticate = parse_www_authenticate(r.headers["WWW-Authenticate"])
     assert isinstance(authenticate, AuthErrorChallenge)
     assert authenticate.auth_type == AuthType.Bearer
-    assert authenticate.realm == config.realm
+    assert authenticate.realm == config.base_hostname
     assert authenticate.error == AuthError.invalid_request
     assert authenticate.error_description == "Malformed Authorization header"
 
@@ -760,7 +760,7 @@ async def test_invalid(
     authenticate = parse_www_authenticate(r.headers["WWW-Authenticate"])
     assert isinstance(authenticate, AuthErrorChallenge)
     assert authenticate.auth_type == AuthType.Bearer
-    assert authenticate.realm == config.realm
+    assert authenticate.realm == config.base_hostname
     assert authenticate.error == AuthError.invalid_token
     assert authenticate.error_description
 
@@ -788,7 +788,7 @@ async def test_invalid(
     authenticate = parse_www_authenticate(r.headers["WWW-Authenticate"])
     assert isinstance(authenticate, AuthErrorChallenge)
     assert authenticate.auth_type == AuthType.Bearer
-    assert authenticate.realm == config.realm
+    assert authenticate.realm == config.base_hostname
     assert authenticate.error == AuthError.invalid_token
     msg = "Token of type session not allowed"
     assert authenticate.error_description == msg

--- a/tests/support/headers.py
+++ b/tests/support/headers.py
@@ -42,7 +42,7 @@ def assert_unauthorized_is_correct(
     challenge = parse_www_authenticate(r.headers["WWW-Authenticate"])
     assert not isinstance(challenge, AuthErrorChallenge)
     assert challenge.auth_type == auth_type
-    assert challenge.realm == config.realm
+    assert challenge.realm == config.base_hostname
 
 
 def parse_www_authenticate(header: str) -> AuthChallenge:


### PR DESCRIPTION
Rather than having a separate config property for the domain, make a config property for `base_hostname` that does the check required by mypy because `HttpUrl` doesn't work well with typing. Use that instead of accessing the `host` attribute of `config.base_url` directly.