### PR TITLE
DM-51818: Add TAP quotas

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -181,7 +181,7 @@ jobs:
           || (github.event_name == 'workflow_dispatch')
           || (github.event_name == 'pull_request'
               && startsWith(github.head_ref, 'tickets/')
-              && steps.filter.outputs.docs-specific == 'true')
+              && needs.changes.outputs.docs-specific == 'true')
 
   linkcheck:
     runs-on: ubuntu-latest

--- a/changelog.d/20250715_153805_rra_DM_51818.md
+++ b/changelog.d/20250715_153805_rra_DM_51818.md
@@ -1,0 +1,3 @@
+### New features
+
+- Add TAP quotas. Currently, this allows specifying the allowable number of concurrent TAP queries for each of a list of TAP services, with the same override and group-specific addition behavior as API quotas. These quotas are not applied by Gafaelfawr; they are intended for use by TAP services that retrieve quota information from Gafaelfawr and apply it internally.

--- a/docs/user-guide/helm.rst
+++ b/docs/user-guide/helm.rst
@@ -574,11 +574,16 @@ Quotas
 
 Gafaelfawr supports calculating user quotas based on group membership and providing quota information through its API.
 API quotas are also enforced directly by Gafaelfawr.
+See :doc:`quotas` for more information.
+
+Setting quotas is optional.
+Omit this setting if you don't want to set user quotas.
 
 Default quota
 -------------
 
 The default quota setting controls the quotas that all users get when there are no more specific rules (discussed below).
+All of these keys are optional and may be omitted to not set that type of quota.
 
 The ``api`` key should contain a mapping of service names to number of requests per minute.
 The keys for API quotas are names of services.
@@ -587,6 +592,9 @@ If a service name has no corresponding quota setting, access to that service wil
 
 The ``notebook`` key should contain ``cpu`` and ``memory`` keys specifying the default CPU and memory limits.
 The memory limit is given in a floating point number of GiB.
+
+The ``tap`` key should contain a mapping of TAP service names to quotas for that service.
+Currently, the per-TAP-service quota only supports one key: ``concurrent``, which specifies the number of concurrent TAP queries that a user may have in progress.
 
 For example:
 
@@ -600,8 +608,11 @@ For example:
          notebook:
            cpu: 2.0
            memory: 4.0
+         tap:
+           sso:
+             concurrent: 10
 
-This sets a quota of 100 requests per minute for the ``datalinker`` service, no quotas for any other API service, and a default limit of 2.0 CPU equivalents and 4.0 GiB of memory for notebooks.
+This sets a quota of 100 requests per minute for the ``datalinker`` service, no quotas for any other API service, a default limit of 2.0 CPU equivalents and 4.0 GiB of memory for notebooks, and allows 10 concurrent TAP queries per user to the ``sso`` TAP service.
 
 The default quota for all API services not listed is unlimited.
 To set a default quota of 0, explicitly list the API service with a quota of 0.
@@ -626,7 +637,7 @@ For example:
              memory: 4.0
 
 If this were combined with the above default quota, members of the ``g_developers`` group would receive a total of 150 requests per minute for datalinker, and a total of 8.0 GiB of memory for notebooks.
-The CPU quota for notebooks would be unchanged.
+The CPU quota for notebooks and the quota for TAP queries would be unchanged.
 
 Members of specific groups cannot be granted unrestricted access to an API service since a missing key for a service instead means that this group contributes no additional quota for that service.
 Instead, grant effectively unlimited access by granting a very large quota number.

--- a/src/gafaelfawr/models/quota.py
+++ b/src/gafaelfawr/models/quota.py
@@ -2,12 +2,15 @@
 
 from __future__ import annotations
 
+from typing import Self
+
 from pydantic import BaseModel, ConfigDict, Field
 
 __all__ = [
     "NotebookQuota",
     "Quota",
     "QuotaConfig",
+    "TapQuota",
 ]
 
 
