### PR TITLE
Fix periodic documentation build

### DIFF
--- a/.github/workflows/periodic-ci.yaml
+++ b/.github/workflows/periodic-ci.yaml
@@ -22,6 +22,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          # Ensure the documentation gets the right version.
+          fetch-depth: 0
 
       - name: Set up Python
         uses: actions/setup-python@v5


### PR DESCRIPTION
Add `fetch-depth: 0` for the periodic GitHub Actions CI build, since it is now required by Sphinx.