### PR TITLE
DM-49347: Block cross-origin OPTIONS requests

### DIFF
--- a/changelog.d/20250306_123621_rra_DM_49347.md
+++ b/changelog.d/20250306_123621_rra_DM_49347.md
@@ -1,0 +1,3 @@
+### Backwards-incompatible changes
+
+- Block all cross-origin `OPTIONS` requests unless the origin matches the hostname of the Gafaelfar base URL or, if subdomain support is enabled, is some subdomain of the hostname of the base URL.

--- a/docs/user-guide/cors.rst
+++ b/docs/user-guide/cors.rst
@@ -1,0 +1,34 @@
+#####################
+Cross-origin requests
+#####################
+
+A cross-origin HTTP request is one initiated by a web site at a different origin (meaning the tuple of scheme, hostname, and port) than the target of the request.
+Cross-origin requests are restricted according to `complex rules <https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS>`__ in the HTTP security model.
+
+Gafaelfawr does not protect against cross-origin `simple requests <https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS#simple_requests>`__ (requests that do not require CORS preflight).
+This is up to the protected web application.
+However, note that :ref:`disabling cookie authentication <allow-cookies>` is generally effective at forcing a CORS preflight check, since inclusion of an ``Authorization`` header requires preflight checking.
+
+CORS preflight policy
+=====================
+
+Gafaelfawr implements the following authorization policy for CORS preflight requests to authenticated ingresses:
+
+- An ``OPTIONS`` request containing an ``Origin`` header matching the hostname of the base URL of the Science Platform is allowed through to the protected site to respond to as it wishes.
+  This is true even if the protected site is served from a hostname that does not match the base URL.
+
+- If :ref:`subdomain support is enabled <helm-subdomains>`, an ``OPTIONS`` request containing an ``Origin`` header for any hostname that is a subdomain of the base URL is also allowed through to the protected site to respond to as it wishes.
+
+- All other ``OPTIONS`` requests are rejected.
+
+The intended effect of this policy is to allow protected applications to control their CORS policy for requests from other components of the same instance of the Science Platform, but to reject all cross-origin requests from outside the Science Platform, regardless of the opinions of the protected application.
+
+Anonymous ingresses pass all requests through to the underlying application, including ``OPTIONS`` requests.
+
+Other ``OPTIONS`` requests
+==========================
+
+All ``OPTIONS`` requests to authenticated ingresses that do not contain an ``Origin`` header are rejected with a 404 error.
+
+This means that sites protected by Gafaelfawr do not support the non-CORS use of ``OPTIONS`` to determine supported HTTP methods.
+This use of ``OPTIONS`` is not widely supported or used.

--- a/docs/user-guide/index.rst
+++ b/docs/user-guide/index.rst
@@ -21,6 +21,7 @@ Also see the `Phalanx Gafaelfawr application documentation <https://phalanx.lsst
 
    ingress-overview
    gafaelfawringress
+   cors
    quotas
    service-tokens
    openid-connect

--- a/docs/user-guide/ingress-overview.rst
+++ b/docs/user-guide/ingress-overview.rst
@@ -31,6 +31,8 @@ NGINX will then send the user's HTTP request along to the protected service, inc
    If they return a 403 error, the client will receive a response with the 403 HTTP status, but the body of the response will be lost, as will any ``WWW-Authenticate`` header.
    This is an unfortunate side effect of the limitations of the NGINX ``auth_request`` module.
 
+All authenticated ingresses are also subject to a :doc:`cross-origin request policy <cors>`.
+
 .. _header-filtering:
 
 Header filtering

--- a/src/gafaelfawr/exceptions.py
+++ b/src/gafaelfawr/exceptions.py
@@ -20,6 +20,7 @@ from safir.slack.blockkit import (
 
 __all__ = [
     "DatabaseSchemaError",
+    "DisallowedCORSRequestError",
     "DuplicateAdminError",
     "DuplicateTokenNameError",
     "ExternalUserInfoError",
@@ -62,6 +63,7 @@ __all__ = [
     "OIDCError",
     "OIDCNotEnrolledError",
     "OIDCWebError",
+    "OptionsNotSupportedError",
     "PermissionDeniedError",
     "ProviderError",
     "ProviderWebError",
@@ -290,6 +292,34 @@ class OAuthBearerError(OAuthError):
     """The status code to use for this HTTP error."""
 
 
+class DisallowedCORSRequestError(OAuthBearerError):
+    """The ``OPTIONS`` CORS preflight check was rejected."""
+
+    error = "cors_preflight_rejected"
+    message = "Cross-origin request not allowed"
+    status_code = status.HTTP_403_FORBIDDEN
+
+
+class OptionsNotSupportedError(OAuthBearerError):
+    """The ``OPTIONS`` request is not a valid CORS preflight request."""
+
+    error = "options_not_supported"
+    message = "Non-CORS OPTIONS requests not supported"
+    status_code = status.HTTP_404_NOT_FOUND
+
+
+class InsufficientScopeError(OAuthBearerError):
+    """The provided token does not have the right authorization scope.
+
+    This corresponds to the ``insufficient_scope`` error in RFC 6750: "The
+    request requires higher privileges than provided by the access token."
+    """
+
+    error = "insufficient_scope"
+    message = "Permission denied"
+    status_code = status.HTTP_403_FORBIDDEN
+
+
 class InvalidRequestError(OAuthBearerError):
     """The provided Authorization header could not be parsed.
 
@@ -314,18 +344,6 @@ class InvalidTokenError(OAuthBearerError, ValueError):
     error = "invalid_token"
     message = "Invalid token"
     status_code = status.HTTP_401_UNAUTHORIZED
-
-
-class InsufficientScopeError(OAuthBearerError):
-    """The provided token does not have the right authorization scope.
-
-    This corresponds to the ``insufficient_scope`` error in RFC 6750: "The
-    request requires higher privileges than provided by the access token."
-    """
-
-    error = "insufficient_scope"
-    message = "Permission denied"
-    status_code = status.HTTP_403_FORBIDDEN
 
 
 class DatabaseSchemaError(SlackException):


### PR DESCRIPTION
Block all cross-origin `OPTIONS` requests unless the origin matches the hostname of the Gafaelfar base URL or, if subdomain support is enabled, is some subdomain of the hostname of the base URL. Reject `OPTIONS` requests without `Origin` headers with a 404 error.