### PR TITLE
DM-49149: Ignore baseUrl in GafaelfawrIngress

### DIFF
--- a/changelog.d/20250304_151908_rra_DM_49149.md
+++ b/changelog.d/20250304_151908_rra_DM_49149.md
@@ -1,0 +1,3 @@
+### Backwards-incompatible changes
+
+- Ignore the `config.baseUrl` setting in a `GafaelfawrIngress` entirely. The URL to which the user is redirected when not logged in is now determined only by the global Gafaelfawr `baseUrl` configuration option (set automatically by the Phalanx chart).

--- a/src/gafaelfawr/models/kubernetes.py
+++ b/src/gafaelfawr/models/kubernetes.py
@@ -310,7 +310,7 @@ class GafaelfawrIngressConfig(BaseModel):
     """Auth type of challenge for 401 responses."""
 
     base_url: str | None = None
-    """The base URL for user-facing Gafaelfawr URLs in Ingress annotations."""
+    """Obsolete field, now ignored."""
 
     delegate: GafaelfawrIngressDelegate | None = None
     """Details of the requested delegated token, if any."""
@@ -322,7 +322,7 @@ class GafaelfawrIngressConfig(BaseModel):
     """If non-empty, restrict to tokens issued by one of the services."""
 
     replace_403: bool = False
