### PR TITLE
DM-51818: Add new route to get user info without a token

### DIFF
--- a/alembic/gafaelfawr.yaml
+++ b/alembic/gafaelfawr.yaml
@@ -26,6 +26,7 @@ initialAdmins:
 # Only the built-in scopes.
 knownScopes:
   "admin:token": "Can create and modify tokens for any user"
+  "admin:userinfo": "Can see user information for any user"
   "user:token": "Can create and modify user tokens"
 
 # A minimal mapping sufficient for Gafaelfawr to start.

--- a/changelog.d/20250716_171549_rra_DM_51818.md
+++ b/changelog.d/20250716_171549_rra_DM_51818.md
@@ -1,0 +1,4 @@
+### New features
+
+- Add new `/auth/api/v1/users/<username>` API route that returns the LDAP and, if configured, Firestore information about the given username. This route is only available on Gafaelfawr installations that use LDAP and only returns useful information for users in LDAP.
+- Add new reserved `admin:userinfo` scope, which controls access to the new `/auth/api/v1/users/<username>` route for usernames other than the one associated with the authenticating token. A token with this scope can be used to look up user information for other users without having a token for that user.

--- a/docs/dev/scopes.rst
+++ b/docs/dev/scopes.rst
@@ -23,12 +23,13 @@ Reserved scopes
 ===============
 
 Gafaelfawr reserves scopes beginning with ``admin:`` and ``user:`` for internal use by the identity management system.
-Currently, two scopes in that reserved namespace are used:
+Currently, three scopes in that reserved namespace are used:
 
 * ``admin:token`` grants token administrator powers.
   Users authenticated with a token with this scope can view, create, modify, and delete tokens for any user.
   Administrators are automatically granted this scope when they authenticate.
   The bootstrap token (configured with the ``bootstrap-token`` Kubernetes secret) is automatically granted ``admin:token`` scope.
+* ``admin:userinfo`` grants access to the :samp:`/auth/api/v1/users/{username}` route, which allows retrieval of user information from LDAP (and Firestore if configured) for arbitrary usernames without having a delegated token for that user.
 * ``user:token`` grants the ability to view and delete all tokens for the same user, and create and modify user tokens for that user.
   All session tokens are automatically granted this scope.
 

--- a/docs/user-guide/helm.rst
+++ b/docs/user-guide/helm.rst
@@ -494,6 +494,7 @@ The default includes:
    config:
      knownScopes:
        "admin:token": "Can create and modify tokens for any user"
+       "admin:userinfo": "Can see user information for any user"
        "user:token": "Can create and modify user tokens"
 
 which are used internally by Gafaelfawr, plus the scopes that are used by the Rubin Science Platform.
@@ -523,6 +524,10 @@ A complete setting for GitHub might look something like this:
    config:
      groupMapping:
        "admin:token":
+         - github:
+             organization: "lsst-sqre"
+             team: "square"
+       "admin:userinfo":
          - github:
              organization: "lsst-sqre"
              team: "square"
@@ -566,6 +571,8 @@ A user who is a member of the ``bar`` and ``other`` groups will have the ``exec:
 
 Regardless of the ``config.groupMapping`` configuration, the ``user:token`` scope will be automatically added to the session token of any user authenticating via OpenID Connect or GitHub.
 The ``admin:token`` scope will be automatically added to any user marked as an admin in Gafaelfawr.
+
+You will probably want to grant ``admin:userinfo`` scope to platform administrators so that they can use the :samp:`/auth/api/v1/users/{username}` route to retrieve the user information for a user from LDAP while debugging problems.
 
 .. _helm-quota:
 

--- a/src/gafaelfawr/config.py
+++ b/src/gafaelfawr/config.py
@@ -980,7 +980,7 @@ class Config(EnvFirstSettings):
         for scope in v:
             if not re.match(SCOPE_REGEX, scope):
                 raise ValueError(f"invalid scope {scope}")
-        for required in ("admin:token", "user:token"):
+        for required in ("admin:token", "admin:userinfo", "user:token"):
             if required not in v:
                 raise ValueError(f"required scope {required} missing")
         return v

--- a/src/gafaelfawr/models/ldap.py
+++ b/src/gafaelfawr/models/ldap.py
@@ -27,3 +27,12 @@ class LDAPUserData:
 
     gid: int | None = None
     """Primary GID."""
