### PR TITLE
DM-55961: Strip more nulls from YAML configuration

### DIFF
--- a/changelog.d/20260826_115915_rra_DM_55961.md
+++ b/changelog.d/20260826_115915_rra_DM_55961.md
@@ -1,0 +1,3 @@
+### Bug fixes
+
+- Drop more placeholder `null` values from the YAML configuration file before initializing settings. This works around a pydantic-settings bug triggered by Helm v4.

--- a/src/gafaelfawr/config.py
+++ b/src/gafaelfawr/config.py
@@ -1109,6 +1109,10 @@ class Config(EnvFirstSettings):
         for key in ("afterLogoutUrl", "baseInternalUrl", "databaseUrl"):
             if key in data and data[key] is None:
                 del data[key]
+        if "oidcServer" in data:
+            for key in ("clientSuffix", "issuer"):
+                if key in data and data[key] is None:
+                    del data[key]
 
         return cls.model_validate(data)
 


### PR DESCRIPTION
Drop more placeholder `null` values from the YAML configuration file before initializing settings. This works around a pydantic-settings bug triggered by Helm v4.