### PR TITLE
DM-55072: Add IVOA GMS protocol implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Read those documents for a more complete picture of how Gafaelfawr fits into a l
 Gafaelfawr provides authentication and access control via NGINX's `auth_request` directive, and handles integration with an external identity provider (either with GitHub or OpenID Connect).
 Authentication sessions and user identity information are stored in Redis.
 Token information is stored in a SQL database.
-It also provides an API to create and manipulate tokens, and a minimal OpenID Connect server to support protected services that only understand OpenID Connect.
+It also provides basic API rate limiting and user quota information, an API to create and manipulate tokens, a minimal OpenID Connect server to support protected services that only understand OpenID Connect, and an implementation of the IVAO Group Membership Service protocol (version 1.0).
 
 For full documentation, see [gafaelfawr.lsst.io](https://gafaelfawr.lsst.io/).
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Read those documents for a more complete picture of how Gafaelfawr fits into a l
 Gafaelfawr provides authentication and access control via NGINX's `auth_request` directive, and handles integration with an external identity provider (either with GitHub or OpenID Connect).
 Authentication sessions and user identity information are stored in Redis.
 Token information is stored in a SQL database.
-It also provides basic API rate limiting and user quota information, an API to create and manipulate tokens, a minimal OpenID Connect server to support protected services that only understand OpenID Connect, and an implementation of the IVAO Group Membership Service protocol (version 1.0).
+It also provides basic API rate limiting and user quota information, an API to create and manipulate tokens, a minimal OpenID Connect server to support protected services that only understand OpenID Connect, and an implementation of the IVOA Group Membership Service protocol (version 1.0).
 
 For full documentation, see [gafaelfawr.lsst.io](https://gafaelfawr.lsst.io/).
 

--- a/changelog.d/20260527_133734_rra_DM_55072.md
+++ b/changelog.d/20260527_133734_rra_DM_55072.md
@@ -1,0 +1,3 @@
+### New features
+
+- Add an implementation of the IVOA GMS 1.0 protocol on the `/auth/gms` route. This is a simple protocol that allows IVOA services to determine the group membership of the current authenticated user.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -16,8 +16,10 @@ Gafaelfawr
 Gafaelfawr provides the authentication and authorization infrastructure for Phalanx_ environments, including the Vera C. Rubin Observatory Science Platform.
 
 Its primary purpose is to serve as an NGINX ``auth_request`` backend.
-It also provides a web page where people can create and manage long-lived tokens for use outside of a web browser, and can serve as a simple OpenID Connect server.
-Gafaelfawr requires the Kubernetes `NGINX ingress controller <https://github.com/kubernetes/ingress-nginx>`__.
+It also provides basic API rate limiting and user quota information, an API to create and manipulate tokens, a minimal OpenID Connect server to support protected services that only understand OpenID Connect, and an implementation of the `IVAO Group Membership Service protocol (version 1.0) <https://www.ivoa.net/documents/GMS/20220222/REC-GMS-1.0.html>`__.
+
+Currently, the Kubernetes `NGINX ingress controller <https://github.com/kubernetes/ingress-nginx>`__.
+A future version will use a Kubernetes gateway controller (probably Envoy) instead.
 
 Gafaelfawr is developed on `GitHub <https://github.com/lsst-sqre/gafaelfawr>`__.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -16,7 +16,7 @@ Gafaelfawr
 Gafaelfawr provides the authentication and authorization infrastructure for Phalanx_ environments, including the Vera C. Rubin Observatory Science Platform.
 
 Its primary purpose is to serve as an NGINX ``auth_request`` backend.
-It also provides basic API rate limiting and user quota information, an API to create and manipulate tokens, a minimal OpenID Connect server to support protected services that only understand OpenID Connect, and an implementation of the `IVAO Group Membership Service protocol (version 1.0) <https://www.ivoa.net/documents/GMS/20220222/REC-GMS-1.0.html>`__.
+It also provides basic API rate limiting and user quota information, an API to create and manipulate tokens, a minimal OpenID Connect server to support protected services that only understand OpenID Connect, and an implementation of the `IVOA Group Membership Service protocol (version 1.0) <https://www.ivoa.net/documents/GMS/20220222/REC-GMS-1.0.html>`__.
 
 Currently, the Kubernetes `NGINX ingress controller <https://github.com/kubernetes/ingress-nginx>`__.
 A future version will use a Kubernetes gateway controller (probably Envoy) instead.

--- a/docs/user-guide/client.rst
+++ b/docs/user-guide/client.rst
@@ -2,6 +2,8 @@
 
 .. py:currentmodule:: rubin.gafaelfawr
 
+.. _python-client:
+
 ########################
 Gafaelfawr Python client
 ########################

--- a/docs/user-guide/gms.rst
+++ b/docs/user-guide/gms.rst
@@ -6,7 +6,7 @@
 IVOA GMS queries
 ################
 
-Gafaelfawr also provides an implementation of the `IVAO Group Membership Service protocol (version 1.0) <https://www.ivoa.net/documents/GMS/20220222/REC-GMS-1.0.html>`__.
+Gafaelfawr also provides an implementation of the `IVOA Group Membership Service protocol (version 1.0) <https://www.ivoa.net/documents/GMS/20220222/REC-GMS-1.0.html>`__.
 This is a simple text-based API that allows a service with a delegated credential (see :ref:`delegated-tokens`) to get the group membership of an authenticated user.
 
 To use this API, send a GET request to ``/auth/gms``.

--- a/docs/user-guide/gms.rst
+++ b/docs/user-guide/gms.rst
@@ -1,0 +1,27 @@
+:og:description: Learn how to use the Gafaelfawr IVOA GMS API.
+
+.. _gms:
+
+################
+IVOA GMS queries
+################
+
+Gafaelfawr also provides an implementation of the `IVAO Group Membership Service protocol (version 1.0) <https://www.ivoa.net/documents/GMS/20220222/REC-GMS-1.0.html>`__.
+This is a simple text-based API that allows a service with a delegated credential (see :ref:`delegated-tokens`) to get the group membership of an authenticated user.
+
+To use this API, send a GET request to ``/auth/gms``.
+Include the delegated token in an ``Authorization`` header as a bearer token.
+The response will be a list of the names of the groups of which the user is a member.
+Each group name will end in a newline.
+If the user is not a member of any groups, the body of the response will be empty.
+
+One or more ``group`` query parameters may be provided to the ``/auth/gms`` GET request.
+If present, only the intersection between the user's group membership and the groups specified in ``group`` query parameters will be returned.
+This allows for a simple check to see if the user is a member of one or more specific groups: List those groups in ``group`` query parameters, and then if the response has a 200 HTTP status code and a non-empty body, the user is a member of at least one of those groups.
+
+As specified in the GMS protocol, the HTTP ``Expires`` header should be used to determine how long the result of a GMS query can be safely cached by the client.
+
+.. note::
+
+   GMS support is primarily for applications that prefer to use IVOA protocols or that were written to work in a generic IVOA environment.
+   Most Gafaelfawr-native applications should use the :ref:`python-client` instead, or the richer :doc:`Gafaelfawr REST API </api/rest>`.

--- a/docs/user-guide/index.rst
+++ b/docs/user-guide/index.rst
@@ -15,6 +15,7 @@ While there is nothing intrinsic in Gafaelfawr that would prevent it from workin
    quotas
    service-tokens
    openid-connect
+   gms
 
 .. toctree::
    :caption: Using the Python client

--- a/src/gafaelfawr/handlers/gms.py
+++ b/src/gafaelfawr/handlers/gms.py
@@ -4,15 +4,7 @@ from datetime import UTC, datetime, timedelta
 from email.utils import format_datetime
 from typing import Annotated
 
-from fastapi import (
-    APIRouter,
-    Depends,
-    HTTPException,
-    Query,
-    Request,
-    Response,
-    status,
-)
+from fastapi import APIRouter, Depends, HTTPException, Query, Response, status
 from fastapi.responses import PlainTextResponse
 from safir.sentry import report_exception
 from safir.slack.webhook import SlackRouteErrorHandler
@@ -42,7 +34,6 @@ __all__ = ["router"]
 async def get_gms(
     group: Annotated[list[str] | None, Query()] = None,
     *,
-    request: Request,
     response: Response,
     auth_data: Annotated[TokenData, Depends(AuthenticateRead())],
     context: Annotated[RequestContext, Depends(context_dependency)],
@@ -79,6 +70,6 @@ async def get_gms(
     seen = {g.name for g in user_info.groups}
     matching = seen & wanted if wanted else seen
     if matching:
-        return "\n".join(sorted(matching)) + "\n"
+        return "\r\n".join(sorted(matching)) + "\r\n"
     else:
         return ""

--- a/src/gafaelfawr/handlers/gms.py
+++ b/src/gafaelfawr/handlers/gms.py
@@ -1,0 +1,84 @@
+"""Route handlers for the IVOA GMS protocol."""
+
+from datetime import UTC, datetime, timedelta
+from email.utils import format_datetime
+from typing import Annotated
+
+from fastapi import (
+    APIRouter,
+    Depends,
+    HTTPException,
+    Query,
+    Request,
+    Response,
+    status,
+)
+from fastapi.responses import PlainTextResponse
+from safir.sentry import report_exception
+from safir.slack.webhook import SlackRouteErrorHandler
+
+from ..constants import LDAP_CACHE_LIFETIME
+from ..dependencies.auth import AuthenticateRead
+from ..dependencies.context import RequestContext, context_dependency
+from ..exceptions import ExternalUserInfoError
+from ..models.token import TokenData
+
+router = APIRouter(route_class=SlackRouteErrorHandler)
+"""Router for GMS routes."""
+
+__all__ = ["router"]
+
+
+@router.get(
+    "/auth/gms",
+    description=(
+        "Get group information in IVOA GMS format for the authenticated user"
+    ),
+    response_class=PlainTextResponse,
+    responses={401: {"description": "Unauthenticated"}},
+    summary="Get user groups",
+    tags=["user"],
+)
+async def get_gms(
+    group: Annotated[list[str] | None, Query()] = None,
+    *,
+    request: Request,
+    response: Response,
+    auth_data: Annotated[TokenData, Depends(AuthenticateRead())],
+    context: Annotated[RequestContext, Depends(context_dependency)],
+) -> str:
+    wanted = set(group) if group else None
+
+    # Get the user information.
+    user_info_service = context.factory.create_user_info_service()
+    try:
+        user_info = await user_info_service.get_user_info_from_token(auth_data)
+    except ExternalUserInfoError as e:
+        msg = "Unable to get user information"
+        context.logger.exception(msg, error=str(e))
+        slack_client = context.factory.create_slack_client()
+        await report_exception(e, slack_client=slack_client)
+        raise HTTPException(
+            headers={"Cache-Control": "no-cache, no-store"},
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=[{"msg": msg, "type": "user_info_failed"}],
+        ) from e
+
+    # Set the Expires header on the response to reflect our caching interval
+    # for groups. Use the LDAP cache lifetime unconditionally, even if
+    # configured to use GitHub, for simplicity. The worst consequence would be
+    # some additional client requests, and this handler should be very fast.
+    expires = datetime.now(tz=UTC) + timedelta(seconds=LDAP_CACHE_LIFETIME)
+    response.headers["Expires"] = format_datetime(expires, usegmt=True)
+
+    # Construct the response. If no groups are provided, list all of the
+    # user's groups. If groups are provided, only list the intersection
+    # between that list of groups and the user's groups. Each group line must
+    # end with a newline, but if there are no matching groups, the body must
+    # be completely empty.
+    seen = {g.name for g in user_info.groups}
+    matching = seen & wanted if wanted else seen
+    if matching:
+        return "\n".join(sorted(matching)) + "\n"
+    else:
+        return ""

--- a/src/gafaelfawr/main.py
+++ b/src/gafaelfawr/main.py
@@ -23,7 +23,7 @@ from .constants import COOKIE_NAME
 from .dependencies.config import config_dependency
 from .dependencies.context import context_dependency
 from .exceptions import DatabaseSchemaError
-from .handlers import api, ingress, internal, login, logout, oidc
+from .handlers import api, gms, ingress, internal, login, logout, oidc
 from .middleware.state import StateMiddleware
 from .models.state import State
 
@@ -141,6 +141,7 @@ def create_app(
             403: {"description": "Permission denied", "model": ErrorModel},
         },
     )
+    app.include_router(gms.router)
     app.include_router(ingress.router)
     app.include_router(internal.router)
     app.include_router(login.router)

--- a/tests/handlers/gms_test.py
+++ b/tests/handlers/gms_test.py
@@ -1,0 +1,79 @@
+"""Tests for the IVOA GMS protocol."""
+
+import pytest
+from httpx import AsyncClient
+
+from gafaelfawr.factory import Factory
+from gafaelfawr.models.token import TokenUserInfo
+from gafaelfawr.models.userinfo import Group
+
+from ..support.cookies import set_session_cookie
+
+
+@pytest.mark.asyncio
+async def test_gms(client: AsyncClient, factory: Factory) -> None:
+    user_info = TokenUserInfo(
+        username="example",
+        uid=1234,
+        groups=[Group(name="foo", id=1111), Group(name="foobar", id=1112)],
+    )
+    token_service = factory.create_token_service()
+    session_token = await token_service.create_session_token(
+        user_info, scopes=set(), ip_address="127.0.0.1"
+    )
+
+    r = await client.get(
+        "/auth/gms", headers={"Authorization": f"Bearer {session_token}"}
+    )
+    assert r.status_code == 200
+    assert r.text == "foo\nfoobar\n"
+
+    r = await client.get(
+        "/auth/gms",
+        params=(("group", "foo"), ("group", "foobar")),
+        headers={"Authorization": f"Bearer {session_token}"},
+    )
+    assert r.status_code == 200
+    assert r.text == "foo\nfoobar\n"
+
+    # Remaining tests are done using cookie authentication.
+    await set_session_cookie(client, session_token)
+
+    r = await client.get(
+        "/auth/gms", params=(("group", "foo"), ("group", "bar"))
+    )
+    assert r.status_code == 200
+    assert r.text == "foo\n"
+
+    r = await client.get("/auth/gms", params={"group": "bar"})
+    assert r.status_code == 200
+    assert r.text == ""
+
+
+@pytest.mark.asyncio
+async def test_no_groups(client: AsyncClient, factory: Factory) -> None:
+    user_info = TokenUserInfo(username="example", uid=1234)
+    token_service = factory.create_token_service()
+    session_token = await token_service.create_session_token(
+        user_info, scopes=set(), ip_address="127.0.0.1"
+    )
+
+    r = await client.get(
+        "/auth/gms", headers={"Authorization": f"Bearer {session_token}"}
+    )
+    assert r.status_code == 200
+    assert r.text == ""
+
+    r = await client.get(
+        "/auth/gms",
+        params={"group": "foo"},
+        headers={"Authorization": f"Bearer {session_token}"},
+    )
+    assert r.status_code == 200
+    assert r.text == ""
+
+
+@pytest.mark.asyncio
+async def test_auth_required(client: AsyncClient) -> None:
+    r = await client.get("/auth/gms")
+    assert r.status_code == 401

--- a/tests/handlers/gms_test.py
+++ b/tests/handlers/gms_test.py
@@ -26,7 +26,7 @@ async def test_gms(client: AsyncClient, factory: Factory) -> None:
         "/auth/gms", headers={"Authorization": f"Bearer {session_token}"}
     )
     assert r.status_code == 200
-    assert r.text == "foo\nfoobar\n"
+    assert r.text == "foo\r\nfoobar\r\n"
 
     r = await client.get(
         "/auth/gms",
@@ -34,7 +34,7 @@ async def test_gms(client: AsyncClient, factory: Factory) -> None:
         headers={"Authorization": f"Bearer {session_token}"},
     )
     assert r.status_code == 200
-    assert r.text == "foo\nfoobar\n"
+    assert r.text == "foo\r\nfoobar\r\n"
 
     # Remaining tests are done using cookie authentication.
     await set_session_cookie(client, session_token)
@@ -43,7 +43,7 @@ async def test_gms(client: AsyncClient, factory: Factory) -> None:
         "/auth/gms", params=(("group", "foo"), ("group", "bar"))
     )
     assert r.status_code == 200
-    assert r.text == "foo\n"
+    assert r.text == "foo\r\n"
 
     r = await client.get("/auth/gms", params={"group": "bar"})
     assert r.status_code == 200


### PR DESCRIPTION
Add an implementation of the IVOA GMS 1.0 protocol on the `/auth/gms` route. This is a simple protocol that allows IVOA services to determine the group membership of the current authenticated user.