### PR TITLE
Add `vinylAuthCacheEnabled` config option to `GafaelfawrIngress` CRD

### DIFF
--- a/alembic/gafaelfawr.yaml
+++ b/alembic/gafaelfawr.yaml
@@ -10,6 +10,7 @@ logLevel: "WARNING"
 # Dummy base URLs.
 baseUrl: "https://example.org/"
 baseInternalUrl: "http://gafaelfawr.gafaelfawr.svc.cluster.local:8080"
+baseCachingInternalUrl: "http://gafaelfawr-vinyl-cache.gafaelfawr.svc.cluster.local:8080"
 
 # Dummy secrets so that Gafaelfawr will start.
 bootstrapToken: "gt-HJQLhg7DQT7lXDL3BDFjgw.kRGKrVPcQBsNHszvZN9Qjw"

--- a/crds/ingress.yaml
+++ b/crds/ingress.yaml
@@ -212,6 +212,17 @@ spec:
                     other users, regardless of their scopes, will receive 403
                     errors. The user's token must still satisfy any scope
                     constraints.
+                vinylAuthCacheEnabled:
+                  type: boolean
+                  description: >-
+                    Whether Gafaelfawr authorization results should be cached
+                    by Vinyl. The Vinyl cache is configured to cache results
+                    for five minutes. The cache is invalidated if the `Cookie`
+                    or `Authorization` HTTP headers change.
+              not:
+                required:
+                  - authCacheDuration
+                  - vinylAuthCacheEnabled
             template:
               type: object
               description: "The template used to create the ingress."

--- a/src/gafaelfawr/config.py
+++ b/src/gafaelfawr/config.py
@@ -753,6 +753,18 @@ class Config(EnvFirstSettings):
         ),
     )
 
+    base_caching_internal_url: HttpUrl = Field(
+        ...,
+        title="Internal caching base URL",
+        description=(
+            "Base URL for internal-only routes such as ``/ingress/auth`` where"
+            " all responses will be cached."
+        ),
+        validation_alias=AliasChoices(
+            "GAFAELFAWR_BASE_CACHING_INTERNAL_URL", "baseCachingInternalUrl"
+        ),
+    )
+
     bootstrap_token: SecretStr = Field(
         ...,
         title="Bootstrap token",

--- a/src/gafaelfawr/models/kubernetes.py
+++ b/src/gafaelfawr/models/kubernetes.py
@@ -342,6 +342,9 @@ class GafaelfawrIngressConfig(BaseModel):
     JupyterLab pods.
     """
 
+    vinyl_auth_cache_enabled: bool = False
+    """Whether Gafaelfawr authorization results should be cached by Vinyl."""
+
     username: str | None = None
     """Restrict access to the given user."""
 

--- a/src/gafaelfawr/services/kubernetes.py
+++ b/src/gafaelfawr/services/kubernetes.py
@@ -106,8 +106,12 @@ class KubernetesIngressService:
 
     def _build_annotations(self, ingress: GafaelfawrIngress) -> dict[str, str]:
         """Build annotations for an ``Ingress``."""
+        if ingress.config.vinyl_auth_cache_enabled:
+            base_url = self._config.base_caching_internal_url
+        else:
+            base_url = self._config.base_internal_url
         auth_url = (
-            str(self._config.base_internal_url).rstrip("/")
+            str(base_url).rstrip("/")
             + "/ingress/auth?"
             + urlencode(ingress.config.to_auth_query(), safe=":/")
         )

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -45,6 +45,7 @@ def test_config_alembic(monkeypatch: pytest.MonkeyPatch) -> None:
     """Check the configuration used for Alembic operations."""
     monkeypatch.delenv("GAFAELFAWR_BASE_URL")
     monkeypatch.delenv("GAFAELFAWR_BASE_INTERNAL_URL")
+    monkeypatch.delenv("GAFAELFAWR_BASE_CACHING_INTERNAL_URL")
     monkeypatch.delenv("GAFAELFAWR_BOOTSTRAP_TOKEN")
     monkeypatch.delenv("GAFAELFAWR_GITHUB_CLIENT_SECRET")
     monkeypatch.delenv("GAFAELFAWR_SESSION_SECRET")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -49,6 +49,10 @@ def environment(monkeypatch: pytest.MonkeyPatch) -> None:
         "GAFAELFAWR_BASE_INTERNAL_URL",
         "http://gafaelfawr.gafaelfawr.svc.cluster.local:8080",
     )
+    monkeypatch.setenv(
+        "GAFAELFAWR_BASE_CACHING_INTERNAL_URL",
+        "http://gafaelfawr-vinyl-cache.gafaelfawr.svc.cluster.local:8080",
+    )
 
 
 @pytest_asyncio.fixture

--- a/tests/data/kubernetes/input/ingresses.yaml
+++ b/tests/data/kubernetes/input/ingresses.yaml
@@ -265,3 +265,29 @@ template:
       - hosts:
           - "*.nb.example.com"
         secretName: "tls-secret"
+---
+apiVersion: gafaelfawr.lsst.io/v1alpha1
+kind: GafaelfawrIngress
+metadata:
+  name: vinyl-ingress
+  namespace: {namespace}
+config:
+  scopes:
+    all: ["read:all"]
+  service: tap
+  vinylAuthCacheEnabled: true
+template:
+  metadata:
+    name: vinyl
+  spec:
+    rules:
+      - host: example.com
+        http:
+          paths:
+            - path: /foo
+              pathType: Prefix
+              backend:
+                service:
+                  name: something
+                  port:
+                    name: http

--- a/tests/data/kubernetes/output/ingresses.yaml
+++ b/tests/data/kubernetes/output/ingresses.yaml
@@ -371,3 +371,43 @@ spec:
         - "*.nb.example.com"
       secretName: tls-secret
 status: {any}
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: vinyl
+  namespace: {namespace}
+  annotations:
+    nginx.ingress.kubernetes.io/auth-method: GET
+    nginx.ingress.kubernetes.io/auth-response-headers: "Authorization,Cookie,X-Auth-Request-Email,X-Auth-Request-Service,X-Auth-Request-Token,X-Auth-Request-User"
+    nginx.ingress.kubernetes.io/auth-url: "http://gafaelfawr-vinyl-cache.gafaelfawr.svc.cluster.local:8080/ingress/auth?scope=read:all&service=tap"
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      {snippet}
+  creationTimestamp: {any}
+  generation: {any}
+  labels:
+    app.kubernetes.io/managed-by: Gafaelfawr
+  managedFields: {any}
+  ownerReferences:
+    - apiVersion: gafaelfawr.lsst.io/v1alpha1
+      blockOwnerDeletion: true
+      controller: true
+      kind: GafaelfawrIngress
+      name: vinyl-ingress
+      uid: {any}
+  resourceVersion: {any}
+  uid: {any}
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: example.com
+      http:
+        paths:
+          - path: /foo
+            pathType: Prefix
+            backend:
+              service:
+                name: something
+                port:
+                  name: http
+status: {any}


### PR DESCRIPTION
If this is set to true, then all auth requests for a given ingress will be sent to the the Vinyl cache sidecar container in the Gafaelfawr pod. This cache is configured to cache all GET responses by Authorization header and cookie for five minutes.