+
+    def is_empty(self) -> bool:
+        """Whether any information was found in LDAP for this user."""
+        return (
+            self.name is None
+            and self.email is None
+            and self.uid is None
+            and self.gid is None
+        )

--- a/src/gafaelfawr/models/token.py
+++ b/src/gafaelfawr/models/token.py
@@ -267,9 +267,9 @@ class TokenUserInfo(BaseModel):
         -------
         dict
             Dictionary of information, roughly equivalent to calling
-            ``dict(exclude_none=True)`` on the `TokenUserInfo` object, but
-            ensuring that only its data is included even if called on a
-            subclass such as `TokenData`.
+            ``model_dump(mode="json", exclude_none=True)`` on the
+            `TokenUserInfo` object, but ensuring that only its data is
+            included even if called on a subclass such as `TokenData`.
         """
         token_userinfo: dict[str, Any] = {}
         if self.name is not None:
@@ -281,7 +281,9 @@ class TokenUserInfo(BaseModel):
         if self.gid is not None:
             token_userinfo["gid"] = self.gid
         if self.groups is not None:
-            token_userinfo["groups"] = [g.model_dump() for g in self.groups]
+            token_userinfo["groups"] = [
+                g.model_dump(mode="json") for g in self.groups
+            ]
         return token_userinfo
 
 

--- a/src/gafaelfawr/services/ldap.py
+++ b/src/gafaelfawr/services/ldap.py
@@ -128,7 +128,10 @@ class LDAPService:
 
     @sentry_sdk.trace
     async def get_data(
-        self, username: str, *, uncached: bool = False
+        self,
+        username: str,
+        *,
+        uncached: bool = False,
     ) -> LDAPUserData:
         """Get configured data from LDAP.
 

--- a/src/gafaelfawr/services/token.py
+++ b/src/gafaelfawr/services/token.py
@@ -1190,10 +1190,9 @@ class TokenService:
         Arguments
         ---------
         username
-            The user whose tokens are being changed, or `None` if listing
-            all tokens.
+            User whose tokens are affected, or `None` if listing all tokens.
         auth_data
-            The authenticated user changing the tokens.
+            Aauthenticated user performing the action.
         require_admin
             If set to `True`, require the authenticated user have
             ``admin:token`` scope.

--- a/tests/data/config/bad-admin.yaml
+++ b/tests/data/config/bad-admin.yaml
@@ -8,6 +8,7 @@ groupMapping:
   "read:all": ["foo", "admin", "org-a-team"]
 knownScopes:
   "admin:token": "Can create and modify tokens for any user"
+  "admin:userinfo": "Can see user information for any user"
   "user:token": "Can create and modify user tokens"
 github:
   clientId: "some-github-client-id"

--- a/tests/data/config/bad-groups.yaml
+++ b/tests/data/config/bad-groups.yaml
@@ -6,6 +6,7 @@ groupMapping:
   "exec:admin": "admin"
 knownScopes:
   "admin:token": "token administration"
+  "admin:userinfo": "Can see user information for any user"
   "exec:admin": "admin description"
   "user:token": "Can create and modify user tokens"
 github:

--- a/tests/data/config/bad-lifetime.yaml
+++ b/tests/data/config/bad-lifetime.yaml
@@ -7,6 +7,7 @@ groupMapping:
   "exec:admin": ["admin"]
 knownScopes:
   "admin:token": "token administration"
+  "admin:userinfo": "Can see user information for any user"
   "exec:admin": "admin description"
   "user:token": "Can create and modify user tokens"
 github:

--- a/tests/data/config/bad-log-level.yaml
+++ b/tests/data/config/bad-log-level.yaml
@@ -9,6 +9,7 @@ groupMapping:
   "read:all": ["foo", "admin", "org-a-team"]
 knownScopes:
   "admin:token": "Can create and modify tokens for any user"
+  "admin:userinfo": "Can see user information for any user"
   "exec:admin": "admin description"
   "exec:test": "test description"
   "read:all": "can read everything"

