### PR TITLE
DM-49329: Fix return URL checking

### DIFF
--- a/src/gafaelfawr/dependencies/return_url.py
+++ b/src/gafaelfawr/dependencies/return_url.py
@@ -45,11 +45,13 @@ def _check_url(url: str, param: str, context: RequestContext) -> ParseResult:
     """
     domain = context.config.base_hostname
     parsed_url = urlparse(url)
-    if context.config.allow_subdomains:
+    if parsed_url.hostname and parsed_url.hostname == domain:
+        okay = True
+    elif context.config.allow_subdomains:
         hostname = parsed_url.hostname
-        okay = hostname and hostname.endswith(f".{domain}")
+        okay = bool(hostname and hostname.endswith(f".{domain}"))
     else:
-        okay = parsed_url.hostname == domain
+        okay = False
     if not okay:
         msg = f"URL is not at {context.config.base_hostname}"
         context.logger.warning("Bad return URL", error=msg)

--- a/tests/handlers/logout_test.py
+++ b/tests/handlers/logout_test.py
@@ -127,6 +127,11 @@ async def test_logout_subdomain(client: AsyncClient) -> None:
     assert r.status_code == 307
     assert r.headers["Location"] == "https://foo.example.com/"
 
+    # Check with a hostname matching the parent domain as well.
+    r = await client.get("/logout", params={"rd": "https://example.com/"})
+    assert r.status_code == 307
+    assert r.headers["Location"] == "https://example.com/"
+
 
 @pytest.mark.asyncio
 async def test_logout_github(


### PR DESCRIPTION
If subdomain support was enabled and the return URL exactly matched the parent domain, the URL was incorrectly rejected. Fix the logic of the check.