### PR TITLE
DM-49329: Refactor hostname checking code

### DIFF
--- a/src/gafaelfawr/config.py
+++ b/src/gafaelfawr/config.py
@@ -1152,3 +1152,29 @@ class Config(EnvFirstSettings):
             set if the group was not recognized.
         """
         return self._group_to_scopes.get(group) or frozenset()
+
+    def is_hostname_allowed(self, hostname: str | None) -> bool:
+        """Check whether a hostname is within the Gafaelfawr domain.
+
+        Numerous places in Gafaelfawr want to allow only hostnames that fall
+        within the base domain of Gafaelfawr. If subdomains are disabled, the
+        hostname must match the base hostname exactly. If subdomains are
+        allowed, the hostname must be a subdomain of that base domain.
+
+        Parameters
+        ----------
+        hostname
+            Hostname to check. `None` is allowed for typing convenience but
+            is always rejected.
+
+        Returns
+        -------
+        bool
+            Whether that hostname is allowed for this Gafaelfawr instance.
+        """
+        if not hostname:
+            return False
+        domain = self.base_hostname
+        if hostname == domain:
+            return True
+        return self.allow_subdomains and hostname.endswith(f".{domain}")

--- a/src/gafaelfawr/dependencies/return_url.py
+++ b/src/gafaelfawr/dependencies/return_url.py
@@ -43,16 +43,8 @@ def _check_url(url: str, param: str, context: RequestContext) -> ParseResult:
     InvalidReturnURLError
         Raised if the return URL was invalid.
     """
-    domain = context.config.base_hostname
     parsed_url = urlparse(url)
-    if parsed_url.hostname and parsed_url.hostname == domain:
-        okay = True
-    elif context.config.allow_subdomains:
-        hostname = parsed_url.hostname
-        okay = bool(hostname and hostname.endswith(f".{domain}"))
-    else:
-        okay = False
-    if not okay:
+    if not context.config.is_hostname_allowed(parsed_url.hostname):
         msg = f"URL is not at {context.config.base_hostname}"
         context.logger.warning("Bad return URL", error=msg)
         raise InvalidReturnURLError(msg, param)

--- a/src/gafaelfawr/handlers/ingress.py
+++ b/src/gafaelfawr/handlers/ingress.py
@@ -684,15 +684,13 @@ def user_allowed(
     if auth_config.user_domain:
         try:
             hostname = urlparse(auth_config.auth_uri).hostname
-            if hostname:
-                hostname, domain = hostname.split(".", 1)
-            else:
+            if not hostname:
                 return False
+            if not context.config.is_hostname_allowed(hostname):
+                return False
+            hostname, _ = hostname.split(".", 1)
             if hostname != token_data.username:
                 return False
-            if domain != context.config.base_hostname:
-                if not domain.endswith(f".{context.config.base_hostname}"):
-                    return False
         except Exception:
             return False
     return True

--- a/src/gafaelfawr/services/kubernetes.py
+++ b/src/gafaelfawr/services/kubernetes.py
@@ -265,15 +265,10 @@ class KubernetesIngressService:
             return
         if not ingress.config.allow_cookies:
             return
-        subdomain = self._config.allow_subdomains
-        base_hostname = self._config.base_hostname
         for rule in ingress.template.spec.rules:
-            if rule.host == base_hostname:
-                continue
-            if subdomain and rule.host.endswith(f".{base_hostname}"):
-                continue
-            msg = f"Host {rule.host} not allowed with cookie authentication"
-            raise KubernetesIngressError(msg)
+            if not self._config.is_hostname_allowed(rule.host):
+                msg = f"Host {rule.host} must disable cookie authentication"
+                raise KubernetesIngressError(msg)
 
     def _validate_scopes(self, scopes: GafaelfawrIngressScopesBase) -> None:
         """Check that the requested scopes are valid.

--- a/tests/operator/ingress_test.py
+++ b/tests/operator/ingress_test.py
@@ -161,7 +161,7 @@ async def test_errors_host(
     ingress = operator_test_input("ingress-error-host", namespace)[0]
     name = ingress["template"]["metadata"]["name"]
     status = KubernetesResourceStatus(
-        message="Host foo.example.com not allowed with cookie authentication",
+        message="Host foo.example.com must disable cookie authentication",
         generation=ANY,
         reason=StatusReason.Failed,
         timestamp=ANY,


### PR DESCRIPTION
We had three separate places where hostnames were checked to see if they were either the base hostname or (if subdomain support is enabled) a subdomain. Move this code to be a method on the `Config` object so that there's only one copy of it.