### PR TITLE
DM-50042: Remove unnecessary apt-get update in Docker build

### DIFF
--- a/scripts/install-dependency-packages.sh
+++ b/scripts/install-dependency-packages.sh
@@ -18,9 +18,6 @@ set -x
 # Tell apt-get we're never going to be able to give manual feedback.
 export DEBIAN_FRONTEND=noninteractive
 
-# Update the package listing, so we know what packages exist.
-apt-get update
-
 # Install various dependencies that may be required to install mobu.
 #
 # build-essential: sometimes needed to build Python modules


### PR DESCRIPTION
Now that the Docker build is using a cache for apt metadata, it's no longer necessary to call `apt-get update` again when installing packages needed for building Python dependencies.