### PR TITLE
DM-55193: Add an API to list all users in LDAP

### DIFF
--- a/changelog.d/20260609_145807_rra_DM_55193.md
+++ b/changelog.d/20260609_145807_rra_DM_55193.md
@@ -1,0 +1,3 @@
+### New features
+
+- Add new API at `/auth/api/v1/users` to list all users in LDAP, for sites using LDAP as the source of user identity.

--- a/src/gafaelfawr/handlers/api.py
+++ b/src/gafaelfawr/handlers/api.py
@@ -572,6 +572,28 @@ async def get_user_token_change_history(
 
 
 @router.get(
+    "/auth/api/v1/users",
+    response_model_exclude_defaults=True,
+    summary="List known users",
+    description=(
+        "Only information from LDAP is displayed. Bot users will not be"
+        " listed unless they also exist in LDAP. Gafaelfawr installations"
+        " using GitHub for authentication will return a 404 error since LDAP"
+        " is not configured."
+    ),
+    responses={404: {"description": "LDAP is not configured"}},
+    tags=["admin"],
+)
+async def list_users(
+    *,
+    auth_data: Annotated[TokenData, Depends(authenticate_read)],
+    context: Annotated[RequestContext, Depends(context_dependency)],
+) -> list[UserInfo]:
+    user_info_service = context.factory.create_user_info_service()
+    return await user_info_service.get_users_from_ldap(auth_data)
+
+
+@router.get(
     "/auth/api/v1/users/{username}",
     response_model_exclude_defaults=True,
     summary="Get user information",

--- a/src/gafaelfawr/services/firestore.py
+++ b/src/gafaelfawr/services/firestore.py
@@ -114,19 +114,33 @@ class FirestoreService:
             self._uid_cache.store(username, uid)
             return uid
 
-    async def get_uid_if_assigned(self, username: str) -> int | None:
+    async def get_uid_if_assigned(
+        self, username: str, *, uncached: bool = False
+    ) -> int | None:
         """Get the UID for a given user if one is assigned.
-
-        This method is never cached.
 
         Parameters
         ----------
         username
             Username of the user.
+        uncached
+            Bypass the cache.
 
         Returns
         -------
         int or None
             UID of the user if assigned or `None`.
         """
-        return await self._storage.get_uid_if_assigned(username)
+        if uncached:
+            return await self._storage.get_uid_if_assigned(username)
+        uid = self._uid_cache.get(username)
+        if uid:
+            return uid
+        async with self._uid_cache.lock():
+            uid = self._uid_cache.get(username)
+            if uid:
+                return uid
+            uid = await self._storage.get_uid_if_assigned(username)
+            if uid is not None:
+                self._uid_cache.store(username, uid)
+            return uid

--- a/src/gafaelfawr/services/firestore.py
+++ b/src/gafaelfawr/services/firestore.py
@@ -113,3 +113,20 @@ class FirestoreService:
             uid = await self._storage.get_uid(username, bot=bot)
             self._uid_cache.store(username, uid)
             return uid
+
+    async def get_uid_if_assigned(self, username: str) -> int | None:
+        """Get the UID for a given user if one is assigned.
+
+        This method is never cached.
+
+        Parameters
+        ----------
+        username
+            Username of the user.
+
+        Returns
+        -------
+        int or None
+            UID of the user if assigned or `None`.
+        """
+        return await self._storage.get_uid_if_assigned(username)

--- a/src/gafaelfawr/services/ldap.py
+++ b/src/gafaelfawr/services/ldap.py
@@ -46,6 +46,54 @@ class LDAPService:
         self._user_cache = user_cache
         self._logger = logger
 
+    async def get_all_users(self) -> dict[str, LDAPUserData]:
+        """List all users found in LDAP.
+
+        This operation is not cached.
+
+        Returns
+        -------
+        dict of LDAPUserData
+            Mappings of usernames to `~gafaelfawr.models.ldap.LDAPUserData`.
+        """
+        return await self._ldap.get_all_users()
+
+    @sentry_sdk.trace
+    async def get_data(
+        self,
+        username: str,
+        *,
+        uncached: bool = False,
+    ) -> LDAPUserData:
+        """Get configured data from LDAP.
+
+        Returns all data configured to be retrieved from LDAP.
+
+        Parameters
+        ----------
+        username
+            Username of the user.
+        uncached
+            Bypass the cache, used for health checks.
+
+        Returns
+        -------
+        LDAPUserData
+            The retrieved data.
+        """
+        if uncached:
+            return await self._ldap.get_data(username)
+        data = self._user_cache.get(username)
+        if data:
+            return data
+        async with await self._user_cache.lock(username):
+            data = self._user_cache.get(username)
+            if data:
+                return data
+            data = await self._ldap.get_data(username)
+            self._user_cache.store(username, data)
+            return data
+
     @sentry_sdk.trace
     async def get_group_names(
         self, username: str, gid: int | None, *, uncached: bool = False
@@ -93,13 +141,14 @@ class LDAPService:
         username
             Username for which to get information.
         gid
-            Primary GID if set.  If not `None`, the user's groups will be
-            checked for this GID.  If it's not found, search for the group
-            with this GID and add it to the user's group memberships.  This
-            handles LDAP configurations where the user's primary group is
-            represented only by their GID and not their group memberships.
+            Primary GID if set. If not `None`, the user's groups will be
+            checked for this GID. If it's not found, search for the group with
+            this GID and add it to the user's group memberships. This handles
+            LDAP configurations where the user's primary group is represented
+            only by their GID and not their group memberships.
         uncached
-            Bypass the cache, used for health checks.
+            Bypass the cache, used for health checks and when performing an
+            uncached operation such as listing all known users.
 
         Returns
         -------
@@ -123,42 +172,6 @@ class LDAPService:
             groups = await self._ldap.get_groups(username, gid)
             self._group_cache.store(username, groups)
             return groups
-
-    @sentry_sdk.trace
-    async def get_data(
-        self,
-        username: str,
-        *,
-        uncached: bool = False,
-    ) -> LDAPUserData:
-        """Get configured data from LDAP.
-
-        Returns all data configured to be retrieved from LDAP.
-
-        Parameters
-        ----------
-        username
-            Username of the user.
-        uncached
-            Bypass the cache, used for health checks.
-
-        Returns
-        -------
-        LDAPUserData
-            The retrieved data.
-        """
-        if uncached:
-            return await self._ldap.get_data(username)
-        data = self._user_cache.get(username)
-        if data:
-            return data
-        async with await self._user_cache.lock(username):
-            data = self._user_cache.get(username)
-            if data:
-                return data
-            data = await self._ldap.get_data(username)
-            self._user_cache.store(username, data)
-            return data
 
     async def invalidate_cache(self, username: str) -> None:
         """Invalidate the cache for a given user.

--- a/src/gafaelfawr/services/userinfo.py
+++ b/src/gafaelfawr/services/userinfo.py
@@ -90,8 +90,6 @@ class UserInfoService:
         information from LDAP and (optionally) Firestore, and therefore is not
         useful or supported when LDAP is not configured.
 
-        Authorization must be handled by the caller.
-
         Parameters
         ----------
         auth_data
@@ -126,7 +124,9 @@ class UserInfoService:
         # just be a typo from an admin trying to get user information.
         ldap_data = await self._ldap.get_data(username)
 
-        # Get the UID and GID from firestore if it is configured.
+        # Get the UID and GID from firestore if it is configured. The value of
+        # ldap_data may be a pointer to a cached object, so take special care
+        # not to modify it.
         uid = None
         gid = None
         if self._firestore and not ldap_data.is_empty():
@@ -226,6 +226,87 @@ class UserInfoService:
             groups=sorted(groups, key=lambda g: g.name),
             quota=await self._calculate_quota(groups),
         )
+
+    async def get_users_from_ldap(
+        self, auth_data: TokenData
+    ) -> list[UserInfo]:
+        """List all users found in LDAP.
+
+        This will not include any override information from tokens, only the
+        information from LDAP and (optionally) Firestore, and therefore is not
+        useful or supported when LDAP is not configured. UIDs and primary GIDs
+        will only be present if they have already been allocated by Firestore,
+        but all groups will have GIDs allocated.
+
+        Authorization must be handled by the caller.
+
+        Parameters
+        ----------
+        auth_data
+            Authenticated user making the request.
+
+        Returns
+        -------
+        list of UserInfo
+            User information for all users found in LDAP.
+
+        Raises
+        ------
+        FirestoreError
+            Raised if UID/GID allocation using Firestore failed.
+        LDAPError
+            Raised if the attempt to get user information from LDAP failed.
+        NotConfiguredError
+            Raised if LDAP is not configured.
+        PermissionDeniedError
+            Raised if the authenticated user does not have access to retrieve
+            user information for this user.
+        """
+        if not self._ldap:
+            msg = "No external user information source configured"
+            raise NotConfiguredError(msg)
+        self._check_authorization(auth_data)
+
+        # Retrieve all users found in LDAP.
+        users = await self._ldap.get_all_users()
+
+        # Flesh out the data for each user.
+        results = []
+        for username, data in users.items():
+            user = UserInfo(
+                username=username,
+                name=data.name,
+                email=data.email,
+                uid=data.uid,
+                gid=data.gid,
+            )
+
+            # Get UID and GID from Firestore if configured, but without
+            # assigning a new one.
+            if self._firestore:
+                user.uid = await self._firestore.get_uid_if_assigned(username)
+                if self._config.add_user_group:
+                    user.gid = user.uid
+
+            # Get groups from LDAP. This is one LDAP query per user, which is
+            # rather inefficient, but this method is infrequently called and
+            # only by admins, so don't bother optimizing for now.
+            groups = await self._get_groups_from_ldap(
+                username, user.uid, user.gid, uncached=True
+            )
+            user.groups = sorted(groups, key=lambda g: g.name)
+
+            # If the primary GID isn't set and we're adding a user private
+            # group, set the primary GID to the same as the UID.
+            if not user.gid and self._config.add_user_group:
+                user.gid = user.uid
+
+            # Add this user to the results.
+            results.append(user)
+
+        # Return the results. Do not include quota information. The client
+        # must retrieve the full user record if it wants that.
+        return sorted(results, key=lambda r: r.username)
 
     async def get_scopes(self, user_info: TokenUserInfo) -> set[str] | None:
         """Get scopes from user information.
@@ -365,7 +446,7 @@ class UserInfoService:
             )
 
     def _check_authorization(
-        self, auth_data: TokenData, username: str
+        self, auth_data: TokenData, username: str | None = None
     ) -> None:
         """Check authorization for performing an action.
 
@@ -374,7 +455,8 @@ class UserInfoService:
         auth_data
             Aauthenticated user performing the action.
         username
-            User whose user information will be returned.
+            User whose user information will be returned, or `None` if all
+            users are being retrieved.
 
         Raises
         ------
@@ -383,7 +465,7 @@ class UserInfoService:
             manipulate tokens for that user.
         """
         is_admin = "admin:userinfo" in auth_data.scopes
-        if username != auth_data.username and not is_admin:
+        if (username != auth_data.username or not username) and not is_admin:
             msg = f"Cannot get information for user {username}"
             self._logger.warning("Permission denied", error=msg)
             raise PermissionDeniedError(msg)

--- a/src/gafaelfawr/storage/firestore.py
+++ b/src/gafaelfawr/storage/firestore.py
@@ -166,6 +166,30 @@ class FirestoreStorage:
             raise FirestoreError(f"{type(e).__name__}: {e!s}") from e
 
     @_convert_exception
+    async def get_uid_if_assigned(self, username: str) -> int | None:
+        """Get the UID for a user if assigned.
+
+        Parameters
+        ----------
+        username
+            Name of the user.
+
+        Returns
+        -------
+        int or None
+            UID of the user or `None` if none was assigned.
+
+        Raises
+        ------
+        FirestoreAPIError
+            Raised if some error occurs talking to Firestore.
+        FirestoreNotInitializedError
+            Raised if Firestore has not been initialized.
+        """
+        user = await self._client.collection("users").document(username).get()
+        return user.get("uid") if user.exists else None
+
+    @_convert_exception
     async def initialize(self) -> None:
         """Initialize a Firestore document store for UID/GID assignment.
 
@@ -305,6 +329,44 @@ async def _get_or_assign_uid(
     transaction.update(counter_ref, {"next": next_uid + 1})
     logger.info("Assigned new UID", user=username, uid=next_uid)
     return next_uid
+
+
+@firestore.async_transactional
+async def _get_uid(
+    transaction: firestore.AsyncTransaction,
+    *,
+    username: str,
+    user_ref: firestore.AsyncDocumentReference,
+    logger: BoundLogger,
+) -> int | None:
+    """Get a UID for a user in a transaction.
+
+    Parameters
+    ----------
+    transaction
+        The open transaction.
+    username
+        Username of user, for logging.
+    user_ref
+        Reference to the user's (possibly nonexistent) UID document.
+    logger
+        Logger for messages.
+
+    Returns
+    -------
+    int
+        UID of the user.
+
+    Raises
+    ------
+    FirestoreNotInitializedError
+        Raised if Firestore has not been initialized.
+    """
+    user = await user_ref.get(transaction=transaction)
+    if user.exists:
+        return user.get("uid")
+    else:
+        return None
 
 
 @firestore.async_transactional

--- a/src/gafaelfawr/storage/ldap.py
+++ b/src/gafaelfawr/storage/ldap.py
@@ -38,6 +38,105 @@ class LDAPStorage:
         self._pool = pool
         self._logger = logger.bind(ldap_url=str(self._config.url))
 
+    async def get_all_users(self) -> dict[str, LDAPUserData]:
+        """List all users found in LDAP.
+
+        This operation is not cached.
+
+        Returns
+        -------
+        dict of LDAPUserData
+            Mapping from usernames to `~gafaelfawr.models.ldap.LDAPUserData`.
+
+        Raises
+        ------
+        LDAPError
+            Raised if the lookup of ``user_search_attr`` at ``user_base_dn``
+            in the LDAP server was not valid (connection to the LDAP server
+            failed, attribute not found in LDAP, UID result value not an
+            integer).
+        """
+        if not self._config.user_base_dn:
+            return {}
+
+        # Perform the LDAP search.
+        search = f"({self._config.user_search_attr}=*)"
+        logger = self._logger.bind(ldap_search=search)
+        results = await self._query(
+            base=self._config.user_base_dn,
+            scope=bonsai.LDAPSearchScope.ONE,
+            filter_exp=search,
+            attrlist=[
+                self._config.user_search_attr,
+                *self._build_user_search_attrs(),
+            ],
+        )
+        logger.debug("LDAP entries for user data", ldap_results=results)
+
+        # Transform the resulting data.
+        users = {}
+        for result in results:
+            try:
+                if self._config.user_search_attr in result:
+                    username = result[self._config.user_search_attr][0]
+                else:
+                    logger.debug(
+                        "Ignoring LDAP entry with missing attribute",
+                        user_search_attr=self._config.user_search_attr,
+                    )
+                    continue
+                user = self._build_user_from_result(username, result, logger)
+                users[username] = user
+            except LDAPError as e:
+                logger.debug("Ignoring invalid LDAP user entry", error=str(e))
+
+        # Return the results.
+        return users
+
+    @sentry_sdk.trace
+    async def get_data(self, username: str) -> LDAPUserData:
+        """Get the data for an LDAP user.
+
+        Parameters
+        ----------
+        username
+            Username of the user.
+
+        Returns
+        -------
+        LDAPUserData
+            The data for an LDAP user.  Which fields are filled in will be
+            determined by the configuration.
+
+        Raises
+        ------
+        LDAPError
+            Raised if the lookup of ``user_search_attr`` at ``user_base_dn``
+            in the LDAP server was not valid (connection to the LDAP server
+            failed, attribute not found in LDAP, UID result value not an
+            integer).
+        """
+        if not self._config.user_base_dn:
+            return LDAPUserData(name=None, email=None, uid=None, gid=None)
+
+        search = f"({self._config.user_search_attr}={username})"
+        logger = self._logger.bind(ldap_search=search, user=username)
+        results = await self._query(
+            base=self._config.user_base_dn,
+            scope=bonsai.LDAPSearchScope.ONE,
+            filter_exp=search,
+            attrlist=self._build_user_search_attrs(),
+            username=username,
+        )
+        logger.debug("LDAP entries for user data", ldap_results=results)
+
+        # If results are empty, return no data.
+        if not results:
+            return LDAPUserData(name=None, email=None, uid=None, gid=None)
+
+        # Extract data from the result.
+        return self._build_user_from_result(username, results[0], logger)
+
     @sentry_sdk.trace
     async def get_group_names(
         self, username: str, primary_gid: int | None
@@ -121,68 +220,6 @@ class LDAPStorage:
 
         return groups
 
-    @sentry_sdk.trace
-    async def get_data(self, username: str) -> LDAPUserData:
-        """Get the data for an LDAP user.
-
-        Parameters
-        ----------
-        username
-            Username of the user.
-
-        Returns
-        -------
-        LDAPUserData
-            The data for an LDAP user.  Which fields are filled in will be
-            determined by the configuration.
-
-        Raises
-        ------
-        LDAPError
-            Raised if the lookup of ``user_search_attr`` at ``user_base_dn``
-            in the LDAP server was not valid (connection to the LDAP server
-            failed, attribute not found in LDAP, UID result value not an
-            integer).
-        """
-        if not self._config.user_base_dn:
-            return LDAPUserData(name=None, email=None, uid=None, gid=None)
-
-        search = f"({self._config.user_search_attr}={username})"
-        logger = self._logger.bind(ldap_search=search, user=username)
-        results = await self._query(
-            self._config.user_base_dn,
-            bonsai.LDAPSearchScope.ONE,
-            search,
-            self._build_user_search_attrs(),
-            username,
-        )
-        logger.debug("LDAP entries for user data", ldap_results=results)
-
-        # If results are empty, return no data.
-        if not results:
-            return LDAPUserData(name=None, email=None, uid=None, gid=None)
-        result = results[0]
-
-        # Extract data from the result.
-        try:
-            name = None
-            email = None
-            uid = None
-            gid = None
-            if self._config.name_attr and self._config.name_attr in result:
-                name = result[self._config.name_attr][0]
-            if self._config.email_attr and self._config.email_attr in result:
-                email = result[self._config.email_attr][0]
-            if self._config.uid_attr and self._config.uid_attr in result:
-                uid = int(result[self._config.uid_attr][0])
-            if self._config.gid_attr and self._config.gid_attr in result:
-                gid = int(result[self._config.gid_attr][0])
-            return LDAPUserData(name=name, email=email, uid=uid, gid=gid)
-        except Exception as e:
-            msg = "LDAP user entry invalid"
-            logger.exception(msg, error=str(e))
-            raise LDAPError(msg, username) from e
-
     def _build_group_member_search(self, username: str) -> str:
         """Build the LDAP search to find group memberships for a user.
 
@@ -205,6 +242,50 @@ class LDAPStorage:
         else:
             target = username
         return f"(&(objectClass={group_class})({member_attr}={target}))"
+
+    def _build_user_from_result(
+        self, username: str, result: dict[str, list[str]], logger: BoundLogger
+    ) -> LDAPUserData:
+        """Construct a user record from a result.
+
+        Parameters
+        ----------
+        username
+            Username of record, for error reporting.
+        result
+            Raw result from LDAP.
+        logger
+            Logger to use.
+
+        Returns
+        -------
+        LDAPUserData
+            Corresponding user record.
+
+        Raises
+        ------
+        LDAPError
+            Raised if the result entry could not be parsed into a valid
+            result.
+        """
+        try:
+            name = None
+            email = None
+            uid = None
+            gid = None
+            if self._config.name_attr and self._config.name_attr in result:
+                name = result[self._config.name_attr][0]
+            if self._config.email_attr and self._config.email_attr in result:
+                email = result[self._config.email_attr][0]
+            if self._config.uid_attr and self._config.uid_attr in result:
+                uid = int(result[self._config.uid_attr][0])
+            if self._config.gid_attr and self._config.gid_attr in result:
+                gid = int(result[self._config.gid_attr][0])
+            return LDAPUserData(name=name, email=email, uid=uid, gid=gid)
+        except Exception as e:
+            msg = "LDAP user entry invalid"
+            logger.exception(msg, error=f"{type(e).__name__}: {e!s}")
+            raise LDAPError(msg, username) from e
 
     def _build_user_search_attrs(self) -> list[str]:
         """Construct the list of user attributes to search for."""
@@ -243,11 +324,11 @@ class LDAPStorage:
         search = f"(&(objectClass={group_class})(gidNumber={gid}))"
         logger = self._logger.bind(ldap_search=search, user=username)
         results = await self._query(
-            self._config.group_base_dn,
-            bonsai.LDAPSearchScope.SUB,
-            search,
-            ["cn"],
-            username,
+            base=self._config.group_base_dn,
+            scope=bonsai.LDAPSearchScope.SUB,
+            filter_exp=search,
+            attrlist=["cn"],
+            username=username,
         )
         logger.debug(
             "Results for primary group", gid=gid, ldap_results=results
@@ -288,11 +369,11 @@ class LDAPStorage:
         search = self._build_group_member_search(username)
         logger = self._logger.bind(ldap_search=search, user=username)
         results = await self._query(
-            self._config.group_base_dn,
-            bonsai.LDAPSearchScope.SUB,
-            search,
-            attrs,
-            username,
+            base=self._config.group_base_dn,
+            scope=bonsai.LDAPSearchScope.SUB,
+            filter_exp=search,
+            attrlist=attrs,
+            username=username,
         )
         logger.debug("LDAP groups found", ldap_results=results)
 
@@ -315,11 +396,12 @@ class LDAPStorage:
 
     async def _query(
         self,
+        *,
         base: str,
         scope: LDAPSearchScope,
         filter_exp: str,
         attrlist: list[str],
-        username: str,
+        username: str | None = None,
     ) -> list[dict[str, list[str]]]:
         """Perform an LDAP query using the connection pool.
 
@@ -334,7 +416,8 @@ class LDAPStorage:
         attrlist
             List of attributes to retrieve.
         username
-            User for which the query is being performed, for error reporting.
+            User for which the query is being performed, if any, for error
+            reporting.
 
         Returns
         -------
@@ -363,11 +446,10 @@ class LDAPStorage:
         clear whether that's true if there are other active coroutines.
         """
         logger = self._logger.bind(
-            ldap_attrs=attrlist,
-            ldap_base=base,
-            ldap_search=filter_exp,
-            user=username,
+            ldap_attrs=attrlist, ldap_base=base, ldap_search=filter_exp
         )
+        if username:
+            logger = logger.bind(user=username)
 
         try:
             for _ in range(2):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -40,6 +40,15 @@ every configuration file.
 """
 
 
+def pytest_addoption(parser: pytest.Parser) -> None:
+    parser.addoption(
+        "--update-test-data",
+        action="store_true",
+        default=False,
+        help="Overwrite expected test output with current results",
+    )
+
+
 @pytest.fixture(autouse=True)
 def environment(monkeypatch: pytest.MonkeyPatch) -> None:
     """Set default values of environment variables for testing."""
@@ -142,8 +151,9 @@ def config(
 
 
 @pytest.fixture
-def data() -> Data:
-    return Data(Path(__file__).parent / "data")
+def data(request: pytest.FixtureRequest) -> Data:
+    update = request.config.getoption("--update-test-data")
+    return Data(Path(__file__).parent / "data", update_test_data=update)
 
 
 @pytest_asyncio.fixture

--- a/tests/data/api/users-firestore.json
+++ b/tests/data/api/users-firestore.json
@@ -1,0 +1,55 @@
+[
+  {
+    "email": "ldap-user@example.com",
+    "gid": 3000000,
+    "groups": [
+      {
+        "id": 3000000,
+        "name": "99digits99"
+      },
+      {
+        "id": 2000000,
+        "name": "foo"
+      },
+      {
+        "id": 2000001,
+        "name": "group-1"
+      },
+      {
+        "id": 2000002,
+        "name": "group-2"
+      }
+    ],
+    "name": "LDAP User",
+    "uid": 3000000,
+    "username": "99digits99"
+  },
+  {
+    "groups": [
+      {
+        "id": 2000001,
+        "name": "group-1"
+      }
+    ],
+    "username": "ldap-user"
+  },
+  {
+    "gid": 3000001,
+    "groups": [
+      {
+        "id": 2000000,
+        "name": "foo"
+      },
+      {
+        "id": 3000001,
+        "name": "some-user"
+      }
+    ],
+    "name": "\u540d\u5b57",
+    "uid": 3000001,
+    "username": "some-user"
+  },
+  {
+    "username": "unknown-user"
+  }
+]

--- a/tests/data/api/users-unallocated.json
+++ b/tests/data/api/users-unallocated.json
@@ -1,0 +1,43 @@
+[
+  {
+    "email": "ldap-user@example.com",
+    "groups": [
+      {
+        "id": 2000000,
+        "name": "foo"
+      },
+      {
+        "id": 2000001,
+        "name": "group-1"
+      },
+      {
+        "id": 2000002,
+        "name": "group-2"
+      }
+    ],
+    "name": "LDAP User",
+    "username": "99digits99"
+  },
+  {
+    "groups": [
+      {
+        "id": 2000001,
+        "name": "group-1"
+      }
+    ],
+    "username": "ldap-user"
+  },
+  {
+    "groups": [
+      {
+        "id": 2000000,
+        "name": "foo"
+      }
+    ],
+    "name": "\u540d\u5b57",
+    "username": "some-user"
+  },
+  {
+    "username": "unknown-user"
+  }
+]

--- a/tests/data/api/users.json
+++ b/tests/data/api/users.json
@@ -1,0 +1,51 @@
+[
+  {
+    "email": "ldap-user@example.com",
+    "gid": 1045,
+    "groups": [
+      {
+        "id": 1222,
+        "name": "foo"
+      },
+      {
+        "id": 1223,
+        "name": "group-1"
+      },
+      {
+        "id": 1224,
+        "name": "group-2"
+      }
+    ],
+    "name": "LDAP User",
+    "uid": 1999,
+    "username": "99digits99"
+  },
+  {
+    "gid": 1045,
+    "groups": [
+      {
+        "id": 1223,
+        "name": "group-1"
+      }
+    ],
+    "uid": 2002,
+    "username": "ldap-user"
+  },
+  {
+    "gid": 1045,
+    "groups": [
+      {
+        "id": 1222,
+        "name": "foo"
+      }
+    ],
+    "name": "\u540d\u5b57",
+    "uid": 2000,
+    "username": "some-user"
+  },
+  {
+    "gid": 1045,
+    "uid": 2001,
+    "username": "unknown-user"
+  }
+]

--- a/tests/data/ldap/users.json
+++ b/tests/data/ldap/users.json
@@ -1,0 +1,55 @@
+{
+  "users": [
+    {
+      "username": "99digits99",
+      "name": "LDAP User",
+      "email": "ldap-user@example.com",
+      "uid": 1999,
+      "gid": 1045
+    },
+    {
+      "username": "ldap-user",
+      "uid": 2002,
+      "gid": 1045
+    },
+    {
+      "username": "some-user",
+      "name": "名字",
+      "uid": 2000,
+      "gid": 1045
+    },
+    {
+      "username": "unknown-user",
+      "uid": 2001,
+      "gid": 1045
+    }
+  ],
+  "membership": {
+    "99digits99": [
+      {
+        "name": "foo",
+        "id": 1222
+      },
+      {
+        "name": "group-1",
+        "id": 1223
+      },
+      {
+        "name": "group-2",
+        "id": 1224
+      }
+    ],
+    "ldap-user": [
+      {
+        "name": "group-1",
+        "id": 1223
+      }
+    ],
+    "some-user": [
+      {
+        "name": "foo",
+        "id": 1222
+      }
+    ]
+  }
+}

--- a/tests/handlers/api_users_test.py
+++ b/tests/handlers/api_users_test.py
@@ -1,11 +1,14 @@
 """Tests for the user information API."""
 
 import pytest
+import pytest_asyncio
 from httpx import AsyncClient
+from safir.testing.data import Data
 
 from gafaelfawr.config import Config
 from gafaelfawr.constants import GID_MIN, UID_USER_MIN
 from gafaelfawr.factory import Factory
+from gafaelfawr.models.token import TokenData
 from gafaelfawr.models.userinfo import Group, UserInfo
 
 from ..support.firestore import MockFirestore
@@ -13,20 +16,74 @@ from ..support.ldap import MockLDAP
 from ..support.tokens import create_session_token
 
 
+@pytest_asyncio.fixture
+async def admin_token(factory: Factory) -> TokenData:
+    return await create_session_token(
+        factory, username="admin", scopes={"admin:userinfo"}
+    )
+
+
+@pytest.mark.parametrize("config", ["oidc"], indirect=True)
+@pytest.mark.asyncio
+async def test_list_users(
+    *,
+    data: Data,
+    admin_token: TokenData,
+    client: AsyncClient,
+    mock_ldap: MockLDAP,
+) -> None:
+    headers = {"Authorization": f"Bearer {admin_token.token}"}
+    mock_ldap.load_test_data(data, "ldap/users")
+
+    r = await client.get("/auth/api/v1/users", headers=headers)
+    assert r.status_code == 200
+    assert r.json()
+    data.assert_json_matches(r.json(), "api/users")
+
+
+@pytest.mark.parametrize("config", ["oidc-firestore"], indirect=True)
+@pytest.mark.asyncio
+async def test_list_users_firestore(
+    *,
+    data: Data,
+    admin_token: TokenData,
+    client: AsyncClient,
+    mock_ldap: MockLDAP,
+) -> None:
+    headers = {"Authorization": f"Bearer {admin_token.token}"}
+    mock_ldap.load_test_data(data, "ldap/users")
+
+    # Initially, there will be GIDs for the explicitly listed groups, but not
+    # UIDs or GIDs for any of the users since no entries exist in Firestore.
+    r = await client.get("/auth/api/v1/users", headers=headers)
+    assert r.status_code == 200
+    data.assert_json_matches(r.json(), "api/users-unallocated")
+
+    # Force UID allocation for each of the users.
+    for user in data.read_json("api/users-unallocated"):
+        username = user["username"]
+        r = await client.get(f"/auth/api/v1/users/{username}", headers=headers)
+        assert r.status_code == 200
+
+    # Now, there should be UIDs and GIDs for all of the users that have any
+    # LDAP attributes.
+    r = await client.get("/auth/api/v1/users", headers=headers)
+    assert r.status_code == 200
+    data.assert_json_matches(r.json(), "api/users-firestore")
+
+
 @pytest.mark.parametrize("config", ["oidc"], indirect=True)
 @pytest.mark.asyncio
 async def test_userinfo_basic(
     *,
     config: Config,
+    admin_token: TokenData,
     client: AsyncClient,
     factory: Factory,
     mock_ldap: MockLDAP,
 ) -> None:
     assert config.ldap
-    token_data = await create_session_token(
-        factory, username="admin", scopes={"admin:userinfo"}
-    )
-    headers = {"Authorization": f"bearer {token_data.token}"}
+    headers = {"Authorization": f"bearer {admin_token.token}"}
     mock_ldap.add_test_user(
         UserInfo(username="some-user", name="Some user", uid=2000, gid=1045)
     )
@@ -48,9 +105,11 @@ async def test_userinfo_basic(
 
     # Getting the information for the admin user should return just the
     # username since the user doesn't exist in LDAP.
-    r = await client.get("/auth/api/v1/users/admin", headers=headers)
+    r = await client.get(
+        f"/auth/api/v1/users/{admin_token.username}", headers=headers
+    )
     assert r.status_code == 200
-    assert r.json() == {"username": "admin"}
+    assert r.json() == {"username": admin_token.username}
 
 
 @pytest.mark.parametrize("config", ["oidc-firestore"], indirect=True)
@@ -125,13 +184,19 @@ async def test_userinfo_firestore(
 
 
 @pytest.mark.asyncio
-async def test_userinfo_github(client: AsyncClient, factory: Factory) -> None:
-    token_data = await create_session_token(factory, scopes={"admin:userinfo"})
+async def test_userinfo_github(
+    admin_token: TokenData, client: AsyncClient, factory: Factory
+) -> None:
+    """Test GitHub handling of user listing endpoints.
 
-    # When configured with GitHub, any attempt to access the users endpoint
-    # directly should fail with 404.
-    r = await client.get(
-        f"/auth/api/v1/users/{token_data.username}",
-        headers={"Authorization": f"bearer {token_data.token}"},
-    )
+    When configured with GitHub, any attempt to access the users endpoint
+    directly should fail with 404.
+    """
+    username = admin_token.username
+    headers = {"Authorization": f"bearer {admin_token.token}"}
+
+    r = await client.get("/auth/api/v1/users", headers=headers)
+    assert r.status_code == 404
+
+    r = await client.get(f"/auth/api/v1/users/{username}", headers=headers)
     assert r.status_code == 404

--- a/tests/support/firestore.py
+++ b/tests/support/firestore.py
@@ -29,8 +29,11 @@ class MockDocumentRef(Mock):
         super().__init__(spec=firestore.AsyncDocumentReference)
         self.document: dict[str, Any] | None = None
 
-    async def get(self, *, transaction: MockTransaction) -> MockDocument:
-        assert isinstance(transaction, MockTransaction)
+    async def get(
+        self, *, transaction: MockTransaction | None = None
+    ) -> MockDocument:
+        if transaction:
+            assert isinstance(transaction, MockTransaction)
         return MockDocument(self.document)
 
     def get_for_testing(self) -> MockDocument:

--- a/tests/support/ldap.py
+++ b/tests/support/ldap.py
@@ -9,6 +9,7 @@ from unittest.mock import Mock, patch
 
 import bonsai
 from bonsai.utils import escape_filter_exp
+from safir.testing.data import Data
 
 from gafaelfawr import factory
 from gafaelfawr.constants import LDAP_TIMEOUT
@@ -96,7 +97,7 @@ class MockLDAP(Mock):
         """
         config = config_dependency.config()
         assert config.ldap
-        entry = {}
+        entry = {config.ldap.user_search_attr: [userinfo.username]}
         if userinfo.name:
             entry[config.ldap.name_attr or "displayName"] = [userinfo.name]
         if userinfo.email:
@@ -111,6 +112,23 @@ class MockLDAP(Mock):
             userinfo.username,
             [entry],
         )
+
+    def load_test_data(self, data: Data, path: str) -> None:
+        """Load test data for users and groups.
+
+        Parameters
+        ----------
+        data
+            Test data management object.
+        path
+            Path to the test data file containing user and group information.
+        """
+        ldap_data = data.read_json(path)
+        for user in ldap_data.get("users"):
+            self.add_test_user(UserInfo.model_validate(user))
+        for username, group_data in ldap_data.get("membership").items():
+            groups = [Group.model_validate(g) for g in group_data]
+            self.add_test_group_membership(username, groups)
 
     async def close(self) -> None:
         pass
@@ -135,10 +153,22 @@ class MockLDAP(Mock):
         )
         assert match, f"{filter_exp} does not match regex of searches"
         key = (match.group(1), match.group(2))
+        results = []
+
+        # Handle wildcard searches.
+        if key[1] == "*":
+            for entry_key, entries in self._entries[base].items():
+                if entry_key[0] != key[0]:
+                    continue
+                for entry in entries:
+                    attributes = {a: entry[a] for a in attrlist if a in entry}
+                    results.append(attributes)
+            return results
+
+        # Otherwise, we're searching for a specific entry.
         if key not in self._entries[base]:
             return []
         entries = self._entries[base][key]
-        results = []
         for entry in entries:
             attributes = {a: entry[a] for a in attrlist if a in entry}
             results.append(attributes)


### PR DESCRIPTION
Similar to the API to get LDAP information for a specific user, add a new API at `/auth/api/v1/users` to list all users in LDAP. If Firestore is enabled, retrieve their UID and GID, but only if it is already allocated.