### PR TITLE
DM-55193: Add new list_groups client method

### DIFF
--- a/changelog.d/20260610_154737_rra_DM_55193.md
+++ b/changelog.d/20260610_154737_rra_DM_55193.md
@@ -1,0 +1,3 @@
+### New features
+
+- Add a new `list_groups` method to the client to retrieve all known groups from a Gafaelfawr server that uses LDAP as the user information source. This method requires a token with `admin:userinfo` scope. Also add the corresponding mock and a method to set the mock's return value.

--- a/client/src/rubin/gafaelfawr/__init__.py
+++ b/client/src/rubin/gafaelfawr/__init__.py
@@ -23,6 +23,7 @@ from ._mock import (
 )
 from ._models import (
     GafaelfawrGroup,
+    GafaelfawrGroups,
     GafaelfawrNotebookQuota,
     GafaelfawrQuota,
     GafaelfawrTapQuota,
@@ -36,6 +37,7 @@ __all__ = [
     "GafaelfawrDiscoveryError",
     "GafaelfawrError",
     "GafaelfawrGroup",
+    "GafaelfawrGroups",
     "GafaelfawrNotFoundError",
     "GafaelfawrNotebookQuota",
     "GafaelfawrQuota",

--- a/client/src/rubin/gafaelfawr/_client.py
+++ b/client/src/rubin/gafaelfawr/_client.py
@@ -20,6 +20,7 @@ from ._exceptions import (
 from ._models import (
     AdminTokenRequest,
     GafaelfawrGroup,
+    GafaelfawrGroups,
     GafaelfawrUserInfo,
     NewToken,
     TokenType,
@@ -243,6 +244,36 @@ class GafaelfawrClient:
                 userinfo = await self._get(url, GafaelfawrUserInfo, token)
                 self._userinfo_token_cache[token] = userinfo
                 return userinfo
+
+    async def list_groups(self, token: str) -> GafaelfawrGroups:
+        """List all known groups.
+
+        This method may only be called with a token with ``admin:userinfo``
+        scope, and group information is only available from a Gafaelfawr
+        instance that uses LDAP as a backing store for user information. Only
+        LDAP information will be returned, not any overrides present in
+        tokens.
+
+        Parameters
+        ----------
+        token
+            Gafaelfawr token used for authentication.
+
+        Raises
+        ------
+        GafaelfawrNotFoundError
+            Raised if the group list is not available, such as when Gafaelfawr
+            is not using LDAP as a source of user information.
+        GafaelfawrValidationError
+            Raised if the response from Gafaelfawr is invalid.
+        GafaelfawrWebError
+            Raised if there is some problem talking to the Gafaelfawr API,
+            such as an invalid token or network or service failure.
+        rubin.repertoire.RepertoireError
+            Raised if there was an error talking to service discovery.
+        """
+        url = await self._url_for("groups")
+        return await self._get(url, GafaelfawrGroups, token)
 
     async def _get[T: BaseModel](
         self, url: str, model: type[T], token: str

--- a/client/src/rubin/gafaelfawr/_mock.py
+++ b/client/src/rubin/gafaelfawr/_mock.py
@@ -12,7 +12,13 @@ from urllib.parse import urljoin
 from httpx import Request, Response
 from rubin.repertoire import DiscoveryClient
 
-from ._models import AdminTokenRequest, GafaelfawrUserInfo, NewToken, TokenData
+from ._models import (
+    AdminTokenRequest,
+    GafaelfawrGroups,
+    GafaelfawrUserInfo,
+    NewToken,
+    TokenData,
+)
 from ._tokens import create_token
 
 if TYPE_CHECKING:
@@ -39,6 +45,7 @@ class MockGafaelfawrAction(Enum):
     """Possible actions that could fail."""
 
     CREATE_TOKEN = "create_token"
+    LIST_GROUPS = "list_groups"
     USER_INFO = "user_info"
 
 
@@ -48,6 +55,7 @@ class MockGafaelfawr:
     def __init__(self) -> None:
         self._fail: defaultdict[str, set[MockGafaelfawrAction]]
         self._fail = defaultdict(set)
+        self._groups: GafaelfawrGroups | None = None
         self._tokens: dict[str, TokenData] = {}
         self._user_info: dict[str, GafaelfawrUserInfo | None] = {}
 
@@ -124,6 +132,8 @@ class MockGafaelfawr:
             Base URL for the mock routes.
         """
         prefix = base_url.rstrip("/") + "/"
+        handler = self._handle_groups
+        respx_mock.get(urljoin(prefix, "groups")).mock(side_effect=handler)
         handler = self._handle_user_info
         respx_mock.get(urljoin(prefix, "user-info")).mock(side_effect=handler)
         handler = self._handle_create_token
@@ -133,6 +143,16 @@ class MockGafaelfawr:
         base_regex = re.escape(base_url.rstrip("/"))
         regex = re.compile(base_regex + "/users/(?P<username>[^/]+)$")
         respx_mock.get(url__regex=regex).mock(side_effect=self._handle_user)
+
+    def set_groups(self, groups: GafaelfawrGroups) -> None:
+        """Set the group information returned when listing all groups.
+
+        Parameters
+        ----------
+        groups
+            Group information to return.
+        """
+        self._groups = groups
 
     def set_user_info(
         self, username: str, user_info: GafaelfawrUserInfo | None
@@ -232,6 +252,19 @@ class MockGafaelfawr:
         self.set_user_info(body.username, userinfo)
         response = NewToken(token=token)
         return Response(200, json=response.model_dump(mode="json"))
+
+    @_check(
+        fail_on=MockGafaelfawrAction.LIST_GROUPS,
+        required_scope="admin:userinfo",
+    )
+    def _handle_groups(
+        self, request: Request, token_data: TokenData
+    ) -> Response:
+        if groups := self._groups:
+            result = groups.model_dump(mode="json", exclude_defaults=True)
+            return Response(200, json=result)
+        else:
+            return Response(404)
 
     @_check(required_scope="admin:userinfo")
     def _handle_user(

--- a/client/src/rubin/gafaelfawr/_models.py
+++ b/client/src/rubin/gafaelfawr/_models.py
@@ -15,6 +15,7 @@ from pydantic import BaseModel, Field
 __all__ = [
     "AdminTokenRequest",
     "GafaelfawrGroup",
+    "GafaelfawrGroups",
     "GafaelfawrNotebookQuota",
     "GafaelfawrQuota",
     "GafaelfawrTapQuota",
@@ -31,6 +32,14 @@ class GafaelfawrGroup(BaseModel):
     name: Annotated[str, Field(title="Name of the group")]
 
     id: Annotated[int, Field(title="Numeric GID of the group")]
+
+
+class GafaelfawrGroups(BaseModel):
+    """List of all known groups."""
+
+    user: list[GafaelfawrGroup] = Field([], title="User-managed groups")
+
+    system: list[GafaelfawrGroup] = Field([], title="System groups")
 
 
 class GafaelfawrNotebookQuota(BaseModel):

--- a/client/tests/client_test.py
+++ b/client/tests/client_test.py
@@ -12,6 +12,7 @@ from rubin.gafaelfawr import (
     GafaelfawrClient,
     GafaelfawrDiscoveryError,
     GafaelfawrGroup,
+    GafaelfawrGroups,
     GafaelfawrNotFoundError,
     GafaelfawrUserInfo,
     GafaelfawrWebError,
@@ -167,3 +168,26 @@ async def test_cache_by_token(
     # Clearing the cache should result in the new data.
     await client.clear_cache()
     assert await client.get_user_info(token) == user_info
+
+
+@pytest.mark.asyncio
+async def test_list_groups(
+    data: Data, mock_gafaelfawr: MockGafaelfawr
+) -> None:
+    token = mock_gafaelfawr.create_token("admin", scopes=["admin:userinfo"])
+    client = GafaelfawrClient()
+
+    # If no data is available, should raise GafaelfawrNotFoundError.
+    with pytest.raises(GafaelfawrNotFoundError):
+        await client.list_groups(token)
+
+    # HTTP errors should raise GafaelfawrWebError.
+    mock_gafaelfawr.fail_on("admin", MockGafaelfawrAction.LIST_GROUPS)
+    with pytest.raises(GafaelfawrWebError):
+        await client.list_groups(token)
+
+    # Register some user information and try again.
+    mock_gafaelfawr.fail_on("admin", [])
+    groups = data.read_pydantic(GafaelfawrGroups, "userinfo/groups")
+    mock_gafaelfawr.set_groups(groups)
+    assert await client.list_groups(token) == groups

--- a/client/tests/data/userinfo/groups.json
+++ b/client/tests/data/userinfo/groups.json
@@ -1,0 +1,18 @@
+{
+  "system": [
+    {
+      "id": 1222,
+      "name": "foo"
+    }
+  ],
+  "user": [
+    {
+      "id": 1223,
+      "name": "group-1"
+    },
+    {
+      "id": 1224,
+      "name": "group-2"
+    }
+  ]
+}

--- a/client/tests/mock_test.py
+++ b/client/tests/mock_test.py
@@ -82,6 +82,11 @@ async def test_fail_on(data: Data, mock_gafaelfawr: MockGafaelfawr) -> None:
     with pytest.raises(GafaelfawrWebError) as exc_info:
         await client.create_service_token(admin_token, "bot-user", scopes=[])
 
+    # Check failure for retrieving a list of groups.
+    mock_gafaelfawr.fail_on("admin", MockGafaelfawrAction.LIST_GROUPS)
+    with pytest.raises(GafaelfawrWebError) as exc_info:
+        await client.list_groups(admin_token)
+
 
 @pytest.mark.asyncio
 async def test_missing_discovery(
@@ -105,10 +110,14 @@ async def test_required_scopes(
     mock_gafaelfawr.set_user_info("someuser", user_info)
 
     # A token without admin:userinfo should not be able to access the user
-    # route used by get_user_info with an explicit username.
+    # route used by get_user_info with an explicit username or list all
+    # groups.
     token = mock_gafaelfawr.create_token("otheruser")
     with pytest.raises(GafaelfawrWebError) as exc_info:
         await client.get_user_info(token, "someuser")
+    assert exc_info.value.status == 403
+    with pytest.raises(GafaelfawrWebError) as exc_info:
+        await client.list_groups(token)
     assert exc_info.value.status == 403
 
     # A token without admin:token should not be able to create a token.

--- a/docs/user-guide/client.rst
+++ b/docs/user-guide/client.rst
@@ -121,6 +121,23 @@ There are separate caches for retrieving user information by token and by userna
 
 To clear the cache and force any subsequent requests to go back to the Gafealfawr API, call `GafaelfawrClient.clear_cache`.
 
+Listing known groups
+--------------------
+
+Gafaelfawr instances that use LDAP as the source for user information support listing all groups known to the server.
+
+To obtain the group list, the application must have a token with ``admin:userinfo`` scope.
+Usually, it will obtain this token via a ``GafaelfawrServiceToken`` Kubernetes object (see :doc:`service-tokens`).
+
+Then, call `GafaelfawrClient.list_groups`, passing in that service token as the one argument.
+The result will be a `GafaelfawrGroups` object.
+
+The groups are classified into "user" and "system" groups based on the Gafaelfawr server configuration, where user groups are ones created or managed by users and system groups are ones used by the environment administrators.
+This allows clients that only want to act on user groups, such as a client that wants to create a collaboration space for every user group but not spaces for the large system groups, to distinguish between the types of groups.
+
+Gafaelfawr configurations that do not use LDAP for user information will raise `GafaelfawrNotFoundError` for requests to list groups.
+This does not imply that there are no groups, only that the list of groups cannot be retrieved.
+
 Creating service tokens
 =======================
 

--- a/src/gafaelfawr/models/userinfo.py
+++ b/src/gafaelfawr/models/userinfo.py
@@ -40,7 +40,7 @@ class AllGroups(BaseModel):
 
     user: list[Group] = Field(
         [],
-        title="User-created groups",
+        title="User-managed groups",
         description=(
             "Excludes any groups marked in the configuration as system groups."
             " Those will be in the system attribute."


### PR DESCRIPTION
Add a new `list_groups` method to the client to retrieve all known groups from a Gafaelfawr server that uses LDAP as the user information source. This method requires a token with `admin:userinfo` scope. Also add the corresponding mock and a method to set the mock's return value.