### PR TITLE
DM-49315: Add support for per-user domain authorization

### DIFF
--- a/changelog.d/20250304_184003_rra_DM_49315.md
+++ b/changelog.d/20250304_184003_rra_DM_49315.md
@@ -1,0 +1,3 @@
+### New features
+
+- Add new `config.userDomain` setting to `GafaelfawrIngress` that requires the authenticated username be the last component of the hostname of the requested URL. This is intended for use with ingresses that use per-user subdomains, such as [Jupyter labs with origin isolation](https://z2jh.jupyter.org/en/latest/administrator/security.html#jupyterhub-subdomains).

--- a/changelog.d/20250305_154010_rra_DM_49315.md
+++ b/changelog.d/20250305_154010_rra_DM_49315.md
@@ -1,0 +1,3 @@
+### Other changes
+
+- Include the full URL of the original request in the ingress authorization logs, not just the path and query portion.

--- a/crds/ingress.yaml
+++ b/crds/ingress.yaml
@@ -194,6 +194,12 @@ spec:
                     used for metrics reporting. When delegating internal
                     tokens, this must match config.delegate.internal.service.
                     This attribute will be required in the future.
+                userDomain:
+                  type: boolean
+                  description: >-
+                    Expect the last component of the request URL hostname to
+                    be a username and only allow access from matching
+                    usernames. Requires that the ingress host be a wildcard.
                 username:
                   type: string
                   description: >-

--- a/docs/user-guide/gafaelfawringress.rst
+++ b/docs/user-guide/gafaelfawringress.rst
@@ -301,6 +301,9 @@ So, for example, if the internal token from a listed service doesn't have a requ
 Per-user ingresses
 ==================
 
+List of allowed users
+---------------------
+
 Access to an ingress may be restricted to a specific user as follows:
 
 .. code-block:: yaml
@@ -310,6 +313,28 @@ Access to an ingress may be restricted to a specific user as follows:
 
 Any user other than the one with the username ``<username>`` will then receive a 403 error.
 The scope requirements must still be met to allow access.
+
+Per-user hostnames
+------------------
+
+In some cases, you may wish Gafaelfawr to enforce that the hostname in the URL of the service that Gafaelfawr is protecting contain the username of the authenticated user.
+One common example of this use case is `per-user subdomains for Jupyter labs <https://z2jh.jupyter.org/en/latest/administrator/security.html#jupyterhub-subdomains>`__.
+In this case, every user gets their own hostname for their lab, which ensures that JavaScript origins are kept isolated, and only the matching user should be allowed to access that hostname.
+
+Gafaelfawr supports this in a ``GafaelfawrIngress`` with the following configuration:
+
+.. code-block:: yaml
+
+   config:
+     userDomain: true
+
+With this setting, Gafaelfawr requires that the first component of the hostname portion of the request URL match the authenticated username, and that the hostname as a whole be a subdomain of the domain of Gafaelfawr's base URL.
+For example, assuming a base URL of ``example.org``, user ``someone`` would be allowed access to URLs with hostnames ``someone.example.org`` or ``someone.nb.example.org`` but not ``other.example.org`` or ``someone.example.com``.
+
+With only this setting, this is the only restriction applied, but this setting stacks with all of Gafaelfawr's other access control settings, including ``scope``, ``username``, and ``service``.
+
+This option is normally used in conjunction with Gafaelfawr's subdomain support.
+See :ref:`helm-subdomains`.
 
 .. _anonymous:
 

--- a/docs/user-guide/helm.rst
+++ b/docs/user-guide/helm.rst
@@ -23,6 +23,8 @@ For example, there should be one top-level ``config:`` key and all parameters th
 You should also read the `Gafaelfawr application documentation <https://phalanx.lsst.io/applications/gafaelfawr/index.html>`__.
 In particular, when bootstrapping a new Phalanx environment, see the `Gafaelfawr bootstrapping instructions <https://phalanx.lsst.io/applications/gafaelfawr/bootstrap.html>`__.
 
+.. _helm-subdomains:
+
 Subdomains
 ==========
 

--- a/docs/user-guide/logging.rst
+++ b/docs/user-guide/logging.rst
@@ -34,7 +34,7 @@ The ``/ingress/auth`` route adds the following attributes:
 
 ``auth_uri``
     The URL being authenticated.
-    This is the URL (withough the scheme and host) of the original request that Gafaelfawr is being asked to authenticate via a subrequest.
+    This is the URL of the original request that Gafaelfawr is being asked to authenticate via a subrequest.
 
 ``quota``
     Information about the API quota, if there is any.

--- a/src/gafaelfawr/models/kubernetes.py
+++ b/src/gafaelfawr/models/kubernetes.py
@@ -334,6 +334,13 @@ class GafaelfawrIngressConfig(BaseModel):
     service: str | None = None
     """Name of the service this ingress is for."""
 
+    user_domain: bool = False
+    """Restrict access to the user matching the last hostname component.
+
+    Used for per-user hostnames, such as the per-user domain names for
+    JupyterLab pods.
+    """
+
     username: str | None = None
     """Restrict access to the given user."""
 
@@ -363,6 +370,7 @@ class GafaelfawrIngressConfig(BaseModel):
                 "login_redirect",
                 "only_services",
                 "replace_403",
+                "user_domain",
                 "username",
             )
             for snake_name in fields:
