### PR TITLE
DM-54461: Fix issuer URL in OIDC well-known endpoint

### DIFF
--- a/changelog.d/20260323_123939_rra_DM_54461.md
+++ b/changelog.d/20260323_123939_rra_DM_54461.md
@@ -1,0 +1,3 @@
+### Bug fixes
+
+- Do not strip trailing slashes from the issuer string when constructing the response to `/.well-known/openid-configuration` requests. Removing a trailing slash was causing mismatches with the `iss` claim inside ID tokens.

--- a/src/gafaelfawr/services/oidc.py
+++ b/src/gafaelfawr/services/oidc.py
@@ -127,7 +127,7 @@ class OIDCService:
         """Return the OpenID Connect configuration for the internal server."""
         base_url = str(self._config.issuer).rstrip("/")
         return OIDCConfig(
-            issuer=base_url,
+            issuer=str(self._config.issuer),
             authorization_endpoint=base_url + "/auth/openid/login",
             token_endpoint=base_url + "/auth/openid/token",
             userinfo_endpoint=base_url + "/auth/openid/userinfo",

--- a/tests/handlers/oidc_test.py
+++ b/tests/handlers/oidc_test.py
@@ -869,7 +869,7 @@ async def test_well_known_oidc(
 
     base_url = str(config.oidc_server.issuer).rstrip("/")
     assert r.json() == {
-        "issuer": base_url,
+        "issuer": str(config.oidc_server.issuer),
         "authorization_endpoint": base_url + "/auth/openid/login",
         "token_endpoint": base_url + "/auth/openid/token",
         "userinfo_endpoint": base_url + "/auth/openid/userinfo",


### PR DESCRIPTION
Do not strip trailing slashes from the issuer string when constructing the response to `/.well-known/openid-configuration` requests. Removing a trailing slash was causing mismatches with the `iss` claim inside ID tokens.