### PR TITLE
DM-51810: Base API rate limits on requests per minute

### DIFF
--- a/changelog.d/20250714_154548_rra_rate_limit.md
+++ b/changelog.d/20250714_154548_rra_rate_limit.md
@@ -1,0 +1,3 @@
+### Backwards-incompatible changes
+
+- API rate limits now specify the number of requests per minute instead of per 15 minutes. All configured rate limits should be updated accordingly. The rate limiting algorithm is otherwise unchanged.

--- a/docs/user-guide/helm.rst
+++ b/docs/user-guide/helm.rst
@@ -580,7 +580,7 @@ Default quota
 
 The default quota setting controls the quotas that all users get when there are no more specific rules (discussed below).
 
-The ``api`` key should contain a mapping of service names to number of requests per 15 minutes.
+The ``api`` key should contain a mapping of service names to number of requests per minute.
 The keys for API quotas are names of services.
 This is the same name the service should use in the ``config.service`` key of a ``GafaelfawrIngress`` resource (see :ref:`ingress`).
 If a service name has no corresponding quota setting, access to that service will be unrestricted.
@@ -596,12 +596,12 @@ For example:
      quota:
        default:
          api:
-           datalinker: 1000
+           datalinker: 100
          notebook:
            cpu: 2.0
            memory: 4.0
 
-This sets a quota of 1000 requests per 15 minutes for the ``datalinker`` service, no quotas for any other API service, and a default limit of 2.0 CPU equivalents and 4.0 GiB of memory for notebooks.
+This sets a quota of 100 requests per minute for the ``datalinker`` service, no quotas for any other API service, and a default limit of 2.0 CPU equivalents and 4.0 GiB of memory for notebooks.
 
 The default quota for all API services not listed is unlimited.
 To set a default quota of 0, explicitly list the API service with a quota of 0.
@@ -620,12 +620,12 @@ For example:
        groups:
          g_developers:
            api:
-             datalinker: 500
+             datalinker: 50
            notebook:
              cpu: 0.0
              memory: 4.0
 
-If this were combined with the above default quota, members of the ``g_developers`` group would receive a total of 1500 requests per 15 minutes for datalinker, and a total of 8.0 GiB of memory for notebooks.
+If this were combined with the above default quota, members of the ``g_developers`` group would receive a total of 150 requests per minute for datalinker, and a total of 8.0 GiB of memory for notebooks.
 The CPU quota for notebooks would be unchanged.
 
 Members of specific groups cannot be granted unrestricted access to an API service since a missing key for a service instead means that this group contributes no additional quota for that service.
@@ -642,13 +642,13 @@ Consider the following addditional configuration:
        groups:
          g_limited:
            api:
-             tap: 1000
+             tap: 100
            notebook:
              cpu: 0.0
              memory: 0.0
              spawn: false
 
-If combined with the previous default configuration, members of the ``g_limited`` group will have a quota of 1000 requests per 15 minutes to the tap service.
+If combined with the previous default configuration, members of the ``g_limited`` group will have a quota of 100 requests per minute to the tap service.
 Users who are not a member of that group will continue to have unlimited access to the tap service.
 Also, members of the ``g_limited`` group will not be allowed to spawn new notebooks, because their ``spawn`` flag is set to false instead of the default of true.
 Note that ``cpu`` and ``memory`` are also set because they are required fields, but are set to 0.0 so they don't add anything to the quota.

--- a/docs/user-guide/metrics.rst
+++ b/docs/user-guide/metrics.rst
@@ -19,13 +19,13 @@ auth_bot
     A bot user was successfully authenticated to a service.
     The username is present as the ``username`` tag.
     The service name is present as the ``service`` tag, if known.
-    If the request was affected by an API quota, the quota limit is included in the ``quota`` field (an integer number of requests allowed per 15 minutes) and the number of requests seen in that window is included in the ``quota_used`` field.
+    If the request was affected by an API quota, the quota limit is included in the ``quota`` field (an integer number of requests allowed per minute) and the number of requests seen in that window is included in the ``quota_used`` field.
 
 auth_user
     A non-bot user was successfully authenticated to a service.
     The username is present as the ``username`` tag.
     The service name is present as the ``service`` tag, if known.
