### PR TITLE
DM-51521: Change Ruff checker pre-commit id

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,7 +16,7 @@ repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.12.0
     hooks:
-      - id: ruff
+      - id: ruff-check
         args: [--fix, --exit-non-zero-on-fix]
       - id: ruff-format
 


### PR DESCRIPTION
Ruff now uses `ruff-check` as the id for the linter, rather than a bare `ruff`. Adjust `.pre-commit-config.yaml` accordingly.