### PR TITLE
DM-51818: Make default section optional in quota overrides

### DIFF
--- a/changelog.d/20250721_172249_rra_DM_51818.md
+++ b/changelog.d/20250721_172249_rra_DM_51818.md
@@ -1,0 +1,3 @@
+### New features
+
+- When setting quota overrides, the `default` section can be entirely omitted. This simplifies overriding the quota for only one group.

--- a/src/gafaelfawr/models/quota.py
+++ b/src/gafaelfawr/models/quota.py
@@ -92,7 +92,9 @@ class QuotaConfig(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     default: Quota = Field(
-        ..., title="Default quota", description="Default quotas for all users"
+        default_factory=Quota,
+        title="Default quota",
+        description="Default quotas for all users",
     )
 
     groups: dict[str, Quota] = Field(


### PR DESCRIPTION
When setting a quota override, the `default` section can now be omitted entirely, instead of requiring it be present but empty. This simplifies overriding the quota for only one group.

Expand the documentation for quotas to add a more detailed example of how overrides work and to suggest checking the quota for a specific user after setting an override.