### PR TITLE
DM-55780: Add authorization checks for OIDC client API

### DIFF
--- a/docs/operations/bootstrapping.rst
+++ b/docs/operations/bootstrapping.rst
@@ -14,6 +14,6 @@ This token must be generated with :command:`gafaelfawr generate-token` and then 
 See :ref:`vault-secrets` for more details.
 It can then be used with API calls as a bearer token in the ``Authenticate`` header.
 
-The bootstrap token acts like the token of a service or user with the ``admin:token`` scope, but can only access specific routes, namely ``/auth/api/v1/tokens``.
+The bootstrap token acts like the token of a service or user with the ``admin:token`` scope, but can only access specific routes, namely ``/auth/api/v1/tokens`` and ``/auth/api/v1/oidc-clients``.
 This allows it to be used to create user tokens for arbitrary users and with arbitrary scopes, including privileged scopes such as ``admin:token``
 Those tokens can then be used to access all of the Gafaelfawr API regardless of the state of the user information service.

--- a/src/gafaelfawr/handlers/api.py
+++ b/src/gafaelfawr/handlers/api.py
@@ -283,7 +283,7 @@ async def get_oidc_clients(
     context: Annotated[RequestContext, Depends(context_dependency)],
 ) -> list[OIDCClient]:
     oidc_service = context.factory.create_oidc_service()
-    clients = await oidc_service.list_clients()
+    clients = await oidc_service.list_clients(auth_data)
     for client in clients:
         client.url = get_oidc_client_url(context.request, client.client_id)
     return clients

--- a/src/gafaelfawr/models/token.py
+++ b/src/gafaelfawr/models/token.py
@@ -313,7 +313,7 @@ class TokenData(TokenBase, TokenUserInfo):
             token=Token(),
             username="<bootstrap>",
             token_type=TokenType.service,
-            scopes={"admin:token"},
+            scopes={"admin:oidc", "admin:token"},
         )
 
     @classmethod
@@ -321,7 +321,7 @@ class TokenData(TokenBase, TokenUserInfo):
         """Build authentication data for the internal token.
 
         Similar to the bootstrap token, this does not exist in the backing
-        store.  It is used by background jobs internal to Gafaelfawr.
+        store. It is used by background jobs internal to Gafaelfawr.
 
         Returns
         -------

--- a/src/gafaelfawr/services/oidc.py
+++ b/src/gafaelfawr/services/oidc.py
@@ -24,6 +24,7 @@ from ..exceptions import (
     InvalidRequestError,
     InvalidTokenError,
     NotFoundError,
+    PermissionDeniedError,
     ReturnUriMismatchError,
     UnsupportedGrantTypeError,
 )
@@ -148,6 +149,7 @@ class OIDCService:
         NotFoundError
             Raised if the client could not be found.
         """
+        self._check_authorization(auth_data)
         async with self._session.begin():
             await self._client_store.delete(client_id)
 
@@ -173,6 +175,7 @@ class OIDCService:
         NotFoundError
             Raised if the client could not be found.
         """
+        self._check_authorization(auth_data)
         async with self._session.begin():
             oidc_client = await self._client_store.get(client_id)
         if not oidc_client:
@@ -302,14 +305,20 @@ class OIDCService:
             encoded=encoded_token, claims=payload, jti=payload.get("jti")
         )
 
-    async def list_clients(self) -> list[OIDCClient]:
+    async def list_clients(self, auth_data: TokenData) -> list[OIDCClient]:
         """List all registered OpenID Connect clients.
+
+        Parameters
+        ----------
+        auth_data
+            Token information for the person requesting the client list.
 
         Returns
         -------
         list of OIDCClient
             List of registered OpenID Connect clients.
         """
+        self._check_authorization(auth_data)
         async with self._session.begin():
             return await self._client_store.list()
 
@@ -455,6 +464,7 @@ class OIDCService:
         request
             OpenID Connect client information.
         """