-    """Whether to generate a custom error response for 403 errors."""
+    """Obsolete field, now ignored."""
 
     scopes: (
         GafaelfawrIngressScopesAll
@@ -383,11 +383,6 @@ class GafaelfawrIngressConfig(BaseModel):
 
     def to_auth_query(self) -> list[tuple[str, str]]:
         """Generate the query corresponding to this ingress configuration.
-
-        Parameters
-        ----------
-        base_url
-            Base URL for the internal Gafaelfawr service.
 
         Returns
         -------

--- a/src/gafaelfawr/services/kubernetes.py
+++ b/src/gafaelfawr/services/kubernetes.py
@@ -113,7 +113,6 @@ class KubernetesIngressService:
             + "/ingress/auth?"
             + urlencode(ingress.config.to_auth_query(), safe=":/")
         )
-        base_url = ingress.config.base_url or str(self._config.base_url)
         snippet_key = "nginx.ingress.kubernetes.io/configuration-snippet"
         snippet = ingress.template.metadata.annotations.get(snippet_key, "")
         if snippet and not snippet.endswith("\n"):
@@ -135,7 +134,7 @@ class KubernetesIngressService:
                 f"200 202 401 {ingress.config.auth_cache_duration}"
             )
         if ingress.config.login_redirect:
-            url = base_url.rstrip("/") + "/login"
+            url = str(self._config.base_url).rstrip("/") + "/login"
             annotations["nginx.ingress.kubernetes.io/auth-signin"] = url
 
         return annotations

--- a/tests/data/kubernetes/input/ingress-error-cookies.yaml
+++ b/tests/data/kubernetes/input/ingress-error-cookies.yaml
@@ -5,7 +5,6 @@ metadata:
   namespace: {namespace}
 config:
   allowCookies: false
-  baseUrl: "https://foo.example.com"
   loginRedirect: true
 template:
   metadata:

--- a/tests/data/kubernetes/input/ingresses.yaml
+++ b/tests/data/kubernetes/input/ingresses.yaml
@@ -4,7 +4,6 @@ metadata:
   name: small-ingress
   namespace: {namespace}
 config:
-  baseUrl: "https://foo.example.com"
   scopes:
     all: ["read:all"]
   service: tap
@@ -30,7 +29,6 @@ metadata:
   name: notebook-ingress
   namespace: {namespace}
 config:
-  baseUrl: "https://foo.example.com"
   scopes:
     any: ["read:all"]
   authCacheDuration: 5m
@@ -70,7 +68,6 @@ metadata:
   name: internal-ingress
   namespace: {namespace}
 config:
-  baseUrl: "https://foo.example.com"
   authType: basic
   scopes:
     all:
@@ -105,7 +102,6 @@ metadata:
   namespace: {namespace}
 config:
   allowCookies: false
-  baseUrl: "https://foo.example.com"
   scopes:
     all: ["read:all"]
   delegate:
@@ -139,7 +135,6 @@ metadata:
   name: anonymous-ingress
   namespace: {namespace}
 config:
-  baseUrl: "https://foo.example.com"
   scopes:
     anonymous: true
 template:
@@ -166,7 +161,6 @@ metadata:
   name: username-ingress
   namespace: {namespace}
 config:
-  baseUrl: "https://foo.example.com"
   scopes:
     all: ["read:all"]
   username: some-user

--- a/tests/data/kubernetes/output/ingresses.yaml
+++ b/tests/data/kubernetes/output/ingresses.yaml
@@ -49,7 +49,7 @@ metadata:
     nginx.ingress.kubernetes.io/auth-cache-duration: "200 202 401 5m"
     nginx.ingress.kubernetes.io/auth-method: "GET"
     nginx.ingress.kubernetes.io/auth-response-headers: "Authorization,Cookie,X-Auth-Request-Email,X-Auth-Request-Service,X-Auth-Request-Token,X-Auth-Request-User"
-    nginx.ingress.kubernetes.io/auth-signin: "https://foo.example.com/login"
+    nginx.ingress.kubernetes.io/auth-signin: "https://example.com/login"
     nginx.ingress.kubernetes.io/auth-url: "http://gafaelfawr.gafaelfawr.svc.cluster.local:8080/ingress/auth?notebook=true&minimum_lifetime=600&scope=read:all&satisfy=any"
     nginx.ingress.kubernetes.io/configuration-snippet: |
       {snippet}

--- a/tests/models/kubernetes_test.py
+++ b/tests/models/kubernetes_test.py
@@ -15,39 +15,28 @@ from gafaelfawr.models.kubernetes import (
 def test_scopes() -> None:
     """Test handling of ``all`` and ``any`` in configured scopes."""
     config = GafaelfawrIngressConfig.model_validate(
-        {
-            "baseUrl": "https://example.com/",
-            "scopes": {"any": ["read:all", "read:some"]},
-        }
+        {"scopes": {"any": ["read:all", "read:some"]}}
     )
     assert config.scopes.satisfy == Satisfy.ANY
     assert config.scopes.scopes == ["read:all", "read:some"]
 
     config = GafaelfawrIngressConfig.model_validate(
-        {
-            "baseUrl": "https://example.com/",
-            "scopes": {"all": ["read:all", "read:some"]},
-        }
+        {"scopes": {"all": ["read:all", "read:some"]}}
     )
     assert config.scopes.satisfy == Satisfy.ALL
     assert config.scopes.scopes == ["read:all", "read:some"]
 
-    config = GafaelfawrIngressConfig.model_validate(
-        {"baseUrl": "https://example.com/", "scopes": {"all": []}}
-    )
+    config = GafaelfawrIngressConfig.model_validate({"scopes": {"all": []}})
     assert config.scopes.satisfy == Satisfy.ALL
     assert config.scopes.scopes == []
 
-    config = GafaelfawrIngressConfig.model_validate(
-        {"baseUrl": "https://example.com/", "scopes": {"any": []}}
-    )
+    config = GafaelfawrIngressConfig.model_validate({"scopes": {"any": []}})
     assert config.scopes.satisfy == Satisfy.ANY
     assert config.scopes.scopes == []
 
     with pytest.raises(ValidationError):
         config = GafaelfawrIngressConfig.model_validate(
             {
-                "baseUrl": "https://example.com/",
                 "scopes": {
                     "all": ["read:all"],
                     "any": ["read:some", "read:image"],
@@ -56,16 +45,11 @@ def test_scopes() -> None:
         )
 
     with pytest.raises(ValidationError):
-        GafaelfawrIngressConfig.model_validate(
-            {"baseUrl": "https://example.com/", "scopes": {}}
-        )
+        GafaelfawrIngressConfig.model_validate({"scopes": {}})
 
     with pytest.raises(ValidationError):
         GafaelfawrIngressConfig.model_validate(
-            {
-                "baseUrl": "https://example.com/",
-                "scopes": {"all": [], "any": []},
-            }
+            {"scopes": {"all": [], "any": []}}
         )
 
 
@@ -74,7 +58,6 @@ def test_delegate() -> None:
     with pytest.raises(ValidationError) as excinfo:
         GafaelfawrIngressConfig.model_validate(
             {
-                "baseUrl": "https://example.com/",
                 "scopes": {"all": ["read:all"]},
                 "delegate": {
                     "notebook": {},
@@ -87,11 +70,7 @@ def test_delegate() -> None:
 
     with pytest.raises(ValidationError) as excinfo:
         GafaelfawrIngressConfig.model_validate(
-            {
-                "baseUrl": "https://example.com/",
-                "scopes": {"all": ["read:all"]},
-                "delegate": {},
-            }
+            {"scopes": {"all": ["read:all"]}, "delegate": {}}
         )
     assert "one of notebook and internal must be given" in str(excinfo.value)
 
@@ -109,7 +88,6 @@ def test_service_port() -> None:
 def test_basic_login_redirect() -> None:
     GafaelfawrIngressConfig.model_validate(
         {
-            "baseUrl": "https://example.com/",
             "authType": "bearer",
             "loginRedirect": True,
             "scopes": {"all": ["read:all"]},
@@ -118,7 +96,6 @@ def test_basic_login_redirect() -> None:
     with pytest.raises(ValidationError):
         GafaelfawrIngressConfig.model_validate(
             {
-                "baseUrl": "https://example.com/",
                 "authType": "basic",
                 "loginRedirect": True,
                 "scopes": {"all": ["read:all"]},
@@ -128,52 +105,28 @@ def test_basic_login_redirect() -> None:
 
 def test_anonymous() -> None:
     GafaelfawrIngressConfig.model_validate(
-        {
-            "baseUrl": "https://example.com/",
-            "authType": "basic",
-            "scopes": {"all": ["read:all"]},
-        }
+        {"authType": "basic", "scopes": {"all": ["read:all"]}}
     )
     with pytest.raises(ValidationError):
         GafaelfawrIngressConfig.model_validate(
-            {
-                "baseUrl": "https://example.com/",
-                "authType": "basic",
-                "scopes": {"anonymous": True},
-            }
+            {"authType": "basic", "scopes": {"anonymous": True}}
         )
     GafaelfawrIngressConfig.model_validate(
-        {
-            "baseUrl": "https://example.com/",
-            "delegate": {"notebook": {}},
-            "scopes": {"all": ["read:all"]},
-        }
+        {"delegate": {"notebook": {}}, "scopes": {"all": ["read:all"]}}
     )
     with pytest.raises(ValidationError):
         GafaelfawrIngressConfig.model_validate(
-            {
-                "baseUrl": "https://example.com/",
-                "delegate": {"notebook": {}},
-                "scopes": {"anonymous": True},
-            }
+            {"delegate": {"notebook": {}}, "scopes": {"anonymous": True}}
         )
 
     # Boolean fields should produce an error if set to true, but not if false.
     for field in ("loginRedirect", "replace403"):
         GafaelfawrIngressConfig.model_validate(
-            {
-                "baseUrl": "https://example.com/",
-                field: False,
-                "scopes": {"anonymous": True},
-            }
+            {field: False, "scopes": {"anonymous": True}}
         )
         with pytest.raises(ValidationError):
             GafaelfawrIngressConfig.model_validate(
-                {
-                    "baseUrl": "https://example.com/",
-                    field: True,
-                    "scopes": {"anonymous": True},
-                }
+                {field: True, "scopes": {"anonymous": True}}
             )
 
     # allowCookeis should only produce an error if it's set to false.

--- a/tests/operator/ingress_test.py
+++ b/tests/operator/ingress_test.py
@@ -118,7 +118,7 @@ async def test_replace(
         ] = expected_url
         expected["metadata"]["annotations"][
             "nginx.ingress.kubernetes.io/auth-signin"
-        ] = "https://foo.example.com/login"
+        ] = "https://example.com/login"
         await assert_resources_match(api_client, [expected])
 
 


### PR DESCRIPTION
Remove all remaining support for `config.baseUrl` in `GafaelfawrIngress` and ignore that setting if it is present. The one URL derived from that value (the login URL to which the user is redirected optionally if logged out) is now set only from the global Gafaelfawr configuration setting.