--- a/tests/data/config/bad-scope.yaml
+++ b/tests/data/config/bad-scope.yaml
@@ -8,6 +8,7 @@ groupMapping:
   "read:all": ["foo", "admin", "org-a-team"]
 knownScopes:
   "admin:token": "Can create and modify tokens for any user"
+  "admin:userinfo": "Can see user information for any user"
   "user:token": "Can create and modify user tokens"
   "foo bar": "An invalid scope"
 github:

--- a/tests/data/config/both-providers.yaml
+++ b/tests/data/config/both-providers.yaml
@@ -6,6 +6,7 @@ groupMapping:
   "read:all": ["foo", "admin", "org-a-team"]
 knownScopes:
   "admin:token": "Can create and modify tokens for any user"
+  "admin:userinfo": "Can see user information for any user"
   "exec:admin": "admin description"
   "exec:test": "test description"
   "read:all": "can read everything"

--- a/tests/data/config/cilogon-test.yaml
+++ b/tests/data/config/cilogon-test.yaml
@@ -8,6 +8,7 @@ groupMapping:
   "read:all": ["foo", "admin", "org-a-team"]
 knownScopes:
   "admin:token": "Can create and modify tokens for any user"
+  "admin:userinfo": "Can see user information for any user"
   "exec:admin": "admin description"
   "exec:test": "test description"
   "read:all": "can read everything"

--- a/tests/data/config/cilogon.yaml
+++ b/tests/data/config/cilogon.yaml
@@ -8,6 +8,7 @@ groupMapping:
   "read:all": ["foo", "admin", "org-a-team"]
 knownScopes:
   "admin:token": "Can create and modify tokens for any user"
+  "admin:userinfo": "Can see user information for any user"
   "exec:admin": "admin description"
   "exec:test": "test description"
   "read:all": "can read everything"

--- a/tests/data/config/github-oidc-server.yaml
+++ b/tests/data/config/github-oidc-server.yaml
@@ -8,6 +8,7 @@ groupMapping:
   "read:all": ["foo", "admin", "org-a-team"]
 knownScopes:
   "admin:token": "token administration"
+  "admin:userinfo": "Can see user information for any user"
   "exec:admin": "admin description"
   "exec:test": "test description"
   "read:all": "can read everything"

--- a/tests/data/config/github-quota.yaml
+++ b/tests/data/config/github-quota.yaml
@@ -11,6 +11,7 @@ groupMapping:
         team: "a-team"
 knownScopes:
   "admin:token": "token administration"
+  "admin:userinfo": "Can see user information for any user"
   "exec:admin": "admin description"
   "read:all": "can read everything"
   "user:token": "Can create and modify user tokens"

--- a/tests/data/config/github-subdomain.yaml
+++ b/tests/data/config/github-subdomain.yaml
@@ -12,6 +12,7 @@ groupMapping:
         team: "a-team"
 knownScopes:
   "admin:token": "token administration"
+  "admin:userinfo": "Can see user information for any user"
   "exec:admin": "admin description"
   "read:all": "can read everything"
   "read:some": "can read some things"

--- a/tests/data/config/github.yaml
+++ b/tests/data/config/github.yaml
@@ -20,6 +20,7 @@ groupMapping:
         team: "a-team"
 knownScopes:
   "admin:token": "token administration"
+  "admin:userinfo": "Can see user information for any user"
   "exec:admin": "admin description"
   "exec:test": "test description"
   "read:all": "can read everything"

--- a/tests/data/config/missing-scope.yaml
+++ b/tests/data/config/missing-scope.yaml
@@ -7,6 +7,7 @@ groupMapping:
   "read:all": ["foo", "admin", "org-a-team"]
 knownScopes:
   "admin:token": "Can create and modify tokens for any user"
+  "admin:userinfo": "Can see user information for any user"
 github:
   clientId: "some-github-client-id"
 metrics:

--- a/tests/data/config/no-provider.yaml
+++ b/tests/data/config/no-provider.yaml
@@ -7,6 +7,7 @@ groupMapping:
   "read:all": ["foo", "admin", "org-a-team"]
 knownScopes:
   "admin:token": "Can create and modify tokens for any user"
+  "admin:userinfo": "Can see user information for any user"
   "exec:admin": "admin description"
   "exec:test": "test description"
   "read:all": "can read everything"