@@ -403,6 +411,8 @@ class GafaelfawrIngressConfig(BaseModel):
             query.append(("satisfy", self.scopes.satisfy.value))
         if self.service:
             query.append(("service", self.service))
+        if self.user_domain:
+            query.append(("user_domain", "true"))
         if self.username:
             query.append(("username", self.username))
         return query

--- a/tests/data/config/github-subdomain.yaml
+++ b/tests/data/config/github-subdomain.yaml
@@ -14,6 +14,7 @@ knownScopes:
   "admin:token": "token administration"
   "exec:admin": "admin description"
   "read:all": "can read everything"
+  "read:some": "can read some things"
   "user:token": "Can create and modify user tokens"
 github:
   clientId: "some-github-client-id"

--- a/tests/data/kubernetes/input/ingresses.yaml
+++ b/tests/data/kubernetes/input/ingresses.yaml
@@ -118,7 +118,7 @@ template:
         add_header "X-Foo" "bar";
   spec:
     rules:
-      - host: foo.example.com
+      - host: example.org
         http:
           paths:
             - path: /foo/bar
@@ -234,3 +234,33 @@ template:
                   name: something
                   port:
                     name: http
+---
+apiVersion: gafaelfawr.lsst.io/v1alpha1
+kind: GafaelfawrIngress
+metadata:
+  name: subdomain-ingress
+  namespace: {namespace}
+config:
+  loginRedirect: true
+  scopes:
+    all: ["read:all"]
+  userDomain: true
+template:
+  metadata:
+    name: subdomain
+  spec:
+    rules:
+      - host: "*.nb.example.com"
+        http:
+          paths:
+            - path: "/"
+              pathType: "Prefix"
+              backend:
+                service:
+                  name: "something"
+                  port:
+                    number: 80
+    tls:
+      - hosts:
+          - "*.nb.example.com"
+        secretName: "tls-secret"

--- a/tests/data/kubernetes/output/ingresses.yaml
+++ b/tests/data/kubernetes/output/ingresses.yaml
@@ -156,7 +156,7 @@ metadata:
 spec:
   ingressClassName: nginx
   rules:
-    - host: foo.example.com
+    - host: example.org
       http:
         paths:
           - path: /foo/bar
@@ -325,4 +325,49 @@ spec:
                 name: something
                 port:
                   name: http
+status: {any}
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: subdomain
+  namespace: {namespace}
+  annotations:
+    nginx.ingress.kubernetes.io/auth-method: "GET"
+    nginx.ingress.kubernetes.io/auth-response-headers: "Authorization,Cookie,X-Auth-Request-Email,X-Auth-Request-Service,X-Auth-Request-Token,X-Auth-Request-User"
+    nginx.ingress.kubernetes.io/auth-signin: "https://example.com/login"
+    nginx.ingress.kubernetes.io/auth-url: "http://gafaelfawr.gafaelfawr.svc.cluster.local:8080/ingress/auth?scope=read:all&user_domain=true"
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      {snippet}
+  creationTimestamp: {any}
+  generation: {any}
+  labels:
+    app.kubernetes.io/managed-by: Gafaelfawr
+  managedFields: {any}
+  ownerReferences:
+    - apiVersion: gafaelfawr.lsst.io/v1alpha1
+      blockOwnerDeletion: true
+      controller: true
+      kind: GafaelfawrIngress
+      name: subdomain-ingress
+      uid: {any}
+  resourceVersion: {any}
+  uid: {any}
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: "*.nb.example.com"
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: something
+                port:
+                  number: 80
+  tls:
+    - hosts:
+        - "*.nb.example.com"
+      secretName: tls-secret
 status: {any}

--- a/tests/operator/ingress_test.py
+++ b/tests/operator/ingress_test.py
@@ -12,6 +12,7 @@ from kubernetes_asyncio.client import ApiClient, ApiException
 from gafaelfawr.config import Config
 from gafaelfawr.models.kubernetes import KubernetesResourceStatus, StatusReason
 
+from ..support.config import reconfigure
 from ..support.kubernetes import (
     assert_custom_resource_status_is,
     assert_resources_match,
@@ -27,8 +28,9 @@ from ..support.kubernetes import (
 @requires_kubernetes
 @pytest.mark.asyncio
 async def test_create(
-    config: Config, empty_database: None, api_client: ApiClient, namespace: str
+    empty_database: None, api_client: ApiClient, namespace: str
 ) -> None:
+    await reconfigure("github-subdomain")
     ingresses = operator_test_input("ingresses", namespace)
     await create_custom_resources(api_client, ingresses)
 


### PR DESCRIPTION
Add a new setting to `GafaelfawrIngress` named `config.userDomain` that, if set to true, requires that the last component of the request URL match the authenticated username. This is intended for use with per-user subdomains, such as Jupyter labs with JavaScript origin isolation. In this case, as an additional sanity check, also require that the hostname in the request be a subdomain of Gafaelfawr's base domain.