### PR TITLE
DM-51679: Fix group regex to allow all valid usernames

### DIFF
--- a/changelog.d/20250701_151955_rra_DM_51679.md
+++ b/changelog.d/20250701_151955_rra_DM_51679.md
@@ -1,0 +1,3 @@
+### Bug fixes
+
+- Fix the group name validation regex so that it accepts all valid usernames, specifically including usernames that start with numbers. Otherwise, if `addUserGroup` is enabled, a user with a username starting with digits would trigger internal validation errors. If that user's token was the most recent created, this could in turn cause health check failures.

--- a/src/gafaelfawr/constants.py
+++ b/src/gafaelfawr/constants.py
@@ -199,7 +199,7 @@ BOT_USERNAME_REGEX = "^bot-[a-z0-9](?:[a-z0-9]|-[a-z0-9])*$"
 CURSOR_REGEX = "^p?[0-9]+_[0-9]+$"
 """Regex matching a valid cursor."""
 
-GROUPNAME_REGEX = "^[a-zA-Z][a-zA-Z0-9._-]*$"
+GROUPNAME_REGEX = "^[a-zA-Z0-9][a-zA-Z0-9._-]*[a-zA-Z][a-zA-Z0-9._-]*$"
 """Regex matching all valid group names."""
 
 SCOPE_REGEX = "^[a-zA-Z0-9:._-]+$"


### PR DESCRIPTION
Fix the group name validation regex so that it accepts all valid usernames, specifically including usernames that start with numbers. Otherwise, if `addUserGroup` is enabled, a user with a username starting with digits would trigger internal validation errors. If that user's token was the most recent created, this could in turn cause health check failures.