--- a/tests/data/config/oidc-claims.yaml
+++ b/tests/data/config/oidc-claims.yaml
@@ -7,6 +7,7 @@ groupMapping:
   "read:all": ["foo", "admin", "org-a-team"]
 knownScopes:
   "admin:token": "Can create and modify tokens for any user"
+  "admin:userinfo": "Can see user information for any user"
   "exec:admin": "admin description"
   "exec:test": "test description"
   "read:all": "can read everything"

--- a/tests/data/config/oidc-enrollment.yaml
+++ b/tests/data/config/oidc-enrollment.yaml
@@ -7,6 +7,7 @@ groupMapping:
   "read:all": ["foo", "admin", "org-a-team"]
 knownScopes:
   "admin:token": "Can create and modify tokens for any user"
+  "admin:userinfo": "Can see user information for any user"
   "exec:admin": "admin description"
   "exec:test": "test description"
   "read:all": "can read everything"

--- a/tests/data/config/oidc-firestore.yaml
+++ b/tests/data/config/oidc-firestore.yaml
@@ -7,6 +7,7 @@ groupMapping:
   "read:all": ["foo", "admin", "org-a-team"]
 knownScopes:
   "admin:token": "Can create and modify tokens for any user"
+  "admin:userinfo": "Can see user information for any user"
   "exec:admin": "admin description"
   "exec:test": "test description"
   "read:all": "can read everything"

--- a/tests/data/config/oidc-no-attrs.yaml
+++ b/tests/data/config/oidc-no-attrs.yaml
@@ -8,6 +8,7 @@ groupMapping:
   "read:all": ["foo", "admin", "org-a-team"]
 knownScopes:
   "admin:token": "Can create and modify tokens for any user"
+  "admin:userinfo": "Can see user information for any user"
   "exec:admin": "admin description"
   "exec:test": "test description"
   "read:all": "can read everything"

--- a/tests/data/config/oidc-no-memberdn.yaml
+++ b/tests/data/config/oidc-no-memberdn.yaml
@@ -8,6 +8,7 @@ groupMapping:
   "read:all": ["foo", "admin", "org-a-team"]
 knownScopes:
   "admin:token": "Can create and modify tokens for any user"
+  "admin:userinfo": "Can see user information for any user"
   "exec:admin": "admin description"
   "exec:test": "test description"
   "read:all": "can read everything"

--- a/tests/data/config/oidc-subdomain.yaml
+++ b/tests/data/config/oidc-subdomain.yaml
@@ -7,6 +7,7 @@ groupMapping:
   "read:all": ["foo", "admin", "org-a-team"]
 knownScopes:
   "admin:token": "Can create and modify tokens for any user"
+  "admin:userinfo": "Can see user information for any user"
   "exec:admin": "admin description"
   "exec:test": "test description"
   "read:all": "can read everything"

--- a/tests/data/config/oidc.yaml
+++ b/tests/data/config/oidc.yaml
@@ -10,6 +10,7 @@ groupMapping:
   "read:all": ["foo", "admin", "org-a-team"]
 knownScopes:
   "admin:token": "Can create and modify tokens for any user"
+  "admin:userinfo": "Can see user information for any user"
   "exec:admin": "admin description"
   "exec:test": "test description"
   "read:all": "can read everything"

--- a/tests/data/config/scope-mismatch.yaml
+++ b/tests/data/config/scope-mismatch.yaml
@@ -8,6 +8,7 @@ groupMapping:
   "read:all": ["foo", "admin", "org-a-team"]
 knownScopes:
   "admin:token": "Can create and modify tokens for any user"
+  "admin:userinfo": "Can see user information for any user"
   "exec:admin": "Administrator"
   "user:token": "Can create and modify user tokens"
 github:

--- a/tests/data/config/selenium.yaml
+++ b/tests/data/config/selenium.yaml
@@ -8,6 +8,7 @@ groupMapping:
   "read:all": ["foo", "admin", "org-a-team"]
 knownScopes:
   "admin:token": "Can create and modify tokens for any user"
+  "admin:userinfo": "Can see user information for any user"
   "exec:admin": "admin description"
   "exec:test": "test description"
   "read:all": "can read everything"

