### PR TITLE
DM-55868: Add disk quotas

### DIFF
--- a/changelog.d/20260819_152302_rra_DM_55868.md
+++ b/changelog.d/20260819_152302_rra_DM_55868.md
@@ -1,0 +1,3 @@
+### New features
+
+- Add disk quota to the Gafaelfawr quota representation. These quotas are calculated by Gafaelfawr but not enforced. In many deployments, they will serve purely as documentation of externally-managed file system quotas, allowing them to be displayed alongside other quotas in Rubin Science Platform user interfaces.

--- a/client/src/rubin/gafaelfawr/_models.py
+++ b/client/src/rubin/gafaelfawr/_models.py
@@ -84,7 +84,17 @@ class GafaelfawrQuota(BaseModel):
         dict[str, int],
         Field(
             title="API quotas",
-            description=("Mapping of service names to requests per minute"),
+            description="Mapping of service names to requests per minute",
+        ),
+    ] = {}
+
+    disk: Annotated[
+        dict[str, int],
+        Field(
+            title="Disk quotas",
+            description=(
+                "Mapping of mount points to disk quota allocations in bytes"
+            ),
         ),
     ] = {}
 

--- a/docs/operations/helm.rst
+++ b/docs/operations/helm.rst
@@ -605,6 +605,8 @@ The keys for API quotas are names of services.
 This is the same name the service should use in the ``config.service`` key of a ``GafaelfawrIngress`` resource (see :ref:`ingress`).
 If a service name has no corresponding quota setting, access to that service will be unrestricted.
 
+The ``disk`` key should contain a mapping of mount points to bytes of quota in that file system.
+
 The ``notebook`` key should contain ``cpu`` and ``memory`` keys specifying the default CPU and memory limits.
 The memory limit is given in a floating point number of GiB.
 
@@ -620,6 +622,8 @@ For example:
        default:
          api:
            datalinker: 100
+         disk:
+           "/home": 32212254720
          notebook:
            cpu: 2.0
            memory: 4.0
@@ -647,11 +651,13 @@ For example:
          g_developers:
            api:
              datalinker: 50
+           disk:
+             "/home": 10737418240
            notebook:
              cpu: 0.0
              memory: 4.0
 
-If this were combined with the above default quota, members of the ``g_developers`` group would receive a total of 150 requests per minute for datalinker, and a total of 8.0 GiB of memory for notebooks.
+If this were combined with the above default quota, members of the ``g_developers`` group would receive a total of 150 requests per minute for datalinker, 40GiB of quota in :file:`/home`, and a total of 8.0 GiB of memory for notebooks.
 The CPU quota for notebooks and the quota for TAP queries would be unchanged.
 
 Members of specific groups cannot be granted unrestricted access to an API service since a missing key for a service instead means that this group contributes no additional quota for that service.

--- a/docs/user-guide/quotas.rst
+++ b/docs/user-guide/quotas.rst
@@ -9,8 +9,9 @@ These quotas can be temporarily overridden by using the Gafaelfawr REST API.
 Types of quota
 ==============
 
-Gafaelfawr tracks two types of quota for each user: API quotas and notebook quotas.
-The notebook quotas are only calculated in Gafaelfawr and must be queried and enforced by some other system (normally Nublado_).
+Gafaelfawr tracks four types of quota for each user: API quotas, disk quotas, notebook quotas, and TAP quotas.
+All quotas except for the API quotas are only calculated in Gafaelfawr and must be queried and enforced by some other system.
+For example, notebook quotas are applied by Nublado_.
 
 API quotas
 ----------
@@ -40,6 +41,15 @@ Setting the API quota to zero is a special case.
 This is treated as an administrative block of the accesses to the service that it affects, and all requests are rejected with a 403 error (not a 429 error).
 
 This is normally only useful when done in quota overrides (see :ref:`quota-overrides`).
