### PR TITLE
DM-55961: Group GitHub Actions dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,10 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
 
   - package-ecosystem: "pip"
     directories:


### PR DESCRIPTION
Rather than submitting a separate PR for each GitHub Action that needs to be updated, group them together. It's very rare that we want to merge one update and not the others.