--- a/tests/handlers/api_users_test.py
+++ b/tests/handlers/api_users_test.py
@@ -1,0 +1,133 @@
+"""Tests for the user information API."""
+
+from __future__ import annotations
+
+import pytest
+from httpx import AsyncClient
+
+from gafaelfawr.constants import GID_MIN, UID_USER_MIN
+from gafaelfawr.factory import Factory
+from gafaelfawr.models.userinfo import Group, UserInfo
+
+from ..support.config import reconfigure
+from ..support.firestore import MockFirestore
+from ..support.ldap import MockLDAP
+from ..support.tokens import create_session_token
+
+
+@pytest.mark.asyncio
+async def test_userinfo_basic(
+    client: AsyncClient, factory: Factory, mock_ldap: MockLDAP
+) -> None:
+    config = await reconfigure("oidc")
+    assert config.ldap
+    token_data = await create_session_token(
+        factory, username="admin", scopes={"admin:userinfo"}
+    )
+    headers = {"Authorization": f"bearer {token_data.token}"}
+    mock_ldap.add_test_user(
+        UserInfo(username="some-user", name="Some user", uid=2000, gid=1045)
+    )
+    mock_ldap.add_test_group_membership(
+        "some-user", [Group(name="foo", id=1222)]
+    )
+
+    # We should now be able to get user information for that user without
+    # having a token for that user, using the admin token.
+    r = await client.get("/auth/api/v1/users/some-user", headers=headers)
+    assert r.status_code == 200
+    assert r.json() == {
+        "username": "some-user",
+        "name": "Some user",
+        "uid": 2000,
+        "gid": 1045,
+        "groups": [{"id": 1222, "name": "foo"}],
+    }
+
+    # Getting the information for the admin user should return just the
+    # username since the user doesn't exist in LDAP.
+    r = await client.get("/auth/api/v1/users/admin", headers=headers)
+    assert r.status_code == 200
+    assert r.json() == {"username": "admin"}
+
+
+@pytest.mark.asyncio
+async def test_userinfo_firestore(
+    client: AsyncClient,
+    factory: Factory,
+    mock_ldap: MockLDAP,
+    mock_firestore: MockFirestore,
+) -> None:
+    config = await reconfigure("oidc-firestore", factory)
+    assert config.ldap
+    firestore_storage = factory.create_firestore_storage()
+    await firestore_storage.initialize()
+
+    # Create an admin token and use it to set up quotas via an override, which
+    # saves having to add quota details to the test configuration and change a
+    # lot of user info output in other tests.
+    token_data = await create_session_token(
+        factory, username="admin", scopes={"admin:token", "admin:userinfo"}
+    )
+    headers = {"Authorization": f"bearer {token_data.token}"}
+    r = await client.put(
+        "/auth/api/v1/quota-overrides",
+        json={
+            "default": {"api": {"test": 10}},
+            "groups": {"foo": {"api": {"test": 5}}},
+        },
+        headers=headers,
+    )
+    assert r.status_code == 200
+
+    # some-user will be the user for which we retrieve user information. Add
+    # them without UID and GID information.
+    mock_ldap.add_test_user(UserInfo(username="some-user", name="Some user"))
+    mock_ldap.add_test_group_membership(
+        "some-user", [Group(name="foo", id=1111)], omit_gid=True
+    )
+
+    # We should now be able to get user information for that user, including
+    # Firestore-assigned UID and GID and quota information based on the
+    # override.
+    r = await client.get("/auth/api/v1/users/some-user", headers=headers)
+    assert r.status_code == 200
+    assert r.json() == {
+        "username": "some-user",
+        "name": "Some user",
+        "uid": UID_USER_MIN,
+        "gid": UID_USER_MIN,
+        "groups": [
+            {"id": GID_MIN, "name": "foo"},
+            {"id": UID_USER_MIN, "name": "some-user"},
+        ],
+        "quota": {"api": {"test": 15}},
+    }
+
+    # Getting the information for the admin user should return just the
+    # username and default quota but no other information since the user
+    # doesn't exist in LDAP.
+    r = await client.get("/auth/api/v1/users/admin", headers=headers)
+    assert r.status_code == 200
+    assert r.json() == {"username": "admin", "quota": {"api": {"test": 10}}}
+
+    # Likewise for some other random user.
+    r = await client.get("/auth/api/v1/users/other-user", headers=headers)
+    assert r.status_code == 200
+    assert r.json() == {
+        "username": "other-user",
+        "quota": {"api": {"test": 10}},
+    }
+
+
+@pytest.mark.asyncio
+async def test_userinfo_github(client: AsyncClient, factory: Factory) -> None:
+    token_data = await create_session_token(factory, scopes={"admin:userinfo"})
+
+    # When configured with GitHub, any attempt to access the users endpoint
+    # directly should fail with 404.
+    r = await client.get(
+        f"/auth/api/v1/users/{token_data.username}",
+        headers={"Authorization": f"bearer {token_data.token}"},
+    )
+    assert r.status_code == 404

