### PR TITLE
DM-55193: Add new list_users client method

### DIFF
--- a/changelog.d/20260610_154737_rra_DM_55193.md
+++ b/changelog.d/20260610_154737_rra_DM_55193.md
@@ -1,3 +1,3 @@
 ### New features
 
-- Add a new `list_groups` method to the client to retrieve all known groups from a Gafaelfawr server that uses LDAP as the user information source. This method requires a token with `admin:userinfo` scope. Also add the corresponding mock and a method to set the mock's return value.
+- Add new `list_groups` and `list_users` methods to the client to retrieve all known groups and users from a Gafaelfawr server that uses LDAP as the user information source. These methods require a token with `admin:userinfo` scope. Also add the corresponding mocks and a method to set the list of groups the mock should return.

--- a/client/src/rubin/gafaelfawr/_client.py
+++ b/client/src/rubin/gafaelfawr/_client.py
@@ -275,6 +275,36 @@ class GafaelfawrClient:
         url = await self._url_for("groups")
         return await self._get(url, GafaelfawrGroups, token)
 
+    async def list_users(self, token: str) -> list[GafaelfawrUserInfo]:
+        """List all known groups.
+
+        This method may only be called with a token with ``admin:userinfo``
+        scope, and user information is only available from a Gafaelfawr
+        instance that uses LDAP as a backing store for user information. Only
+        LDAP information will be returned, not any overrides present in
+        tokens or bot users created outside of LDAP.
+
+        Parameters
+        ----------
+        token
+            Gafaelfawr token used for authentication.
+
+        Raises
+        ------
+        GafaelfawrNotFoundError
+            Raised if the group list is not available, such as when Gafaelfawr
+            is not using LDAP as a source of user information.
+        GafaelfawrValidationError
+            Raised if the response from Gafaelfawr is invalid.
+        GafaelfawrWebError
+            Raised if there is some problem talking to the Gafaelfawr API,
+            such as an invalid token or network or service failure.
+        rubin.repertoire.RepertoireError
+            Raised if there was an error talking to service discovery.
+        """
+        url = await self._url_for("users")
+        return await self._get_list(url, GafaelfawrUserInfo, token)
+
     async def _get[T: BaseModel](
         self, url: str, model: type[T], token: str
     ) -> T:
@@ -311,6 +341,50 @@ class GafaelfawrClient:
             )
             r.raise_for_status()
             return model.model_validate(r.json())
+        except HTTPError as e:
+            if isinstance(e, HTTPStatusError):
+                if e.response.status_code == 404:
+                    raise GafaelfawrNotFoundError.from_exception(e) from e
+            raise GafaelfawrWebError.from_exception(e) from e
+        except ValidationError as e:
+            raise GafaelfawrValidationError.from_exception(e) from e
+
+    async def _get_list[T: BaseModel](
+        self, url: str, model: type[T], token: str
+    ) -> list[T]:
+        """Make an HTTP GET request returning a list and validate the results.
+
+        Parameters
+        ----------
+        url
+            URL at which to make the request.
+        model
+            Expected type of each element of the response.
+        token
+            Gafaelfawr token used for authentication.
+
+        Returns
+        -------
+        list of pydantic.BaseModel
+            List of validated models of the requested type.
+
+        Raises
+        ------
+        GafaelfawrNotFoundError
+            Raised if the requested URL returned a 404 response.
+        GafaelfawrValidationError
+            Raised if the response from Gafaelfawr is invalid.
+        GafaelfawrWebError
+            Raised if there is some problem talking to the Gafaelfawr API,
+            such as an invalid token or network or service failure.
+        """
+        headers = {"Authorization": f"Bearer {token}"}
+        try:
+            r = await self._client.get(
+                url, headers=headers, timeout=self._timeout
+            )
+            r.raise_for_status()
+            return [model.model_validate(e) for e in r.json()]
         except HTTPError as e:
             if isinstance(e, HTTPStatusError):
                 if e.response.status_code == 404:

--- a/client/src/rubin/gafaelfawr/_mock.py
+++ b/client/src/rubin/gafaelfawr/_mock.py
@@ -46,6 +46,7 @@ class MockGafaelfawrAction(Enum):
 
     CREATE_TOKEN = "create_token"
     LIST_GROUPS = "list_groups"