+        self._check_authorization(auth_data)
         create = OIDCClientCreate(
             client_id=os.urandom(16).hex() + self._config.client_suffix,
             return_uri=request.return_uri,
@@ -509,6 +519,7 @@ class OIDCService:
         NotFoundError
             Raised if the client could not be found.
         """
+        self._check_authorization(auth_data)
         async with self._session.begin():
             oidc_client = await self._client_store.update(client_id, update)
         if not oidc_client:
@@ -571,7 +582,8 @@ class OIDCService:
             The issuer of this token is unknown and therefore the token cannot
             be verified.
         """
-        audiences = (c.client_id for c in await self.list_clients())
+        async with self._session.begin():
+            audiences = [c.client_id for c in await self._client_store.list()]
         try:
             payload = jwt.decode(
                 token.encoded,
@@ -615,6 +627,25 @@ class OIDCService:
         if not releases:
             return None
         return " ".join(sorted(releases))
+
+    def _check_authorization(self, auth_data: TokenData) -> None:
+        """Check authorization for manipulating OpenID Connect clients.
+
+        Arguments
+        ---------
+        auth_data
+            Aauthenticated user performing the action.
+
+        Raises
+        ------
+        PermissionDeniedError
+            Raised if the authenticated user doesn't have permission to
+            manipulate tokens for that user.
+        """
+        if "admin:oidc" not in auth_data.scopes:
+            msg = "Missing required admin:oidc scope"
+            self._logger.warning("Permission denied", error=msg)
+            raise PermissionDeniedError(msg)
 
     async def _check_client_secret(
         self, client_id: str, client_secret: str | None, return_uri: str

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -153,7 +153,7 @@ def test_delete_all_data(
             bootstrap = TokenData.bootstrap_token()
             assert await token_service.list_tokens(bootstrap) == []
             oidc_service = factory.create_oidc_service()
-            assert await oidc_service.list_clients() == []
+            assert await oidc_service.list_clients(bootstrap) == []
             oidc_storage = factory.create_oidc_authorization_store()
             async with factory.session.begin():
                 assert await oidc_storage.get(code) is None
@@ -355,7 +355,7 @@ def test_update_schema(
             assert await token_service.list_tokens(bootstrap) == []
             oidc_service = factory.create_oidc_service()
             oidc_clients = {
-                c.client_id for c in await oidc_service.list_clients()
+                c.client_id for c in await oidc_service.list_clients(bootstrap)
             }
             assert oidc_clients == {"some-id", "other-id"}
             oidc_store = OIDCClientStore(factory.session)

--- a/tests/services/oidc_test.py
+++ b/tests/services/oidc_test.py
@@ -39,7 +39,7 @@ async def test_issue_code(
 ) -> None:
     redirect_uri = "https://example.com/"
     oidc_service = factory.create_oidc_service()
-    token_data = await create_session_token(factory)
+    token_data = await create_session_token(factory, scopes={"admin:oidc"})
     client = await register_oidc_client(factory, redirect_uri, token_data)
 
     with pytest.raises(InvalidClientIdError):
@@ -86,7 +86,9 @@ async def test_redeem_code(
 ) -> None:
     assert config.oidc_server
     redirect_uri = "https://example.com/"
-    token_data = await create_session_token(factory)
+    token_data = await create_session_token(
+        factory, scopes={"admin:oidc", "user:token"}
+    )
     assert token_data.expires
     client = await register_oidc_client(factory, redirect_uri, token_data)
     oidc_service = factory.create_oidc_service()
@@ -166,7 +168,7 @@ async def test_redeem_code_errors(
     expires = int(timedelta(minutes=60).total_seconds())
     redirect_uri = "https://example.com/"
     oidc_service = factory.create_oidc_service()
-    token_data = await create_session_token(factory)
+    token_data = await create_session_token(factory, scopes={"admin:oidc"})
     client_1 = await register_oidc_client(factory, redirect_uri, token_data)
     client_2 = await register_oidc_client(factory, redirect_uri, token_data)
     code = await oidc_service.issue_code(
@@ -339,7 +341,7 @@ async def test_issue_id_token(
     assert config.oidc_server
     redirect_uri = "https://example.com/"
     oidc_service = factory.create_oidc_service()
-    token_data = await create_session_token(factory)
+    token_data = await create_session_token(factory, scopes={"admin:oidc"})
     assert token_data.expires
     client = await register_oidc_client(factory, redirect_uri, token_data)
     authorization = OIDCAuthorization(


### PR DESCRIPTION
Rather than relying on the handler configuration to protect the OpenID Connect client registration API, perform internal authorization checks at the service level against the scopes of the authenticating token. This is parallel to the checks performed by other Gafaelfawr services.