-    If the request was affected by an API quota, the quota limit is included in the ``quota`` field (an integer number of requests allowed per 15 minutes) and the number of requests seen in that window is included in the ``quota_used`` field.
+    If the request was affected by an API quota, the quota limit is included in the ``quota`` field (an integer number of requests allowed per minute) and the number of requests seen in that window is included in the ``quota_used`` field.
 
 login_attempt
     Gafaelfawr sent a user to the identity provider to authenticate, not including duplicate redirects when the user already has an authentication in progress.
@@ -49,7 +49,7 @@ rate_limit
     The username is present as the ``username`` tag.
     The ``is_bot`` field will be set to true if the user is a bot and false otherwise.
     The service name is present as the ``service`` tag.
-    The applicable API quota (in number of requests per 15 minutes) is present as the ``quota`` field.
+    The applicable API quota (in number of requests per minute) is present as the ``quota`` field.
 
 State metrics
 =============

--- a/docs/user-guide/quotas.rst
+++ b/docs/user-guide/quotas.rst
@@ -15,8 +15,8 @@ The notebook quotas are only calculated in Gafaelfawr and must be queried and en
 API quotas
 ----------
 
-An API quota limits a user to a number of requests in each 15 minute interval.
-After 15 minutes, the user's usage resets and they get their full quota again.
+An API quota limits a user to a number of requests in each one minute interval.
+After one minute, the user's usage resets and they get their full quota again.
 
 Every named service has a separate API quota.
 This quota may not exist, in which case requests to that service are not rate limited.

--- a/src/gafaelfawr/handlers/ingress.py
+++ b/src/gafaelfawr/handlers/ingress.py
@@ -686,7 +686,7 @@ async def check_rate_limit(
 
     # Check the usage against Redis.
     key = ("api", user_info.username)
-    limit = RateLimitItemPerMinute(quota, 15)
+    limit = RateLimitItemPerMinute(quota, 1)
     try:
         allowed = await context.rate_limiter.hit(limit, *key)
         stats = await context.rate_limiter.get_window_stats(limit, *key)

--- a/src/gafaelfawr/models/quota.py
+++ b/src/gafaelfawr/models/quota.py
@@ -38,7 +38,7 @@ class Quota(BaseModel):
         {},
         title="API quotas",
         description=(
-            "Mapping of service names to allowed requests per 15 minutes."
+            "Mapping of service names to allowed requests per minute."
         ),
         examples=[
             {

--- a/tests/handlers/ingress_logging_test.py
+++ b/tests/handlers/ingress_logging_test.py
@@ -109,7 +109,7 @@ async def test_success(
     assert seen_log == [expected_log]
     reset_time = datetime.fromisoformat(seen_log[0]["quota"]["reset"])
     reset_time = reset_time.replace(tzinfo=UTC)
-    expected_reset = datetime.now(tz=UTC) + timedelta(minutes=15)
+    expected_reset = datetime.now(tz=UTC) + timedelta(minutes=1)
     assert expected_reset - timedelta(seconds=1) < reset_time < expected_reset
 
     # Check the logged metrics events.

--- a/tests/handlers/ingress_rate_test.py
+++ b/tests/handlers/ingress_rate_test.py
@@ -25,7 +25,7 @@ async def test_rate_limit(client: AsyncClient, factory: Factory) -> None:
     )
     headers = {"Authorization": f"bearer {token_data.token}"}
     now = datetime.now(tz=UTC)
-    expected = now + timedelta(minutes=15) - timedelta(seconds=1)
+    expected = now + timedelta(minutes=1) - timedelta(seconds=1)
 
     # Two requests should be allowed, one from the default quota and a second
     # from the additional quota from the foo group.


### PR DESCRIPTION
Practical experience with setting rate limits has found that it is sufficiently undesirable to block a user for up to 15 minutes that we don't set rate limits for fear of creating that outcome. Given that and the easier mental math involved in using a more regular interval, reduce the API rate limit interval to one minute and interpret API rate limits as requests per minute. One implication is that the rate limit (apart from total administrative blocks) cannot be less than one request per minute.