+
+Disk quotas
+-----------
+
+Disk quotas are a mapping of mount points to the user's available quota in bytes.
+
+This quota is only calculated by Gafaelfawr, not imposed, and often the quotas set in file systems cannot be set directly from Gafaelfawr information.
+Often, the disk quota information will be set manually in the Gafaelfawr configuration (see :ref:`helm-quota`) to document quotas managed externally.
+This allows retrieved of disk quotas via the same API as other quotas by user interfaces that want to display user quotas.
 
 Notebook quotas
 ---------------
@@ -86,8 +96,8 @@ These routes require a token with ``admin:token`` scope.
 The body sent via ``PUT`` and returned by ``GET`` is the same format as the ``config.quota`` key for the Gafaelfawr configuration except in JSON format.
 
 Quota overrides, unlike group quotas, are not additive.
-Instead, if there is a quota override and it generates a quota for a particular service for a user, that overrides the corresponding quota from the Gafaelfawr configuration.
-If the quota override does not generate quota for a particular service (if, for example, it contains no notebook quota), then the quota from the Gafaelfawr configuration is used.
+Instead, if there is a quota override and it generates a quota for a particular service or disk mount point for a user, that overrides the corresponding quota from the Gafaelfawr configuration.
+If the quota override does not generate quota for a particular service or mount point (if, for example, it contains no notebook quota), then the quota from the Gafaelfawr configuration is used.
 
 Override example
 ----------------

--- a/src/gafaelfawr/models/quota.py
+++ b/src/gafaelfawr/models/quota.py
@@ -75,6 +75,15 @@ class Quota(BaseModel):
         ],
     )
 
+    disk: dict[str, int] = Field(
+        {},
+        title="Disk quotas",
+        description=(
+            "Mapping of mount points to disk quota allocations in bytes"
+        ),
+        examples=[{"/home": 32212254720}],
+    )
+
     notebook: NotebookQuota | None = Field(
         None, title="Notebook Aspect quotas"
     )
@@ -82,6 +91,15 @@ class Quota(BaseModel):
     tap: dict[str, TapQuota] = Field(
         {}, title="TAP quotas", examples=[{"qserv": {"concurrent": 5}}]
     )
+
+    def is_empty(self) -> bool:
+        """Whether this quota contains no rules."""
+        return (
+            not self.api
+            and not self.disk
+            and not self.notebook
+            and not self.tap
+        )
 
 
 class QuotaConfig(BaseModel):
@@ -128,30 +146,50 @@ class QuotaConfig(BaseModel):
 
         # Start with the defaults.
         default = self.default
-        api = dict(default.api)
         notebook = default.notebook.model_copy() if default.notebook else None
-        tap = dict(default.tap)
+        quota = Quota(
+            api=dict(default.api),
+            disk=dict(default.disk),
+            notebook=notebook,
+            tap=dict(default.tap),
+        )
 
-        # Look for group-specific rules.
+        # Merge in group-specific rules.
         for group in groups & set(self.groups.keys()):
-            extra = self.groups[group]
-            if notebook:
-                notebook = notebook.add(extra.notebook)
-            else:
-                notebook = extra.notebook
-            for service, rule in extra.tap.items():
-                if service in tap:
-                    tap[service] = tap[service].add(rule)
-                else:
-                    tap[service] = rule
-            for service, quota in extra.api.items():
-                if service in api:
-                    api[service] += quota
-                else:
-                    api[service] = quota
+            self._merge_group_quota(quota, self.groups[group])
 
         # Return the results.
-        if not notebook and not api:
+        if quota.is_empty():
             return None
         else:
