### PR TITLE
DM-55961: Use url_for to get redirect URLs

### DIFF
--- a/src/gafaelfawr/dependencies/auth.py
+++ b/src/gafaelfawr/dependencies/auth.py
@@ -2,7 +2,7 @@
 
 from datetime import UTC, datetime
 from typing import Annotated
-from urllib.parse import urlencode, urlsplit
+from urllib.parse import urlencode
 
 from fastapi import Depends, Header, HTTPException, status
 
@@ -211,11 +211,11 @@ class Authenticate:
                 context, self.auth_type, ajax_forbidden=self.ajax_forbidden
             )
         query = urlencode({"rd": str(context.request.url)})
-        login_url = urlsplit("/login")._replace(query=query).geturl()
+        login_url = context.request.url_for("login")
         context.logger.info("Redirecting user for authentication")
         return HTTPException(
             status_code=status.HTTP_307_TEMPORARY_REDIRECT,
-            headers={"Location": login_url},
+            headers={"Location": f"{login_url!s}?{query}"},
         )
 
     def _verify_csrf(

--- a/src/gafaelfawr/handlers/api.py
+++ b/src/gafaelfawr/handlers/api.py
@@ -7,7 +7,6 @@ models.
 """
 
 from typing import Annotated, Any
-from urllib.parse import quote
 
 from fastapi import (
     APIRouter,
@@ -522,9 +521,10 @@ async def post_admin_tokens(
     token = await token_service.create_token_from_admin_request(
         token_request, auth_data, ip_address=context.ip_address
     )
-    response.headers["Location"] = quote(
-        f"/auth/api/v1/users/{token_request.username}/tokens/{token.key}"
+    url = context.request.url_for(
+        "get_token", username=token_request.username, key=token.key
     )
+    response.headers["Location"] = str(url)
     return NewToken(token=str(token))
 
 
@@ -786,9 +786,9 @@ async def post_tokens(
         ip_address=context.ip_address,
         **token_params,
     )
-    response.headers["Location"] = quote(
-        f"/auth/api/v1/users/{username}/tokens/{token.key}"
-    )
+    key = token.key
+    url = context.request.url_for("get_token", username=username, key=key)
+    response.headers["Location"] = str(url)
     return NewToken(token=str(token))
 
 

--- a/src/gafaelfawr/handlers/login.py
+++ b/src/gafaelfawr/handlers/login.py
@@ -83,7 +83,7 @@ class LoginError(Enum):
     summary="Authenticate browser",
     tags=["browser"],
 )
-async def get_login(
+async def login(
     *,
     code: Annotated[
         str | None,

--- a/src/gafaelfawr/handlers/oidc.py
+++ b/src/gafaelfawr/handlers/oidc.py
@@ -64,7 +64,7 @@ client_basic = HTTPBasic(
     summary="Start OIDC authentication",
     tags=["oidc"],
 )
-async def get_login(
+async def get_openid_login(
     *,
     client_id: Annotated[
         str,

--- a/tests/handlers/api_tokens_test.py
+++ b/tests/handlers/api_tokens_test.py
@@ -59,7 +59,10 @@ async def test_create_delete_modify(
     assert r.json() == {"token": ANY}
     user_token = Token.from_str(r.json()["token"])
     token_url = r.headers["Location"]
-    assert token_url == f"/auth/api/v1/users/example/tokens/{user_token.key}"
+    assert token_url == (
+        f"https://{TEST_HOSTNAME}/auth/api/v1/users/example/tokens"
+        f"/{user_token.key}"
+    )
 
     # Check the logging.
     assert parse_log_tuples("gafaelfawr", caplog.record_tuples) == [
@@ -190,7 +193,7 @@ async def test_create_delete_modify(
             "event": "Modified token",
             "httpRequest": {
                 "requestMethod": "PATCH",
-                "requestUrl": f"https://{TEST_HOSTNAME}{token_url}",
+                "requestUrl": token_url,
                 "remoteIp": "127.0.0.1",
             },
             "lifetime_seconds": ANY,
@@ -220,7 +223,7 @@ async def test_create_delete_modify(
             "event": "Deleted token",
             "httpRequest": {
                 "requestMethod": "DELETE",
-                "requestUrl": f"https://{TEST_HOSTNAME}{token_url}",
+                "requestUrl": token_url,
                 "remoteIp": "127.0.0.1",
             },
             "lifetime_seconds": ANY,
@@ -966,8 +969,10 @@ async def test_create_admin(
     assert r.status_code == 201
     assert r.json() == {"token": ANY}
     service_token = Token.from_str(r.json()["token"])
-    token_url = f"/auth/api/v1/users/bot-a-service/tokens/{service_token.key}"
-    assert r.headers["Location"] == token_url
+    assert r.headers["Location"] == (
+        f"https://{TEST_HOSTNAME}/auth/api/v1/users/bot-a-service/tokens"
+        f"/{service_token.key}"
+    )
 
     # Check the logging.
     expected_expires = expires.replace(microsecond=0)
@@ -1081,8 +1086,10 @@ async def test_create_admin(
     assert r.status_code == 201
     assert r.json() == {"token": ANY}
     user_token = Token.from_str(r.json()["token"])
-    token_url = f"/auth/api/v1/users/a-user/tokens/{user_token.key}"
-    assert r.headers["Location"] == token_url
+    assert r.headers["Location"] == (
+        f"https://{TEST_HOSTNAME}/auth/api/v1/users/a-user/tokens"
+        f"/{user_token.key}"
+    )
 
     assert parse_log_tuples("gafaelfawr", caplog.record_tuples) == [
         {
@@ -1407,7 +1414,10 @@ async def test_scope_modify(
     assert r.json() == {"token": ANY}
     user_token = Token.from_str(r.json()["token"])
     token_url = r.headers["Location"]
-    assert token_url == f"/auth/api/v1/users/example/tokens/{user_token.key}"
+    assert token_url == (
+        f"https://{TEST_HOSTNAME}/auth/api/v1/users/example/tokens"
+        f"/{user_token.key}"
+    )
 
     r = await client.get(token_url)
     assert r.status_code == 200

--- a/tests/handlers/oidc_test.py
+++ b/tests/handlers/oidc_test.py
@@ -329,8 +329,8 @@ async def test_unauthenticated(
 
     assert r.status_code == 307
     url = urlsplit(r.headers["Location"])
-    assert not url.scheme
-    assert not url.netloc
+    assert url.scheme == "https"
+    assert url.netloc == TEST_HOSTNAME
     assert url.path == "/login"
     params = urlencode(login_params)
     expected_url = f"https://{TEST_HOSTNAME}/auth/openid/login?{params}"


### PR DESCRIPTION
Rather than returning redirects to relative URLs, use `url_for` to get the target URL. Fix a few cases where route names were not unique.