+    LIST_USERS = "list_users"
     USER_INFO = "user_info"
 
 
@@ -134,10 +135,12 @@ class MockGafaelfawr:
         prefix = base_url.rstrip("/") + "/"
         handler = self._handle_groups
         respx_mock.get(urljoin(prefix, "groups")).mock(side_effect=handler)
-        handler = self._handle_user_info
-        respx_mock.get(urljoin(prefix, "user-info")).mock(side_effect=handler)
         handler = self._handle_create_token
         respx_mock.post(urljoin(prefix, "tokens")).mock(side_effect=handler)
+        handler = self._handle_user_info
+        respx_mock.get(urljoin(prefix, "user-info")).mock(side_effect=handler)
+        handler = self._handle_users
+        respx_mock.get(urljoin(prefix, "users")).mock(side_effect=handler)
 
         # These routes require regex matching of the username.
         base_regex = re.escape(base_url.rstrip("/"))
@@ -278,6 +281,23 @@ class MockGafaelfawr:
             return Response(500)
         elif user_info := self._user_info.get(username):
             result = user_info.model_dump(mode="json", exclude_defaults=True)
+            return Response(200, json=result)
+        else:
+            return Response(404)
+
+    @_check(
+        fail_on=MockGafaelfawrAction.LIST_USERS,
+        required_scope="admin:userinfo",
+    )
+    def _handle_users(
+        self, request: Request, token_data: TokenData
+    ) -> Response:
+        result = [
+            u.model_dump(mode="json", exclude_defaults=True)
+            for u in self._user_info.values()
+            if u is not None
+        ]
+        if result:
             return Response(200, json=result)
         else:
             return Response(404)

