### PR TITLE
DM-52140: Fix group name validation regression

### DIFF
--- a/changelog.d/20250808_150548_rra_DM_52140.md
+++ b/changelog.d/20250808_150548_rra_DM_52140.md
@@ -1,0 +1,3 @@
+### Bug fixes
+
+- Allow group names where the only alphabetic character is the first character. This fixes a regression introduced in Gafaelfawr 13.0.1.

--- a/src/gafaelfawr/constants.py
+++ b/src/gafaelfawr/constants.py
@@ -199,7 +199,9 @@ BOT_USERNAME_REGEX = "^bot-[a-z0-9](?:[a-z0-9]|-[a-z0-9])*$"
 CURSOR_REGEX = "^p?[0-9]+_[0-9]+$"
 """Regex matching a valid cursor."""
 
-GROUPNAME_REGEX = "^[a-zA-Z0-9][a-zA-Z0-9._-]*[a-zA-Z][a-zA-Z0-9._-]*$"
+GROUPNAME_REGEX = (
+    "^([a-zA-Z]|[a-zA-Z0-9][a-zA-Z0-9._-]*[a-zA-Z])[a-zA-Z0-9._-]*$"
+)
 """Regex matching all valid group names."""
 
 SCOPE_REGEX = "^[a-zA-Z0-9:._-]+$"

--- a/tests/models/userinfo_test.py
+++ b/tests/models/userinfo_test.py
@@ -1,0 +1,27 @@
+"""Tests for user information models."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from gafaelfawr.models.userinfo import Group
+
+
+def test_group_names() -> None:
+    for valid in (
+        "g_special_users",
+        "rra",
+        "19numbers",
+        "G-12345",
+        "group.name",
+        "group1234",
+        "19numbers19",
+        "1-g",
+        "12341-g-",
+    ):
+        Group(name=valid, id=1234)
+
+    for invalid in ("12345", "rra#foo", "", "-rra", "_rra", "1-"):
+        with pytest.raises(ValidationError):
+            Group(name=invalid, id=1234)


### PR DESCRIPTION
Fix validation of group names where the only alphabetic character is the first character. This fixes a regression introduced in 13.0.1 in the fix for groups starting with digits. Add a new test for group name validation.