### PR TITLE
DM-51521: Build docs when CHANGELOG.md changes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -130,9 +130,11 @@ jobs:
         with:
           filters: |
             docs:
+              - "CHANGELOG.md"
               - "docs/**"
               - "src/gafaelfawr/**"
             docs-specific:
+              - "CHANGELOG.md"
               - "docs/**"
 
   docs:
@@ -140,7 +142,9 @@ jobs:
     timeout-minutes: 15
 
     needs: changes
-    if: ${{ needs.changes.outputs.docs == 'true' }}
+    if: >
+      (needs.changes.outputs.docs == 'true')
+      || (github.event_name == 'workflow_dispatch')
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
The 14.0.0 release did not correctly build and upload documentation because the release push itself didn't modify any documentation files. Add `CHANGELOG.md` to the list of documentation files to catch this case, and also ensure documentation is published on workflow dispatch events.