### PR TITLE
DM-51859: Add service to rate limit key

### DIFF
--- a/changelog.d/20250718_090750_rra_DM_51859.md
+++ b/changelog.d/20250718_090750_rra_DM_51859.md
@@ -1,0 +1,3 @@
+### Bug fixes
+
+- Fix tracking of API quotas to use separate counters for each service and user pair. A bug in previous releases caused usage counters to be shared for a user between services with the same quota.

--- a/src/gafaelfawr/handlers/ingress.py
+++ b/src/gafaelfawr/handlers/ingress.py
@@ -685,7 +685,7 @@ async def check_rate_limit(
         )
 
     # Check the usage against Redis.
-    key = ("api", user_info.username)
+    key = ("api", user_info.username, auth_config.service)
     limit = RateLimitItemPerMinute(quota, 1)
     try:
         allowed = await context.rate_limiter.hit(limit, *key)
@@ -733,7 +733,7 @@ async def check_rate_limit(
 
     # Return a 403 error with the actual status code and body in the
     # headers, where they will be parsed by the ingress-nginx integration.
-    msg = f"Rate limit ({quota}/15m) exceeded"
+    msg = f"Rate limit ({quota}/minute) exceeded"
     context.logger.info("Request rejected due to rate limits", error=msg)
     detail = [{"msg": msg, "type": "rate_limited"}]
     raise HTTPException(

--- a/tests/data/config/github-quota.yaml
+++ b/tests/data/config/github-quota.yaml
@@ -22,6 +22,7 @@ quota:
     api:
       datalinker: 1000
       test: 1
+      other: 2
     notebook:
       cpu: 8
       memory: 4.0

--- a/tests/handlers/ingress_logging_test.py
+++ b/tests/handlers/ingress_logging_test.py
@@ -474,7 +474,7 @@ async def test_rate_limit_events(
     assert parse_log_tuples("gafaelfawr", caplog.record_tuples) == [
         {
             "auth_uri": "https://example.com/foo",
-            "error": "Rate limit (1/15m) exceeded",
+            "error": "Rate limit (1/minute) exceeded",
             "event": "Request rejected due to rate limits",
             "httpRequest": {
                 "requestMethod": "GET",

--- a/tests/handlers/quota_test.py
+++ b/tests/handlers/quota_test.py
@@ -35,7 +35,7 @@ async def test_info(client: AsyncClient, factory: Factory) -> None:
         "username": "example",
         "groups": [{"name": "bar", "id": 12312}],
         "quota": {
-            "api": {"datalinker": 1000, "test": 1},
+            "api": {"datalinker": 1000, "test": 1, "other": 2},
             "notebook": {"cpu": 8.0, "memory": 4.0, "spawn": True},
             "tap": {"qserv": {"concurrent": 10}},
         },
@@ -54,7 +54,7 @@ async def test_info(client: AsyncClient, factory: Factory) -> None:
         "username": "example",
         "groups": [{"name": "foo", "id": 12313}],
         "quota": {
-            "api": {"datalinker": 1000, "test": 2},
+            "api": {"datalinker": 1000, "test": 2, "other": 2},
             "notebook": {"cpu": 8.0, "memory": 8.0, "spawn": True},
             "tap": {"qserv": {"concurrent": 15}, "sso": {"concurrent": 5}},
         },
@@ -85,7 +85,7 @@ async def test_no_spawn(client: AsyncClient, factory: Factory) -> None:
             for g in sorted(token_data.groups, key=lambda g: g.name)
         ],
         "quota": {
-            "api": {"datalinker": 1000, "test": 1},
+            "api": {"datalinker": 1000, "test": 1, "other": 2},
             "notebook": {"cpu": 8.0, "memory": 4.0, "spawn": False},
             "tap": {"qserv": {"concurrent": 10}},
         },
@@ -138,7 +138,7 @@ async def test_rate_limit_override(
             for g in sorted(token_data.groups, key=lambda g: g.name)
         ],
         "quota": {
-            "api": {"datalinker": 1000, "test": 10},
+            "api": {"datalinker": 1000, "test": 10, "other": 2},
             "notebook": {"cpu": 8.0, "memory": 8.0, "spawn": True},
             "tap": {"qserv": {"concurrent": 15}, "sso": {"concurrent": 5}},
         },


### PR DESCRIPTION
Service was incorrectly omitted from the rate limit key, causing a bug where usage counters were merged between different services with the same API quota for a given user. API services with different quotas were still kept separate. Fix this by explicitly adding the service name to the rate limit key.