--- a/tests/handlers/login_oidc_test.py
+++ b/tests/handlers/login_oidc_test.py
@@ -200,21 +200,22 @@ async def test_firestore(
     mock_ldap.add_test_user(UserInfo(username="other-user"))
 
     # Add group memberships without GIDs to test that we don't fail.
-    assert config.ldap
-    base_dn = config.ldap.user_base_dn
-    search_value = f"{config.ldap.user_search_attr}=99digits99,{base_dn}"
-    mock_ldap.add_entries_for_test(
-        config.ldap.group_base_dn,
-        "member",
-        search_value,
-        [{"cn": ["foo"]}, {"cn": ["group-1"]}, {"cn": ["group-2"]}],
+    mock_ldap.add_test_group_membership(
+        "99digits99",
+        [
+            Group(name="foo", id=1111),
+            Group(name="group-1", id=1111),
+            Group(name="group-2", id=1111),
+        ],
+        omit_gid=True,
     )
-    search_value = f"{config.ldap.user_search_attr}=other-user,{base_dn}"
-    mock_ldap.add_entries_for_test(
-        config.ldap.group_base_dn,
-        "member",
-        search_value,
-        [{"cn": ["foo"]}, {"cn": ["group-1"]}],
+    mock_ldap.add_test_group_membership(
+        "other-user",
+        [
+            Group(name="foo", id=1111),
+            Group(name="group-1", id=1111),
+        ],
+        omit_gid=True,
     )
 
     # Simulate the OIDC login.

--- a/tests/support/ldap.py
+++ b/tests/support/ldap.py
@@ -51,7 +51,7 @@ class MockLDAP(Mock):
         self._entries[base_dn][key] = entries
 
     def add_test_group_membership(
-        self, username: str, groups: list[Group]
+        self, username: str, groups: list[Group], *, omit_gid: bool = False
     ) -> None:
         """Add group membership entries for a test user.
 
@@ -61,6 +61,8 @@ class MockLDAP(Mock):
             Username of user
         groups
             Group memberships to add.
+        omit_gid
+            Whether to omit the GID from the record.
         """
         config = config_dependency.config()
         assert config.ldap
@@ -70,7 +72,12 @@ class MockLDAP(Mock):
             search_value = f"{attr}={username},{base_dn}"
         else:
             search_value = username
-        entries = [{"cn": [g.name], "gidNumber": [str(g.id)]} for g in groups]
+        if omit_gid:
+            entries = [{"cn": [g.name]} for g in groups]
+        else:
+            entries = [
+                {"cn": [g.name], "gidNumber": [str(g.id)]} for g in groups
+            ]
         self.add_entries_for_test(
             config.ldap.group_base_dn,
             config.ldap.group_member_attr,


### PR DESCRIPTION
To support TAP quotas in the Qserv Kafka bridge, the bridge needs to be able to retrieve the quota for a user, but it does not have a delegated token for the user and we would prefer not to have to manage that token in the TAP server or send it to Kafka.

Instead, add a new route, `/auth/api/v1/users/<username>`, which can be used to retrieve the user information for an arbitrary user. This will also help with administrator debugging of Science Platform and user authorization issues. Add a new reserved scope, `admin:userinfo`, that controls access to that endpoint so that the Qserv Kafka bridge can query it without having full administrative access.

This route has several limitations: It is not available at all if Gafaelfawr uses GitHub for authentication (it returns 404), and it will only show useful information for users in LDAP, even if they have assigned UIDs or GIDs in Firestore despite not being in LDAP (as is the case with bot users).