### PR TITLE
DM-50591: Fix docker uv cache path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,7 +47,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 
 # Install the Gafaelfawr Python application.
 ADD . /app
-RUN --mount=type=cache,target=/.root/.cache/uv \
+RUN --mount=type=cache,target=/root/.cache/uv \
     uv pip install --no-deps --compile-bytecode .
 
 FROM base-image AS runtime-image


### PR DESCRIPTION
@jonathansick actually [caught this](https://github.com/lsst-sqre/noteburst/pull/116#discussion_r2067200903) when I blindly copied and pasted it into noteburst.

I don't think this will actually change anything about the behavior of the build, because I don't _think_ the `uv pip install --no-deps --compile-bytecode .` command reuses anything from the `uv sync` command, because of the `--no-deps` arg to the `pip install` command. But those paths are probably supposed to match in spirit.