### PR TITLE
DM-54461: Use safir.testing.data in test suite

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
     "pyjwt",
     "pyyaml",
     "redis>=4.2.0",
-    "safir[db,kafka,kubernetes]>=14.1.3",
+    "safir[db,kafka,kubernetes]>=14.3",
     "sentry-sdk[fastapi]",
     "sqlalchemy>=2",
     "starlette",

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -19,6 +19,7 @@ from click.testing import CliRunner
 from cryptography.fernet import Fernet
 from safir.database import drop_database, initialize_database
 from safir.datetime import current_datetime
+from safir.testing.data import Data
 from safir.testing.slack import MockSlackWebhook
 from sqlalchemy.ext.asyncio import AsyncEngine
 
@@ -353,7 +354,9 @@ def test_update_schema(engine: AsyncEngine, config: Config) -> None:
     # Updating via Alembic migrations is tested in test_validate_schema
 
 
-def test_validate_schema(config: Config, engine: AsyncEngine) -> None:
+def test_validate_schema(
+    config: Config, data: Data, engine: AsyncEngine
+) -> None:
     event_loop = asyncio.new_event_loop()
     runner = CliRunner()
 
@@ -368,7 +371,9 @@ def test_validate_schema(config: Config, engine: AsyncEngine) -> None:
     # Initialize the database from an old schema. This was the database schema
     # before Alembic was introduced, so it has to be stamped with the version
     # of the Alembic database migration that includes the original schema.
-    event_loop.run_until_complete(create_old_database(config, engine, "9.6.1"))
+    event_loop.run_until_complete(
+        create_old_database(config, data, engine, version="9.6.1")
+    )
     env = {
         **os.environ,
         "GAFAELFAWR_CONFIG_PATH": str(config_dependency.config_path),

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -5,7 +5,6 @@ interoperability between the client and the server.
 """
 
 from datetime import UTC, datetime, timedelta
-from pathlib import Path
 from unittest.mock import ANY
 
 import pytest
@@ -16,6 +15,7 @@ from rubin.repertoire import (
     DiscoveryClient,
     register_mock_discovery,
 )
+from safir.testing.data import Data
 
 from gafaelfawr.factory import Factory
 from gafaelfawr.models.token import Token, TokenUserInfo
@@ -33,11 +33,10 @@ from .support.ldap import MockLDAP
 
 @pytest.fixture
 def mock_discovery(
-    respx_mock: respx.Router, monkeypatch: pytest.MonkeyPatch
+    data: Data, respx_mock: respx.Router, monkeypatch: pytest.MonkeyPatch
 ) -> Discovery:
     monkeypatch.setenv("REPERTOIRE_BASE_URL", "https://example.com/repertoire")
-    path = Path(__file__).parent / "data" / "discovery.json"
-    return register_mock_discovery(respx_mock, path)
+    return register_mock_discovery(respx_mock, data.path("discovery.json"))
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,6 +13,7 @@ from cryptography.fernet import Fernet
 from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient
 from safir.database import create_database_engine, stamp_database_async
+from safir.testing.data import Data
 from safir.testing.slack import MockSlackWebhook, mock_slack_webhook
 from sqlalchemy.ext.asyncio import AsyncEngine
 from testcontainers.postgres import PostgresContainer
@@ -123,6 +124,11 @@ def config(
     monkeypatch.setenv("GAFAELFAWR_SLACK_WEBHOOK", slack_webhook)
 
     return configure("github")
+
+
+@pytest.fixture
+def data() -> Data:
+    return Data(Path(__file__).parent / "data")
 
 
 @pytest_asyncio.fixture

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -3,6 +3,7 @@
 import pytest
 from asgi_lifespan import LifespanManager
 from safir.database import drop_database
+from safir.testing.data import Data
 from sqlalchemy.ext.asyncio import AsyncEngine
 
 from gafaelfawr.config import Config
@@ -14,9 +15,11 @@ from .support.database import create_old_database
 
 
 @pytest.mark.asyncio
-async def test_out_of_date_schema(config: Config, engine: AsyncEngine) -> None:
+async def test_out_of_date_schema(
+    config: Config, data: Data, engine: AsyncEngine
+) -> None:
     await drop_database(engine, SchemaBase.metadata)
-    await create_old_database(config, engine, "9.6.1")
+    await create_old_database(config, data, engine, version="9.6.1")
 
     app = create_app()
     with pytest.raises(DatabaseSchemaError):

--- a/tests/support/database.py
+++ b/tests/support/database.py
@@ -1,7 +1,6 @@
 """Support code for testing database handling."""
 
-from pathlib import Path
-
+from safir.testing.data import Data
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncEngine
 
@@ -12,7 +11,7 @@ __all__ = ["create_old_database"]
 
 
 async def create_old_database(
-    config: Config, engine: AsyncEngine, version: str
+    config: Config, data: Data, engine: AsyncEngine, *, version: str
 ) -> None:
     """Initialize the database from an old schema.
 
@@ -29,7 +28,7 @@ async def create_old_database(
     version
         Version of schema to load.
     """
-    old_schema = Path(__file__).parent.parent / "data" / "schemas" / version
+    old_schema = data.path(f"schemas/{version}")
     async with Factory.standalone(config, engine) as factory:
         async with factory.session.begin():
             with old_schema.open() as f:

--- a/uv.lock
+++ b/uv.lock
@@ -974,7 +974,7 @@ requires-dist = [
     { name = "python-multipart" },
     { name = "pyyaml" },
     { name = "redis", specifier = ">=4.2.0" },
-    { name = "safir", extras = ["db", "kafka", "kubernetes"], specifier = ">=14.1.3" },
+    { name = "safir", extras = ["db", "kafka", "kubernetes"], specifier = ">=14.3" },
     { name = "sentry-sdk", extras = ["fastapi"] },
     { name = "sqlalchemy", specifier = ">=2" },
     { name = "starlette" },


### PR DESCRIPTION
Use the new Safir library to manage test data. This is a minimal introduction that doesn't use that library in significant ways, yet, but ensures the fixture is available.