-            return Quota(api=api, notebook=notebook, tap=tap)
+            return quota
+
+    def _merge_group_quota(self, base: Quota, extra: Quota) -> None:
+        """Merge quota for a group into an existing quota.
+
+        Parameters
+        ----------
+        base
+            Quota being constructed.
+        extra
+            Additional quota allocated to a group.
+        """
+        if base.notebook:
+            base.notebook = base.notebook.add(extra.notebook)
+        else:
+            base.notebook = extra.notebook
+        for service, rule in extra.tap.items():
+            if service in base.tap:
+                base.tap[service] = base.tap[service].add(rule)
+            else:
+                base.tap[service] = rule
+        for mount, quota in extra.disk.items():
+            if mount in base.disk:
+                base.disk[mount] += quota
+            else:
+                base.disk[mount] = quota
+        for service, quota in extra.api.items():
+            if service in base.api:
+                base.api[service] += quota
+            else:
+                base.api[service] = quota

--- a/src/gafaelfawr/services/userinfo.py
+++ b/src/gafaelfawr/services/userinfo.py
@@ -501,13 +501,13 @@ class UserInfoService:
         elif overrides.bypass & group_names:
             return Quota()
         else:
-            api = quota.api
-            api.update(override_quota.api)
-            return Quota(
-                notebook=override_quota.notebook or quota.notebook,
-                api=api,
-                tap=override_quota.tap or quota.tap,
-            )
+            quota.api.update(override_quota.api)
+            quota.disk.update(override_quota.disk)
+            if override_quota.notebook:
+                quota.notebook = override_quota.notebook
+            if override_quota.tap:
+                quota.tap = override_quota.tap
+            return quota
 
     def _check_authorization(
         self, auth_data: TokenData, username: str | None = None

--- a/tests/data/client/userinfo-example.json
+++ b/tests/data/client/userinfo-example.json
@@ -14,6 +14,9 @@
       "other": 2,
       "test": 2
     },
+    "disk": {
+      "/home": 42949672960
+    },
     "notebook": {
       "cpu": 8.0,
       "memory": 8.0,

--- a/tests/data/config/github-quota.yaml
+++ b/tests/data/config/github-quota.yaml
@@ -23,6 +23,8 @@ quota:
       datalinker: 1000
       test: 1
       other: 2
+    disk:
+      "/home": 32212254720
     notebook:
       cpu: 8
       memory: 4.0
@@ -38,6 +40,8 @@ quota:
     foo:
       api:
         test: 1
+      disk:
+        "/home": 10737418240
       notebook:
         cpu: 0.0
         memory: 4.0

--- a/tests/handlers/quota_test.py
+++ b/tests/handlers/quota_test.py
@@ -33,6 +33,7 @@ async def test_info(client: AsyncClient, factory: Factory) -> None:
         "groups": [{"name": "bar", "id": 12312}],
         "quota": {
             "api": {"datalinker": 1000, "test": 1, "other": 2},
+            "disk": {"/home": 30 * 1024 * 1024 * 1024},
             "notebook": {"cpu": 8.0, "memory": 4.0, "spawn": True},
             "tap": {"qserv": {"concurrent": 10}},
         },
@@ -52,6 +53,7 @@ async def test_info(client: AsyncClient, factory: Factory) -> None:
         "groups": [{"name": "foo", "id": 12313}],
         "quota": {
             "api": {"datalinker": 1000, "test": 2, "other": 2},
+            "disk": {"/home": 40 * 1024 * 1024 * 1024},
             "notebook": {"cpu": 8.0, "memory": 8.0, "spawn": True},
             "tap": {"qserv": {"concurrent": 15}, "sso": {"concurrent": 5}},
         },
@@ -83,6 +85,7 @@ async def test_no_spawn(client: AsyncClient, factory: Factory) -> None:
         ],
         "quota": {
             "api": {"datalinker": 1000, "test": 1, "other": 2},
+            "disk": {"/home": 30 * 1024 * 1024 * 1024},
             "notebook": {"cpu": 8.0, "memory": 4.0, "spawn": False},
             "tap": {"qserv": {"concurrent": 10}},
         },
