### PR TITLE
DM-55780: Update testcontainers imports

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -14,8 +14,8 @@ from typing import Self
 import nox
 from nox.command import CommandFailed
 from nox_uv import session
-from testcontainers.postgres import PostgresContainer
-from testcontainers.redis import RedisContainer
+from testcontainers.community.postgres import PostgresContainer
+from testcontainers.community.redis import RedisContainer
 
 # Default sessions.
 nox.options.sessions = ["lint", "typing", "test", "docs"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -162,10 +162,7 @@ asyncio_default_fixture_loop_scope = "function"
 asyncio_mode = "strict"
 filterwarnings = [
     # dataclases-avroschema hasn't been fully updated for Python 3.14
-    "ignore:.*Core Pydantic V1 functionality.*:UserWarning",
     "ignore:.*'_UnionGenericAlias' is deprecated.*:DeprecationWarning",
-    # testcontainers hasn't updated all of the community modules
-    "ignore:.*wait_container_is_ready decorator.*:DeprecationWarning",
 ]
 norecursedirs = ["client/*"]
 # The python_files setting is not for test detection (pytest will pick up any

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,8 +16,8 @@ from safir.database import create_database_engine, stamp_database_async
 from safir.testing.data import Data
 from safir.testing.slack import MockSlackWebhook, mock_slack_webhook
 from sqlalchemy.ext.asyncio import AsyncEngine
-from testcontainers.postgres import PostgresContainer
-from testcontainers.redis import RedisContainer
+from testcontainers.community.postgres import PostgresContainer
+from testcontainers.community.redis import RedisContainer
 
 from gafaelfawr.config import Config
 from gafaelfawr.database import initialize_gafaelfawr_database


### PR DESCRIPTION
testcontainers has moved some containers to testcontainers.community. Update imports accordingly.

Remove some now-obsolete warning filters.