### PR TITLE
DM-55780: Migrade OIDC clients on schema update

### DIFF
--- a/changelog.d/20260814_170133_rra_DM_55780.md
+++ b/changelog.d/20260814_170133_rra_DM_55780.md
@@ -1,6 +1,6 @@
 ### Backwards-incompatible changes
 
-- Store OpenID Connect client registrations in the database rather than the Gafaelfawr configuration via a secret. Add a new API for managing the registered OpenID Connect clients.
+- Store OpenID Connect client registrations in the database rather than the Gafaelfawr configuration via a secret. Add a new API for managing the registered OpenID Connect clients. Existing clients configured via a secret will be migrated into the database as part of the schema migration, after which any client configuration via a secret will be ignored.
 
 ### Other changes
 

--- a/src/gafaelfawr/cli.py
+++ b/src/gafaelfawr/cli.py
@@ -22,6 +22,7 @@ from safir.slack.blockkit import SlackMessage
 from sqlalchemy import text
 
 from . import __version__
+from .config import OIDCClientConfig
 from .database import (
     generate_schema_sql,
     initialize_gafaelfawr_database,
@@ -35,19 +36,7 @@ from .main import create_openapi
 from .models.token import Token
 from .schema import SchemaBase
 
-__all__ = [
-    "audit",
-    "delete_all_data",
-    "generate_key",
-    "generate_schema",
-    "generate_token",
-    "help",
-    "init",
-    "main",
-    "maintenance",
-    "openapi_schema",
-    "run",
-]
+__all__ = ["main"]
 
 
 @click.group(context_settings={"help_option_names": ["-h", "--help"]})
@@ -342,8 +331,23 @@ def update_schema(
         asyncio.run(initialize_gafaelfawr_database(config, logger))
         stamp_database(alembic_config_path)
         logger.debug("Finished initializing data stores")
-        return
-    subprocess.run(["alembic", "upgrade", "head"], check=True, env=env)
+    else:
+        subprocess.run(["alembic", "upgrade", "head"], check=True, env=env)
+
+    # Support code to migrate old OpenID Connect clients.
+    async def migrate_oidc_clients(clients: list[OIDCClientConfig]) -> None:
+        engine = create_database_engine(
+            config.database_url, config.database_password
+        )
+        async with Factory.standalone(config, engine) as factory:
+            oidc_service = factory.create_oidc_service()
+            await oidc_service.migrate_clients(clients)
+        await engine.dispose()
+
+    # If there are OpenID Connect clients configured using the old approach,
+    # migrate them into the database.
+    if config.oidc_server and config.oidc_server.clients:
+        asyncio.run(migrate_oidc_clients(config.oidc_server.clients))
 
 
 @main.command()

--- a/src/gafaelfawr/services/oidc.py
+++ b/src/gafaelfawr/services/oidc.py
@@ -15,7 +15,7 @@ from safir.slack.webhook import SlackWebhookClient
 from sqlalchemy.ext.asyncio import AsyncSession
 from structlog.stdlib import BoundLogger
 
-from ..config import OIDCServerConfig
+from ..config import OIDCClientConfig, OIDCServerConfig
 from ..constants import ALGORITHM
 from ..exceptions import (
     InvalidClientError,
@@ -312,6 +312,25 @@ class OIDCService:
         """
         async with self._session.begin():
             return await self._client_store.list()
+
+    async def migrate_clients(self, clients: list[OIDCClientConfig]) -> None:
+        """Migrate clients from the old configuration into the database.
+
+        Parameters
+        ----------
+        clients
+            Clients to migrate.
+        """
+        async with self._session.begin():
+            db_clients = await self._client_store.list()
+            if db_clients:
+                self._logger.warning(
+                    "OpenID Connect clients already found in the database,"
+                    " so not migrating clients configured via a secret"
+                )
+                return
+            for client in clients:
+                await self._client_store.migrate(client)
 
     async def redeem_code(
         self,

--- a/src/gafaelfawr/storage/oidc.py
+++ b/src/gafaelfawr/storage/oidc.py
@@ -8,10 +8,12 @@ from typing import cast
 import bcrypt
 from pydantic import SecretStr
 from safir.database import datetime_to_db
+from safir.datetime import format_datetime_for_logging
 from safir.redis import EncryptedPydanticRedisStorage
 from sqlalchemy import CursorResult, delete, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from ..config import OIDCClientConfig
 from ..constants import OIDC_AUTHORIZATION_LIFETIME
 from ..exceptions import InvalidGrantError
 from ..models.oidc import (
@@ -198,6 +200,31 @@ class OIDCClientStore:
             OIDCClient.model_validate(a, from_attributes=True)
             for a in result.all()
         ]
+
+    async def migrate(self, client: OIDCClientConfig) -> None:
+        """Migrate an old-style configured client into the database.
+
+        Parameters
+        ----------
+        config
+            Client configuration.
+        """
+        created = datetime.now(tz=UTC)
+        migration_date = format_datetime_for_logging(created)
+        description = f"Migrated from secret on {migration_date}"
+        secret = client.secret.get_secret_value()
+        hashed_secret = bcrypt.hashpw(secret.encode(), bcrypt.gensalt())
+        new = SQLOIDCClient(
+            client_id=client.id,
+            client_secret_hash=hashed_secret,
+            return_uri=str(client.return_uri),
+            description=description,
+            notes=None,
+            created=datetime_to_db(created),
+            last_modified=datetime_to_db(created),
+            last_modified_by="<internal>",
+        )
+        self._session.add(new)
 
     async def register(self, create: OIDCClientCreate) -> OIDCClientWithSecret:
         """Register a new OpenID Connect client.

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -30,10 +30,15 @@ from gafaelfawr.factory import Factory
 from gafaelfawr.models.admin import Admin
 from gafaelfawr.models.enums import TokenChange, TokenType
 from gafaelfawr.models.history import TokenChangeHistoryEntry
-from gafaelfawr.models.oidc import OIDCAuthorizationCode, OIDCScope
+from gafaelfawr.models.oidc import (
+    OIDCAuthenticateStatus,
+    OIDCAuthorizationCode,
+    OIDCScope,
+)
 from gafaelfawr.models.token import Token, TokenData, TokenUserInfo
 from gafaelfawr.schema import SchemaBase
 from gafaelfawr.storage.history import TokenChangeHistoryStore
+from gafaelfawr.storage.oidc import OIDCClientStore
 from gafaelfawr.storage.token import TokenDatabaseStore
 
 from .support.database import create_old_database
@@ -317,9 +322,24 @@ def test_openapi_schema(tmp_path: Path) -> None:
     assert "Return to Gafaelfawr documentation" in result.output
 
 
-def test_update_schema(engine: AsyncEngine, config: Config) -> None:
+@pytest.mark.parametrize("config", ["github-oidc-server"], indirect=True)
+def test_update_schema(
+    engine: AsyncEngine, config: Config, monkeypatch: pytest.MonkeyPatch
+) -> None:
     event_loop = asyncio.new_event_loop()
     runner = CliRunner()
+
+    # Create some old-style OpenID Connect clients, which should be added to
+    # the database as part of a schema migration when the oidc_client table is
+    # empty.
+    return_uri = "https://example.com/service"
+    oidc_clients = [
+        {"id": "some-id", "secret": "secret", "return_uri": return_uri},
+        {"id": "other-id", "secret": "other", "return_uri": return_uri + "/a"},
+    ]
+    monkeypatch.setenv(
+        "GAFAELFAWR_OIDC_SERVER_CLIENTS", json.dumps(oidc_clients)
+    )
 
     # Start with an empty database. This should produce exactly the same
     # results as gafaelfawr init.
@@ -343,6 +363,17 @@ def test_update_schema(engine: AsyncEngine, config: Config) -> None:
             token_service = factory.create_token_service()
             bootstrap = TokenData.bootstrap_token()
             assert await token_service.list_tokens(bootstrap) == []
+            oidc_service = factory.create_oidc_service()
+            oidc_clients = {
+                c.client_id for c in await oidc_service.list_clients()
+            }
+            assert oidc_clients == {"some-id", "other-id"}
+            oidc_store = OIDCClientStore(factory.session)
+            async with factory.session.begin():
+                result = await oidc_store.authenticate("some-id", "secret")
+                assert result == OIDCAuthenticateStatus.VALID
+                result = await oidc_store.authenticate("other-id", "other")
+                assert result == OIDCAuthenticateStatus.VALID
 
     event_loop.run_until_complete(check_database())
 


### PR DESCRIPTION
When performing a schema update, check if there are OIDC clients configured using the old config/secret method and no clients in the database. If so, perform a one-time migration of the configured clients into the database.