@@ -107,7 +110,7 @@ async def test_rate_limit_override(
 
     overrides: dict[str, Any] = {
         "bypass": [],
-        "default": {"api": {"test": 10}},
+        "default": {"api": {"test": 10}, "disk": {"/shared": 1024 * 1024}},
         "groups": {},
     }
     r = await client.put(
@@ -136,6 +139,7 @@ async def test_rate_limit_override(
         ],
         "quota": {
             "api": {"datalinker": 1000, "test": 10, "other": 2},
+            "disk": {"/home": 40 * 1024 * 1024 * 1024, "/shared": 1024 * 1024},
             "notebook": {"cpu": 8.0, "memory": 8.0, "spawn": True},
             "tap": {"qserv": {"concurrent": 15}, "sso": {"concurrent": 5}},
         },
@@ -159,7 +163,7 @@ async def test_rate_limit_override(
         "/auth/api/v1/quota-overrides", json=overrides, headers=headers
     )
     assert r.status_code == 200
-    expected_user_info["quota"] = {"api": {}, "tap": {}}
+    expected_user_info["quota"] = {"api": {}, "disk": {}, "tap": {}}
     r = await client.get("/auth/api/v1/user-info", headers=headers)
     assert r.json() == expected_user_info
 
@@ -194,8 +198,9 @@ async def test_rate_limit_override_only(
     overrides: dict[str, Any] = {
         "bypass": [],
         "default": {
-            "notebook": {"cpu": 1.0, "memory": 4.0, "spawn": True},
             "api": {"test": 10},
+            "disk": {"/home": 10 * 1024 * 1024 * 1024},
+            "notebook": {"cpu": 1.0, "memory": 4.0, "spawn": True},
             "tap": {"qserv": {"concurrent": 5}},
         },
         "groups": {},
@@ -229,6 +234,7 @@ async def test_rate_limit_override_only(
         ],
         "quota": {
             "api": {"test": 10},
+            "disk": {"/home": 10 * 1024 * 1024 * 1024},
             "notebook": {"cpu": 1.0, "memory": 4.0, "spawn": True},
             "tap": {"qserv": {"concurrent": 5}},
         },
@@ -242,7 +248,7 @@ async def test_rate_limit_override_only(
     )
     assert r.status_code == 200
     assert r.json() == overrides
-    expected_user_info["quota"] = {"api": {}, "tap": {}}
+    expected_user_info["quota"] = {"api": {}, "disk": {}, "tap": {}}
     r = await client.get("/auth/api/v1/user-info", headers=headers)
     assert r.status_code == 200
     assert r.json() == expected_user_info
@@ -300,6 +306,7 @@ async def test_rate_limit_override_groups(
         ],
         "quota": {
             "api": {"datalinker": 1000, "other": 2, "test": 10},
+            "disk": {"/home": 40 * 1024 * 1024 * 1024},
             "notebook": {"cpu": 8.0, "memory": 8.0, "spawn": True},
             "tap": {"qserv": {"concurrent": 15}, "sso": {"concurrent": 5}},
         },
@@ -322,7 +329,7 @@ async def test_permissions(client: AsyncClient, factory: Factory) -> None:
     assert r.status_code == 404
     overrides: dict[str, Any] = {
         "bypass": [],
-        "default": {"api": {"test": 10}, "tap": {}},
+        "default": {"api": {"test": 10}},
         "groups": {},
     }
     r = await client.put(
@@ -335,7 +342,9 @@ async def test_permissions(client: AsyncClient, factory: Factory) -> None:
     assert r.status_code == 200
     r = await client.get("/auth/api/v1/quota-overrides", headers=user_headers)
     assert r.status_code == 200
-    assert r.json() == overrides
+    expected = overrides.copy()
+    expected["default"].update({"tap": {}, "disk": {}})
+    assert r.json() == expected
     r = await client.delete(
         "/auth/api/v1/quota-overrides", headers=user_headers
     )


### PR DESCRIPTION
Add disk quota to the Gafaelfawr quota representation. These quotas are calculated by Gafaelfawr but not enforced. In many deployments, they will serve purely as documentation of externally-managed file system quotas, allowing them to be displayed alongside other quotas in Rubin Science Platform user interfaces.