@@ -27,6 +30,30 @@ class NotebookQuota(BaseModel):
         title="Spawning allowed",
         description="Whether the user is allowed to spawn a notebook",
     )
+
+    def add(self, other: Self | None) -> Self:
+        """Add an additional notebook quota to this one."""
+        if not other:
+            return self
+        return type(self)(
+            cpu=self.cpu + other.cpu,
+            memory=self.memory + other.memory,
+            spawn=self.spawn & other.spawn,
+        )
+
+
+class TapQuota(BaseModel):
+    """TAP quota information for a user."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    concurrent: int = Field(..., title="Concurrent queries", examples=[5])
+
+    def add(self, other: Self | None) -> Self:
+        """Add an additional TAP quota to this one."""
+        if not other:
+            return self
+        return type(self)(concurrent=self.concurrent + other.concurrent)
 
 
 class Quota(BaseModel):
@@ -52,6 +79,10 @@ class Quota(BaseModel):
 
     notebook: NotebookQuota | None = Field(
         None, title="Notebook Aspect quotas"
+    )
+
+    tap: dict[str, TapQuota] = Field(
+        {}, title="TAP quotas", examples=[{"qserv": {"concurrent": 5}}]
     )
 
 
@@ -96,21 +127,23 @@ class QuotaConfig(BaseModel):
             return Quota()
 
         # Start with the defaults.
-        api = dict(self.default.api)
-        notebook = None
-        if self.default.notebook:
-            notebook = self.default.notebook.model_copy()
+        default = self.default
+        api = dict(default.api)
+        notebook = default.notebook.model_copy() if default.notebook else None
+        tap = dict(default.tap)
 
         # Look for group-specific rules.
         for group in groups & set(self.groups.keys()):
             extra = self.groups[group]
-            if extra.notebook:
-                if notebook:
-                    notebook.cpu += extra.notebook.cpu
-                    notebook.memory += extra.notebook.memory
-                    notebook.spawn &= extra.notebook.spawn
+            if notebook:
+                notebook = notebook.add(extra.notebook)
+            else:
+                notebook = extra.notebook
+            for service, rule in extra.tap.items():
+                if service in tap:
+                    tap[service] = tap[service].add(rule)
                 else:
-                    notebook = extra.notebook.model_copy()
+                    tap[service] = rule
             for service, quota in extra.api.items():
                 if service in api:
                     api[service] += quota
@@ -121,4 +154,4 @@ class QuotaConfig(BaseModel):
         if not notebook and not api:
             return None
         else:
-            return Quota(api=api, notebook=notebook)
+            return Quota(api=api, notebook=notebook, tap=tap)

--- a/src/gafaelfawr/services/userinfo.py
+++ b/src/gafaelfawr/services/userinfo.py
@@ -281,7 +281,9 @@ class UserInfoService:
             api = quota.api
             api.update(override_quota.api)
             return Quota(
-                notebook=override_quota.notebook or quota.notebook, api=api
+                notebook=override_quota.notebook or quota.notebook,
+                api=api,
+                tap=override_quota.tap or quota.tap,
             )
 
     async def _get_groups_from_ldap(

--- a/tests/data/config/github-quota.yaml
+++ b/tests/data/config/github-quota.yaml
@@ -24,6 +24,9 @@ quota:
     notebook:
       cpu: 8
       memory: 4.0
+    tap:
+      qserv:
+        concurrent: 10
   groups:
     blocked:
       notebook:
@@ -36,6 +39,11 @@ quota:
       notebook:
         cpu: 0.0
         memory: 4.0
+      tap:
+        qserv:
+          concurrent: 5
+        sso:
+          concurrent: 5
   bypass:
     - "admin"
 metrics:


### PR DESCRIPTION
Add a new TAP quota element to user quotas, with the same group math and override support as API quotas. Currently, there is only one quota, controlling the allowed number of concurrent queries, but the data structure is extensible so that other quota information (result size, perhaps) can be added in the future.