--- a/client/tests/client_test.py
+++ b/client/tests/client_test.py
@@ -191,3 +191,26 @@ async def test_list_groups(
     groups = data.read_pydantic(GafaelfawrGroups, "userinfo/groups")
     mock_gafaelfawr.set_groups(groups)
     assert await client.list_groups(token) == groups
+
+
+@pytest.mark.asyncio
+async def test_list_users(data: Data, mock_gafaelfawr: MockGafaelfawr) -> None:
+    token = mock_gafaelfawr.create_token("admin", scopes=["admin:userinfo"])
+    client = GafaelfawrClient()
+
+    # If no data is available, should raise GafaelfawrNotFoundError.
+    with pytest.raises(GafaelfawrNotFoundError):
+        await client.list_users(token)
+
+    # HTTP errors should raise GafaelfawrWebError.
+    mock_gafaelfawr.fail_on("admin", MockGafaelfawrAction.LIST_USERS)
+    with pytest.raises(GafaelfawrWebError):
+        await client.list_users(token)
+
+    # Register some user information and try again.
+    mock_gafaelfawr.fail_on("admin", [])
+    one = data.read_pydantic(GafaelfawrUserInfo, "userinfo/someuser")
+    mock_gafaelfawr.set_user_info("someuser", one)
+    two = data.read_pydantic(GafaelfawrUserInfo, "userinfo/otheruser")
+    mock_gafaelfawr.set_user_info("otheruser", two)
+    assert await client.list_users(token) == [one, two]

--- a/client/tests/data/userinfo/otheruser.json
+++ b/client/tests/data/userinfo/otheruser.json
@@ -1,0 +1,7 @@
+{
+  "username": "otheruser",
+  "name": "Another User",
+  "uid": 2001,
+  "gid": 1045,
+  "groups": [{"id": 1222, "name": "foo"}]
+}

--- a/client/tests/mock_test.py
+++ b/client/tests/mock_test.py
@@ -87,6 +87,11 @@ async def test_fail_on(data: Data, mock_gafaelfawr: MockGafaelfawr) -> None:
     with pytest.raises(GafaelfawrWebError) as exc_info:
         await client.list_groups(admin_token)
 
+    # Check failure for retrieving a list of users.
+    mock_gafaelfawr.fail_on("admin", MockGafaelfawrAction.LIST_USERS)
+    with pytest.raises(GafaelfawrWebError) as exc_info:
+        await client.list_users(admin_token)
+
 
 @pytest.mark.asyncio
 async def test_missing_discovery(
@@ -110,14 +115,17 @@ async def test_required_scopes(
     mock_gafaelfawr.set_user_info("someuser", user_info)
 
     # A token without admin:userinfo should not be able to access the user
-    # route used by get_user_info with an explicit username or list all
-    # groups.
+    # route used by get_user_info with an explicit username, list all groups,
+    # or list all users.
     token = mock_gafaelfawr.create_token("otheruser")
     with pytest.raises(GafaelfawrWebError) as exc_info:
         await client.get_user_info(token, "someuser")
     assert exc_info.value.status == 403
     with pytest.raises(GafaelfawrWebError) as exc_info:
         await client.list_groups(token)
+    assert exc_info.value.status == 403
+    with pytest.raises(GafaelfawrWebError) as exc_info:
+        await client.list_users(token)
     assert exc_info.value.status == 403
 
     # A token without admin:token should not be able to create a token.

--- a/docs/user-guide/client.rst
+++ b/docs/user-guide/client.rst
@@ -107,6 +107,13 @@ Usually, it will obtain this token via a ``GafaelfawrServiceToken`` Kubernetes o
 Then, call `GafaelfawrClient.get_user_info`, passing in both that service token and, as the second argument, the username for which to get information.
 The result will be a `GafaelfawrUserInfo` object.
 
+.. warning::
+
+   This call does not return the same information that is returned when calling the method with a valid token.
+   The returned user information will only contain the information from LDAP, not any token overrides.
+
+   Bot users that are not present in LDAP will not have any useful information associated with them, even if many fields were set when creating a token for the bot user.
+
 Be aware that some Gafaelfawr configurations will raise `GafaelfawrNotFoundError` for any request for user information with a service token.
 This is the case for GitHub configurations, for example.
 `GafaelfawrNotFoundError` may also be raised in some cases when requesting user information for service tokens.
@@ -137,6 +144,31 @@ This allows clients that only want to act on user groups, such as a client that 
 
 Gafaelfawr configurations that do not use LDAP for user information will raise `GafaelfawrNotFoundError` for requests to list groups.
 This does not imply that there are no groups, only that the list of groups cannot be retrieved.
+
+Listing known users
+-------------------
+
+Similarly, Gafaelfawr instances that use LDAP as the source for user information support listing all groups known to the server.
+
+To obtain the group list, the application must have a token with ``admin:userinfo`` scope.
+Usually, it will obtain this token via a ``GafaelfawrServiceToken`` Kubernetes object (see :doc:`service-tokens`).
+
+Then, call `GafaelfawrClient.list_users`, passing in that service token as the one argument.
+The result will be a list of `GafaelfawrUserInfo` objects.
+
+.. warning::
+
+   The results will only contain the users and information from LDAP, not any token overrides.
+   If a user has created an account but never logged in and UIDs and GIDs are allocated via Firestore, they will not have a UID or GID since they have not been allocated yet.
+   Quota information for users is not included.
+
+   Bot users that are not present in LDAP will not be included, even though they may have valid tokens.
+
+   You should therefore be cautious when using this information.
+   It is only a way to retrieve the information in LDAP and that has already been recorded in Firestore, not the information about the user that you would see with a valid token for the user.
+
+Gafaelfawr configurations that do not use LDAP for user information will raise `GafaelfawrNotFoundError` for requests to list users.
+This does not imply that there are no users, only that the list of groups cannot be retrieved.
 
 Creating service tokens
 =======================

--- a/docs/user-guide/mock.rst
+++ b/docs/user-guide/mock.rst
@@ -104,6 +104,10 @@ To clear the registered information again, call `MockGafaelfawr.set_user_info` w
 
 Tokens created via `GafaelfawrClient.create_service_token` will automatically have their user information set in the mock to the values provided to that call.
 
+To set the list of groups returned by the list groups API, call `MockGafaelfawr.set_groups` with the `GafaelfawrGroups` data to return.
+This must be done separately from setting any user information if the mock needs to support a request to list groups.
+If this method is not called, the mock will return a 404 response to the request for a list of groups.
+
 Testing Gafaelfawr errors
 -------------------------
 

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -44,11 +44,10 @@ def gafaelfawr_client(
 
 
 @pytest.mark.parametrize("config", ["github-quota"], indirect=True)
+@pytest.mark.usefixtures("client")
 @pytest.mark.asyncio
 async def test_get_user_info(
-    *,
     data: Data,
-    client: AsyncClient,
     factory: Factory,
     gafaelfawr_client: GafaelfawrClient,
 ) -> None:
@@ -63,11 +62,11 @@ async def test_get_user_info(
 
 
 @pytest.mark.parametrize("config", ["oidc"], indirect=True)
+@pytest.mark.usefixtures("client")
 @pytest.mark.asyncio
 async def test_get_user_info_ldap(
     *,
     data: Data,
-    client: AsyncClient,
     factory: Factory,
     gafaelfawr_client: GafaelfawrClient,
     mock_ldap: MockLDAP,
@@ -82,6 +81,53 @@ async def test_get_user_info_ldap(
 
     result = await gafaelfawr_client.get_user_info(str(token), "ldap")
     data.assert_pydantic_matches(result, "client/userinfo-ldap")
+
+
+@pytest.mark.parametrize("config", ["oidc"], indirect=True)
+@pytest.mark.usefixtures("client")
+@pytest.mark.asyncio
+async def test_list_groups(
+    *,
+    data: Data,
+    factory: Factory,
+    gafaelfawr_client: GafaelfawrClient,
+    mock_ldap: MockLDAP,
+) -> None:
+    token_service = factory.create_token_service()
+    token = await token_service.create_session_token(
+        TokenUserInfo(username="admin"),
+        scopes={"admin:userinfo"},
+        ip_address="127.0.0.1",
+    )
+    mock_ldap.load_data_for_test(data, "ldap/users")
+
+    result = await gafaelfawr_client.list_groups(str(token))
+    data.assert_pydantic_matches(result, "api/groups")
+
+
+@pytest.mark.parametrize("config", ["oidc"], indirect=True)
+@pytest.mark.usefixtures("client")
+@pytest.mark.asyncio
+async def test_list_users(
+    *,
+    data: Data,
+    factory: Factory,
+    gafaelfawr_client: GafaelfawrClient,
+    mock_ldap: MockLDAP,
+) -> None:
+    token_service = factory.create_token_service()
+    token = await token_service.create_session_token(
+        TokenUserInfo(username="admin"),
+        scopes={"admin:userinfo"},
+        ip_address="127.0.0.1",
+    )
+    mock_ldap.load_data_for_test(data, "ldap/users")
+
+    result = await gafaelfawr_client.list_users(str(token))
+    result_json = [
+        m.model_dump(mode="json", exclude_defaults=True) for m in result
+    ]
+    data.assert_json_matches(result_json, "api/users")
 
 
 @pytest.mark.asyncio

--- a/tests/data/output/admin-change-history.json
+++ b/tests/data/output/admin-change-history.json
@@ -124,6 +124,25 @@
     "event_time": "<ANY>",
     "expires": "<ANY>",
     "ip_address": "2001:db8:34a:ea78:4278:4562:6578:af42",
+    "old_expires": "<ANY>",
+    "old_scopes": null,
+    "old_token_name": null,
+    "parent": "<ANY>",
+    "scopes": [
+      "read:some"
+    ],
+    "service": "foo",
+    "token": "<ANY>",
+    "token_name": null,
+    "token_type": "internal",
+    "username": "two"
+  },
+  {
+    "action": "edit",
+    "actor": "bot-service",
+    "event_time": "<ANY>",
+    "expires": "<ANY>",
+    "ip_address": "2001:db8:34a:ea78:4278:4562:6578:af42",
     "old_expires": null,
     "old_scopes": [
       "admin:token",

--- a/tests/data/output/user-change-history.json
+++ b/tests/data/output/user-change-history.json
@@ -124,6 +124,25 @@
     "event_time": "<ANY>",
     "expires": "<ANY>",
     "ip_address": "2001:db8:34a:ea78:4278:4562:6578:af42",
+    "old_expires": "<ANY>",
+    "old_scopes": null,
+    "old_token_name": null,
+    "parent": "<ANY>",
+    "scopes": [
+      "read:some"
+    ],
+    "service": "foo",
+    "token": "<ANY>",
+    "token_name": null,
+    "token_type": "internal",
+    "username": "two"
+  },
+  {
+    "action": "edit",
+    "actor": "bot-service",
+    "event_time": "<ANY>",
+    "expires": "<ANY>",
+    "ip_address": "2001:db8:34a:ea78:4278:4562:6578:af42",
     "old_expires": null,
     "old_scopes": [
       "admin:token",

--- a/tests/handlers/api_history_test.py
+++ b/tests/handlers/api_history_test.py
@@ -142,7 +142,7 @@ async def build_history(
         service_token_data,
         ip_address="2001:db8:034a:ea78:4278:4562:6578:af42",
         token_name="other name",
-        expires=now + timedelta(days=30),
+        expires=now + timedelta(days=10),
         scopes={"read:all"},
     )
     assert await token_service.delete_token(
@@ -152,18 +152,25 @@ async def build_history(
         ip_address="2001:db8:034a:ea78:4278:4562:6578:9876",
     )
 
-    # Spread out the timestamps so that we can test date range queries.  Every
+    # Spread out the timestamps so that we can test date range queries. Every
     # other entry has the same timestamp as the previous entry to test that
     # queries handle entries with the same timestamp.
+    #
+    # This operation has to be done in descending order (modifying the last
+    # entry first) because the entries are returned in reverse order and we
+    # want the first two in the returned list to have the same timestamp, the
+    # next two to have the next timestamp, and so forth.
     async with factory.session.begin():
-        stmt = select(TokenChangeHistory).order_by(TokenChangeHistory.id)
+        stmt = select(TokenChangeHistory).order_by(
+            TokenChangeHistory.id.desc()
+        )
         result = await factory.session.execute(stmt)
         entries = [e[0] for e in result.all()]
-        event_time = now - timedelta(seconds=len(entries) * 5)
+        event_time = now
         for i, entry in enumerate(entries):
             entry.event_time = datetime_to_db(event_time)
             if i % 2 != 0:
-                event_time += timedelta(seconds=5)
+                event_time -= timedelta(seconds=5)
 
     history = await token_service.get_change_history(service_token_data)
     json_history = [e.model_dump(mode="json") for e in history.entries]
@@ -225,7 +232,7 @@ async def check_pagination(
     first_url = url
     prev_data = None
     all_data = []
-    for end in range(5, len(history) + 4, 5):
+    for end in range(5, len(history) + 5, 5):
         r = await client.get(url)
         assert r.status_code == 200
         data = r.json()
@@ -253,7 +260,7 @@ async def check_pagination(
         all_data.extend(data)
 
         # If we're not done, move to the next URL.
-        if end < len(history):
+        if end <= len(history):
             assert link_data.next_url
             url = link_data.next_url
 
@@ -455,15 +462,15 @@ async def test_user_change_history(
     await check_history_request(
         client,
         {"since": int(history[3].event_time.timestamp())},
-        history[:4],
-        lambda e: True,
+        history,
+        lambda e: e.event_time >= history[3].event_time,
         username="one",
     )
     await check_history_request(
         client,
         {"until": int(history[2].event_time.timestamp())},
-        history[2:],
-        lambda e: True,
+        history,
+        lambda e: e.event_time <= history[2].event_time,
         username="one",
     )
     await check_history_request(
@@ -472,8 +479,10 @@ async def test_user_change_history(
             "since": int(history[5].event_time.timestamp()),
             "until": int(history[4].event_time.timestamp()),
         },
-        history[4:6],
-        lambda e: True,
+        history,
+        lambda e: (
+            history[4].event_time >= e.event_time >= history[5].event_time
+        ),
         username="one",
     )
 


### PR DESCRIPTION
Add a new `list_users` method to the client to retrieve all known users from a Gafaelfawr server that uses LDAP as the user information source. This method requires a token with `admin:userinfo` scope. Also add the corresponding mock.