### PR TITLE
DM-54097: Automatically rewrite mock assertions

### DIFF
--- a/client/src/rubin/gafaelfawr/__init__.py
+++ b/client/src/rubin/gafaelfawr/__init__.py
@@ -1,5 +1,12 @@
 """Client for Gafaelfawr."""
 
+try:
+    import pytest
+
+    pytest.register_assert_rewrite("rubin.gafaelfawr.client._mock")
+except ImportError:
+    pass
+
 from ._client import GafaelfawrClient
 from ._dependencies import GafaelfawrDependency, gafaelfawr_dependency
 from ._exceptions import (

--- a/docs/user-guide/mock.rst
+++ b/docs/user-guide/mock.rst
@@ -28,30 +28,6 @@ Then, add a fixture (usually to :file:`tests/conftest.py`) that calls `register_
    async def mock_gafaelfawr(respx_mock: respx.Router) -> MockGafaelfawr:
        return await register_mock_gafaelfawr(respx_mock)
 
-Enabling assertion rewriting
-----------------------------
-
-For better error reports in pytest_ if an assertion fails inside the mock, tell pytest to rewrite assertions in :py:mod:`rubin.gafaelfawr` by putting the following at the top of :file:`tests/conftest.py`:
-
-.. code-block:: yaml
-
-   import pytest
-
-   pytest.register_assert_rewrite("rubin.gafaelfawr")
-
-Add any other test support modules that may call assert to the list.
-These lines must occur before any imports of the listed modules, either direct or indirect.
-
-Unfortunately, Ruff doesn't understand this pattern and will try to rewrite the file in a way that will break it.
-You will therefore also need to add the following to your :file:`pyproject.toml`:
-
-.. code-block:: toml
-
-   [tool.ruff.lint.extend-per-file-ignores]
-   "tests/conftest.py" = [
-       "E402",   # pytest.register_assert_rewrite precedes relevant imports
-   ]
-
 Overriding service discovery
 ----------------------------
 


### PR DESCRIPTION
Automatically register the Gafaelfawr mock for pytest assertion rewriting if pytest is available, avoiding the need to document how to do this for the user.