### PR TITLE
DM-49329: Always authorize OPTIONS requests

### DIFF
--- a/changelog.d/20250305_171727_rra_DM_49315.md
+++ b/changelog.d/20250305_171727_rra_DM_49315.md
@@ -1,0 +1,3 @@
+### Backwards-incompatible changes
+
+- Always authorize `OPTIONS` requests rather than expecting them to contain authentication credentials. This is required for proper CORS handling since the CORS pre-flight specification says that credentials are not included. Gafaelfawr previously effectively blocked all `OPTIONS` requests by replying with 302 or 401.

--- a/src/gafaelfawr/services/kubernetes.py
+++ b/src/gafaelfawr/services/kubernetes.py
@@ -128,7 +128,7 @@ class KubernetesIngressService:
         }
         if ingress.config.auth_cache_duration:
             annotations["nginx.ingress.kubernetes.io/auth-cache-key"] = (
-                "$http_cookie$http_authorization"
+                "$request_method$http_cookie$http_authorization"
             )
             annotations["nginx.ingress.kubernetes.io/auth-cache-duration"] = (
                 f"200 202 401 {ingress.config.auth_cache_duration}"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -74,7 +74,10 @@ async def client(app: FastAPI) -> AsyncIterator[AsyncClient]:
     """Return an ``httpx.AsyncClient`` configured to talk to the test app."""
     async with AsyncClient(
         base_url=f"https://{TEST_HOSTNAME}",
-        headers={"X-Original-URL": "https://foo.example.com/bar"},
+        headers={
+            "X-Original-Method": "GET",
+            "X-Original-URL": "https://foo.example.com/bar",
+        },
         transport=ASGITransport(app=app),
     ) as client:
         yield client

--- a/tests/data/kubernetes/output/ingresses.yaml
+++ b/tests/data/kubernetes/output/ingresses.yaml
@@ -45,7 +45,7 @@ metadata:
   namespace: {namespace}
   annotations:
     another.annotation.example.com: bar
-    nginx.ingress.kubernetes.io/auth-cache-key: "$http_cookie$http_authorization"
+    nginx.ingress.kubernetes.io/auth-cache-key: "$request_method$http_cookie$http_authorization"
     nginx.ingress.kubernetes.io/auth-cache-duration: "200 202 401 5m"
     nginx.ingress.kubernetes.io/auth-method: "GET"
     nginx.ingress.kubernetes.io/auth-response-headers: "Authorization,Cookie,X-Auth-Request-Email,X-Auth-Request-Service,X-Auth-Request-Token,X-Auth-Request-User"

--- a/tests/selenium/tokens_test.py
+++ b/tests/selenium/tokens_test.py
@@ -57,6 +57,7 @@ async def test_token_info(
             params={"scope": "exec:test", "notebook": "true"},
             headers={
                 "Cookie": f"{COOKIE_NAME}={cookie}",
+                "X-Original-Method": "GET",
                 "X-Original-URL": "https://foo.example.com/bar",
             },
         )
@@ -67,6 +68,7 @@ async def test_token_info(
             params={"scope": "exec:test", "delegate_to": "service"},
             headers={
                 "Cookie": f"{COOKIE_NAME}={cookie}",
+                "X-Original-Method": "GET",
                 "X-Original-URL": "https://foo.example.com/bar",
             },
         )


### PR DESCRIPTION
Deploying Nublado with user subdomains revealed that Gafaelfawr had always been blocking `OPTIONS` requests to authenticated ingresses. It did not special-case the `OPTIONS` method and expected the request to contain normal authentication credentials, but the CORS pre-flight specification says that the `OPTIONS` request must not include credentials.

Special-case `OPTIONS` requests (using the `X-Original-Method` header set by ingress-nginx to detect what method the request used) and treat them as anonymous requests, always authorizing them.