### PR TITLE
DM-51679: Randomly choose a user for health checks

### DIFF
--- a/changelog.d/20250701_170347_rra_DM_51679.md
+++ b/changelog.d/20250701_170347_rra_DM_51679.md
@@ -1,0 +1,3 @@
+### Bug fixes
+
+- Rather than asking the database for one token for health checks, ask the database for 100 session tokens and randomly choose one of them. This, coupled with Kubernetes failure tolerance for the liveness check, should hopefully prevent an isolated problem with a single user from causing `/health` to reliably fail and bring down the service.


### PR DESCRIPTION
Rather than asking the database for one token for health checks, ask the database for 100 session tokens and randomly choose one of them. This, coupled with Kubernetes failure tolerance for the liveness check, should hopefully prevent an isolated problem with a single user from causing `/health` to reliably fail and bring down the service.